### PR TITLE
fix: Make warning less confusing (hopefully)

### DIFF
--- a/packages/core/src/scp-cf/destination-accessor.ts
+++ b/packages/core/src/scp-cf/destination-accessor.ts
@@ -44,9 +44,9 @@ export async function useOrFetchDestination(
 ): Promise<Destination | null> {
   return isDestinationNameAndJwt(destination)
     ? getDestination(destination.destinationName, {
-        userJwt: destination.jwt,
-        ...options
-      })
+      userJwt: destination.jwt,
+      ...options
+    })
     : sanitizeDestination(destination);
 }
 
@@ -212,6 +212,7 @@ function tryDestinationForServiceBinding(name: string): Destination | undefined 
     return destinationForServiceBinding(name);
   } catch (error) {
     logger.warn(error.message);
+    logger.warn("If you're not using SAP Extension Factory, you can ignore this warning.");
     return undefined;
   }
 }
@@ -220,8 +221,8 @@ function tryDestinationFromEnv(name: string): Destination | undefined {
   if (getDestinationsEnvVariable()) {
     logger.warn(
       "Environment variable 'destinations' is set. Destinations will be read from this variable. " +
-        'This is discouraged for a productive application! ' +
-        'Unset the variable to read destinations from the destination service on SAP Cloud Platform.'
+      'This is discouraged for a productive application! ' +
+      'Unset the variable to read destinations from the destination service on SAP Cloud Platform.'
     );
 
     return getDestinationFromEnvByName(name) || undefined;

--- a/packages/core/src/scp-cf/destination-accessor.ts
+++ b/packages/core/src/scp-cf/destination-accessor.ts
@@ -44,9 +44,9 @@ export async function useOrFetchDestination(
 ): Promise<Destination | null> {
   return isDestinationNameAndJwt(destination)
     ? getDestination(destination.destinationName, {
-      userJwt: destination.jwt,
-      ...options
-    })
+        userJwt: destination.jwt,
+        ...options
+      })
     : sanitizeDestination(destination);
 }
 
@@ -221,8 +221,8 @@ function tryDestinationFromEnv(name: string): Destination | undefined {
   if (getDestinationsEnvVariable()) {
     logger.warn(
       "Environment variable 'destinations' is set. Destinations will be read from this variable. " +
-      'This is discouraged for a productive application! ' +
-      'Unset the variable to read destinations from the destination service on SAP Cloud Platform.'
+        'This is discouraged for a productive application! ' +
+        'Unset the variable to read destinations from the destination service on SAP Cloud Platform.'
     );
 
     return getDestinationFromEnvByName(name) || undefined;

--- a/packages/core/src/scp-cf/vcap-service-destination.ts
+++ b/packages/core/src/scp-cf/vcap-service-destination.ts
@@ -118,7 +118,6 @@ function noVcapServicesError(): Error {
 function serviceTypeNotSupportedError(serviceType: string): Error {
   return Error(`Service of type ${serviceType} is not supported! Consider providing your own transformation function when calling destinationForServiceBinding, like this:
   destinationServiceForBinding(yourServiceName, { serviceBindingToDestination: yourTransformationFunction });`);
-
 }
 
 function noServiceBindingFoundError(serviceBindings: Array<MapType<any>>, serviceInstanceName: string): Error {

--- a/packages/core/src/scp-cf/vcap-service-destination.ts
+++ b/packages/core/src/scp-cf/vcap-service-destination.ts
@@ -117,7 +117,9 @@ function noVcapServicesError(): Error {
 
 function serviceTypeNotSupportedError(serviceType: string): Error {
   return Error(`Service of type ${serviceType} is not supported! Consider providing your own transformation function when calling destinationForServiceBinding, like this:
-  destinationServiceForBinding(yourServiceName, { serviceBindingToDestination: yourTransformationFunction });`);
+  destinationServiceForBinding(yourServiceName, { serviceBindingToDestination: yourTransformationFunction });
+  If you're not using SAP Extension Factory, you can ignore this warning.`);
+
 }
 
 function noServiceBindingFoundError(serviceBindings: Array<MapType<any>>, serviceInstanceName: string): Error {

--- a/packages/core/src/scp-cf/vcap-service-destination.ts
+++ b/packages/core/src/scp-cf/vcap-service-destination.ts
@@ -117,8 +117,7 @@ function noVcapServicesError(): Error {
 
 function serviceTypeNotSupportedError(serviceType: string): Error {
   return Error(`Service of type ${serviceType} is not supported! Consider providing your own transformation function when calling destinationForServiceBinding, like this:
-  destinationServiceForBinding(yourServiceName, { serviceBindingToDestination: yourTransformationFunction });
-  If you're not using SAP Extension Factory, you can ignore this warning.`);
+  destinationServiceForBinding(yourServiceName, { serviceBindingToDestination: yourTransformationFunction });`);
 
 }
 
@@ -127,7 +126,6 @@ function noServiceBindingFoundError(serviceBindings: Array<MapType<any>>, servic
     `Unable to find a service binding for given name "${serviceInstanceName}"! Found the following bindings: ${serviceBindings
       .map(s => s.name)
       .join(', ')}.
-      If you're not using SAP Extension Factory, you can ignore this warning.
       `
   );
 }


### PR DESCRIPTION
## Context

This is not the first time that users get confused by the warnings produced by the "three-trier destination loading logic". We already adapted one of the error messages, but missed a different one. I now moved the "XF disclaimer" to a central place.

## Definition of Done

Please consider all items and remove only if not applicable.

- [ ] Tests created/adjusted for your changes.
- [ ] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [x] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [ ] If applicable: Properly documented (JSDoc of public API)

## Labels
We use labels to indicate the status of PRs. 
Please select `please review`, `please merge` or `don't merge` for your PR.
