### PR TITLE
Remove wrong example links

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -11,4 +11,3 @@ This package contains the core functionality of the SAP Cloud SDK as well as the
 - [All versions of this documentation](https://help.sap.com/viewer/product/SAP_CLOUD_SDK/1.0/en-US)
 - [Product page of the SAP Cloud SDK](https://developers.sap.com/topics/cloud-sdk.html)
 - [SAP Cloud SDK Continuous Delivery Toolkit](https://github.com/SAP/cloud-s4-sdk-pipeline)
-- [Example Applications using the SAP Cloud SDK](https://github.com/SAP/cloud-s4-sdk-examples)

--- a/packages/generator/README.md
+++ b/packages/generator/README.md
@@ -46,4 +46,3 @@ project.save();
 - [All versions of this documentation](https://help.sap.com/viewer/product/SAP_CLOUD_SDK/1.0/en-US)
 - [Product page of the SAP Cloud SDK](https://developers.sap.com/topics/cloud-sdk.html)
 - [SAP Cloud SDK Continuous Delivery Toolkit](https://github.com/SAP/cloud-s4-sdk-pipeline)
-- [Example Applications using the SAP Cloud SDK](https://github.com/SAP/cloud-s4-sdk-examples)

--- a/packages/test-util/README.md
+++ b/packages/test-util/README.md
@@ -11,4 +11,3 @@ Package that contains utility functions for testing, like loading credentials or
 - [All versions of this documentation](https://help.sap.com/viewer/product/SAP_CLOUD_SDK/1.0/en-US)
 - [Product page of the SAP Cloud SDK](https://developers.sap.com/topics/cloud-sdk.html)
 - [SAP Cloud SDK Continuous Delivery Toolkit](https://github.com/SAP/cloud-s4-sdk-pipeline)
-- [Example Applications using the SAP Cloud SDK](https://github.com/SAP/cloud-s4-sdk-examples)

--- a/packages/util/README.md
+++ b/packages/util/README.md
@@ -12,4 +12,3 @@ While primarily designed for internal usage, they might also be benefical for co
 - [All versions of this documentation](https://help.sap.com/viewer/product/SAP_CLOUD_SDK/1.0/en-US)
 - [Product page of the SAP Cloud SDK](https://developers.sap.com/topics/cloud-sdk.html)
 - [SAP Cloud SDK Continuous Delivery Toolkit](https://github.com/SAP/cloud-s4-sdk-pipeline)
-- [Example Applications using the SAP Cloud SDK](https://github.com/SAP/cloud-s4-sdk-examples)


### PR DESCRIPTION
These readme files are shown in the npmjs for all packages.
Will add the proper links when the example project is tested with this repo.