### PR TITLE
Remove `forcePublish` flag for canary release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,6 @@ jobs:
         run: |
           git update-index --assume-unchanged .npmrc
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc
-          npx lerna publish --force-publish --canary -y
+          npx lerna publish --canary -y
         env:
           NPM_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}


### PR DESCRIPTION
`lerna publish --canary` creates a version based on the changes that it finds from git. If there are no changes with `--forcePublish` it will try to publish a version that already exists, causing the command to fail.

While I don't agree with this behaviour of `lerna`, I also think we don't need to publish new canary versions, when there are no changes in the packages.