### PR TITLE
Fix sdk dependency version in generated package json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   tests:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]

--- a/packages/generator/src/aggregator-package/package-json.ts
+++ b/packages/generator/src/aggregator-package/package-json.ts
@@ -2,7 +2,12 @@
  * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
  */
 
-export function packageJson(npmPackageName: string, dependencies: string[], versionInPackageJson: string|undefined, generatorVersion: string): string {
+export function packageJson(
+  npmPackageName: string,
+  dependencies: string[],
+  versionInPackageJson: string | undefined,
+  generatorVersion: string
+): string {
   return (
     JSON.stringify(
       {

--- a/packages/generator/src/aggregator-package/package-json.ts
+++ b/packages/generator/src/aggregator-package/package-json.ts
@@ -2,12 +2,12 @@
  * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
  */
 
-export function packageJson(npmPackageName: string, dependencies: string[], version: string): string {
+export function packageJson(npmPackageName: string, dependencies: string[], versionInPackageJson: string|undefined, generatorVersion: string): string {
   return (
     JSON.stringify(
       {
         name: npmPackageName,
-        version,
+        version: versionInPackageJson || generatorVersion,
         description: 'SAP Cloud SDK for JavaScript: Complete Virtual Data Model (VDM)',
         homepage: 'https://www.sap.com/cloud-sdk',
         repository: {
@@ -18,11 +18,11 @@ export function packageJson(npmPackageName: string, dependencies: string[], vers
           version: 'node ../../../after-version-update.js'
         },
         dependencies: dependencies.reduce((deps, service) => {
-          deps[service] = `^${version}`;
+          deps[service] = `^${generatorVersion}`;
           return deps;
         }, {}),
         peerDependencies: {
-          '@sap-cloud-sdk/core': `^${version}`
+          '@sap-cloud-sdk/core': `^${generatorVersion}`
         }
       },
       null,

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -24,7 +24,7 @@ import { serviceMappingFile } from './service-mapping';
 import { csn } from './service/csn';
 import { indexFile } from './service/index-file';
 import { npmrc } from './service/npmrc';
-import { packgeJson } from './service/package-json';
+import { packageJson } from './service/package-json';
 import { readme } from './service/readme';
 import { tsConfig } from './service/ts-config';
 import { typedocJson } from './service/typedoc-json';
@@ -105,7 +105,8 @@ function generateAggregatorPackage(services: VdmServiceMetadata[], options: Gene
       aggregatorPackageJson(
         cloudSdkVdmHack(npmCompliantName(options.aggregatorNpmPackageName)),
         services.map(service => service.npmPackageName),
-        version()
+        options.versionInPackageJson,
+        getGeneratorVersion()
       ),
       options.forceOverwrite
     );
@@ -129,9 +130,10 @@ export async function generateSourcesForService(service: VdmServiceMetadata, pro
     otherFile(
       serviceDir,
       'package.json',
-      packgeJson(
+      packageJson(
         service.npmPackageName,
-        options.versionInPackageJson || version(),
+        options.versionInPackageJson,
+        getGeneratorVersion(),
         serviceDescription(service, options),
         options.sdkAfterVersionScript
       ),
@@ -221,7 +223,7 @@ function sanitizeOptions(options: GeneratorOptions): GeneratorOptions {
   return options;
 }
 
-function version(): string {
+function getGeneratorVersion(): string {
   return JSON.parse(readFileSync(resolve(__dirname, '../package.json'), 'utf8')).version;
 }
 

--- a/packages/generator/src/service/package-json.ts
+++ b/packages/generator/src/service/package-json.ts
@@ -2,7 +2,13 @@
  * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
  */
 
-export function packageJson(npmPackageName: string, versionInPackageJson: string|undefined, generatorVersion: string, description: string, sdkAfterVersionScript: boolean): string {
+export function packageJson(
+  npmPackageName: string,
+  versionInPackageJson: string | undefined,
+  generatorVersion: string,
+  description: string,
+  sdkAfterVersionScript: boolean
+): string {
   return (
     JSON.stringify(
       {

--- a/packages/generator/src/service/package-json.ts
+++ b/packages/generator/src/service/package-json.ts
@@ -2,12 +2,12 @@
  * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
  */
 
-export function packgeJson(npmPackageName: string, version: string, description: string, sdkAfterVersionScript: boolean): string {
+export function packageJson(npmPackageName: string, versionInPackageJson: string|undefined, generatorVersion: string, description: string, sdkAfterVersionScript: boolean): string {
   return (
     JSON.stringify(
       {
         name: npmPackageName,
-        version,
+        version: versionInPackageJson || generatorVersion,
         description,
         homepage: 'https://www.sap.com/cloud-sdk',
         main: './index.js',
@@ -26,10 +26,10 @@ export function packgeJson(npmPackageName: string, version: string, description:
           ...(sdkAfterVersionScript ? { version: 'node ../../../after-version-update.js' } : {})
         },
         dependencies: {
-          '@sap-cloud-sdk/core': `^${version}`
+          '@sap-cloud-sdk/core': `^${generatorVersion}`
         },
         peerDependencies: {
-          '@sap-cloud-sdk/core': `^${version}`
+          '@sap-cloud-sdk/core': `^${generatorVersion}`
         },
         devDependencies: {
           '@types/node': '^11.13.5',

--- a/packages/generator/test/aggregator-package/package-json.spec.ts
+++ b/packages/generator/test/aggregator-package/package-json.spec.ts
@@ -5,12 +5,13 @@ describe('package-json', () => {
     const actual = packageJson(
       '@sap/cloud-sdk-vdm',
       ['@sap/cloud-sdk-vdm-business-area-service', '@sap/cloud-sdk-vdm-business-partner-service'],
-      '1.5.0'
+      '2.0.0',
+      '1.17.4-alpha.8'
     );
     const expected =
       '{\n' +
       '  "name": "@sap/cloud-sdk-vdm",\n' +
-      '  "version": "1.5.0",\n' +
+      '  "version": "2.0.0",\n' +
       '  "description": "SAP Cloud SDK for JavaScript: Complete Virtual Data Model (VDM)",\n' +
       '  "homepage": "https://www.sap.com/cloud-sdk",\n' +
       '  "repository": {\n' +
@@ -21,11 +22,11 @@ describe('package-json', () => {
       '    "version": "node ../../../after-version-update.js"\n' +
       '  },\n' +
       '  "dependencies": {\n' +
-      '    "@sap/cloud-sdk-vdm-business-area-service": "^1.5.0",\n' +
-      '    "@sap/cloud-sdk-vdm-business-partner-service": "^1.5.0"\n' +
+      '    "@sap/cloud-sdk-vdm-business-area-service": "^1.17.4-alpha.8",\n' +
+      '    "@sap/cloud-sdk-vdm-business-partner-service": "^1.17.4-alpha.8"\n' +
       '  },\n' +
       '  "peerDependencies": {\n' +
-      '    "@sap-cloud-sdk/core": "^1.5.0"\n' +
+      '    "@sap-cloud-sdk/core": "^1.17.4-alpha.8"\n' +
       '  }\n' +
       '}\n';
     expect(actual).toEqual(expected);

--- a/packages/generator/test/generator-cli.spec.ts
+++ b/packages/generator/test/generator-cli.spec.ts
@@ -35,16 +35,4 @@ describe('generator-cli', () => {
     expect(entities).toContain('TestEntity.ts');
     expect(entities).toContain('package.json');
   }, 60000);
-
-  it('should generate package.json with version specified in as the parameter', async () => {
-    const versionInPackageJson = '2.0.0';
-    await execa('npx', ['ts-node', pathToGenerator, '-i', inputDir, '-o', outputDir, '--versionInPackageJson', versionInPackageJson]);
-    const services = fs.readdirSync(outputDir);
-    expect(services.length).toBeGreaterThan(0);
-    const servicePackageJson = JSON.parse(fs.readFileSync(path.resolve(outputDir, services[0], 'package.json')));
-    expect(servicePackageJson.version).toEqual(versionInPackageJson);
-
-    const generatorPackageJson = JSON.parse(fs.readFileSync(pathToGeneratorPackageJson));
-    expect(servicePackageJson.dependencies['@sap-cloud-sdk/core']).toEqual(`^${generatorPackageJson.version}`);
-  }, 60000);
 });

--- a/packages/generator/test/generator-cli.spec.ts
+++ b/packages/generator/test/generator-cli.spec.ts
@@ -7,6 +7,7 @@ describe('generator-cli', () => {
   const pathToGenerator = path.resolve(process.cwd(), 'src/generator-cli.ts');
   const inputDir = path.resolve(process.cwd(), '../../test-resources/service-specs/API_TEST_SRV/API_TEST_SRV.edmx');
   const outputDir = path.resolve(process.cwd(), 'test/generator-test-output');
+  const pathToGeneratorPackageJson = path.resolve(process.cwd(), 'package.json');
 
   beforeEach(() => {
     if (!fs.existsSync(outputDir)) {
@@ -40,7 +41,10 @@ describe('generator-cli', () => {
     await execa('npx', ['ts-node', pathToGenerator, '-i', inputDir, '-o', outputDir, '--versionInPackageJson', versionInPackageJson]);
     const services = fs.readdirSync(outputDir);
     expect(services.length).toBeGreaterThan(0);
-    const packageJson = fs.readFileSync(path.resolve(outputDir, services[0], 'package.json'));
-    expect(JSON.parse(packageJson).version).toEqual(versionInPackageJson);
+    const servicePackageJson = JSON.parse(fs.readFileSync(path.resolve(outputDir, services[0], 'package.json')));
+    expect(servicePackageJson.version).toEqual(versionInPackageJson);
+
+    const generatorPackageJson = JSON.parse(fs.readFileSync(pathToGeneratorPackageJson));
+    expect(servicePackageJson.dependencies['@sap-cloud-sdk/core']).toEqual(`^${generatorPackageJson.version}`);
   }, 60000);
 });


### PR DESCRIPTION
In the generated `package.json`, there are two versions that share the same value:
- version of the package
- sdk dependency version

However, this is not correct.
The version of the package can be set from the CLI or as default, use the generator version.
The sdk dependancy should always be the same as the generator version.