### PR TITLE
fix: Ignore destinations other than ‘HTTP’ for validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4425,7 +4425,7 @@
 				"json-stable-stringify": "^1.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "5.14.0",
-				"typescript": "^3.9.0-dev.20200318",
+				"typescript": "^3.9.0-dev.20200319",
 				"yargs": "^15.1.0"
 			},
 			"dependencies": {
@@ -4550,9 +4550,9 @@
 					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 				},
 				"typescript": {
-					"version": "3.9.0-dev.20200318",
-					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200318.tgz",
-					"integrity": "sha512-DxUgDTZCGT5Z54TELss3TnHatBiN254lEuxqOXDGv0qr9V+TkonLsTRJz4TrvbVVj/LOr2JX1deZkqTySHXVow=="
+					"version": "3.9.0-dev.20200319",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200319.tgz",
+					"integrity": "sha512-t8BiBTDOeiN8BMSCLXFNNfEeMjm33JrLMGBtqq5NvY95KDxkDJiP2TsW4FnyRQicNpCJ8o9cQ3clrr0NtfYvJg=="
 				},
 				"wrap-ansi": {
 					"version": "6.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4425,7 +4425,7 @@
 				"json-stable-stringify": "^1.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "5.14.0",
-				"typescript": "^3.9.0-dev.20200317",
+				"typescript": "^3.9.0-dev.20200318",
 				"yargs": "^15.1.0"
 			},
 			"dependencies": {
@@ -4550,9 +4550,9 @@
 					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 				},
 				"typescript": {
-					"version": "3.9.0-dev.20200317",
-					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200317.tgz",
-					"integrity": "sha512-Qk0HeL1zqWEICK2soys8CzhNewpYLnfM4reemw6SXNOLPgwTiWFIH59a7ehf4ViUkNtf7Su8OV4KVaTG8XIxoA=="
+					"version": "3.9.0-dev.20200318",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200318.tgz",
+					"integrity": "sha512-DxUgDTZCGT5Z54TELss3TnHatBiN254lEuxqOXDGv0qr9V+TkonLsTRJz4TrvbVVj/LOr2JX1deZkqTySHXVow=="
 				},
 				"wrap-ansi": {
 					"version": "6.2.0",
@@ -10762,9 +10762,9 @@
 			}
 		},
 		"prompts": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.1.tgz",
-			"integrity": "sha512-qIP2lQyCwYbdzcqHIUi2HAxiWixhoM9OdLCWf8txXsapC/X9YdsCoeyRIXE/GP+Q0J37Q7+XN/MFqbUa7IzXNA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
+			"integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
 			"requires": {
 				"kleur": "^3.0.3",
 				"sisteransi": "^1.0.4"
@@ -11457,9 +11457,9 @@
 			}
 		},
 		"sisteransi": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.4.tgz",
-			"integrity": "sha512-/ekMoM4NJ59ivGSfKapeG+FWtrmWvA1p6FBZwXrqojw90vJu8lBmrTxCMuBCydKtkaUe2zt4PlxeTKpjwMbyig=="
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
 		},
 		"slash": {
 			"version": "2.0.0",

--- a/packages/core/src/scp-cf/destination-service-types.ts
+++ b/packages/core/src/scp-cf/destination-service-types.ts
@@ -99,6 +99,11 @@ export interface Destination {
   tokenServicePassword?: string;
 
   /**
+   * The type of the destination, defaults to 'HTTP'. The SAP Cloud SDK only understands destinations of type 'HTTP'.
+   */
+  type?: 'HTTP' | 'LDAP' | 'MAIL' | 'RFC';
+
+  /**
    * Further properties of the destination as defined in destination service on SAP Cloud Platform, possibly empty.
    */
   originalProperties?: { [key: string]: any };

--- a/packages/core/src/scp-cf/destination-service.ts
+++ b/packages/core/src/scp-cf/destination-service.ts
@@ -4,7 +4,7 @@ import { errorWithCause, propertyExists } from '@sap-cloud-sdk/util';
 import axios, { AxiosError, AxiosPromise, AxiosRequestConfig } from 'axios';
 import { getAxiosConfigWithDefaults } from '../http-client';
 import { wrapJwtInHeader } from '../util';
-import { parseDestination, parseHttpDestinations } from './destination';
+import { parseDestination } from './destination';
 import { Destination } from './destination-service-types';
 import { circuitBreakerDefaultOptions, ResilienceOptions } from './resilience-options';
 
@@ -45,7 +45,7 @@ function fetchDestinations(destinationServiceUri: string, jwt: string, type: Des
   const targetUri = `${destinationServiceUri.replace(/\/$/, '')}/destination-configuration/v1/${type}Destinations`;
 
   return callDestinationService(targetUri, jwt, options)
-    .then(response => parseHttpDestinations(response.data))
+    .then(response => response.data.map(d => parseDestination(d)))
     .catch(error => Promise.reject(errorWithCause(`Failed to fetch ${type} destinations.${errorMessageFromResponse(error)}`, error)));
 }
 

--- a/packages/core/src/scp-cf/destination-service.ts
+++ b/packages/core/src/scp-cf/destination-service.ts
@@ -4,7 +4,7 @@ import { errorWithCause, propertyExists } from '@sap-cloud-sdk/util';
 import axios, { AxiosError, AxiosPromise, AxiosRequestConfig } from 'axios';
 import { getAxiosConfigWithDefaults } from '../http-client';
 import { wrapJwtInHeader } from '../util';
-import { parseDestination, parseDestinations } from './destination';
+import { parseDestination, parseHttpDestinations } from './destination';
 import { Destination } from './destination-service-types';
 import { circuitBreakerDefaultOptions, ResilienceOptions } from './resilience-options';
 
@@ -45,7 +45,7 @@ function fetchDestinations(destinationServiceUri: string, jwt: string, type: Des
   const targetUri = `${destinationServiceUri.replace(/\/$/, '')}/destination-configuration/v1/${type}Destinations`;
 
   return callDestinationService(targetUri, jwt, options)
-    .then(response => parseDestinations(response.data))
+    .then(response => parseHttpDestinations(response.data))
     .catch(error => Promise.reject(errorWithCause(`Failed to fetch ${type} destinations.${errorMessageFromResponse(error)}`, error)));
 }
 

--- a/packages/core/src/scp-cf/destination-service.ts
+++ b/packages/core/src/scp-cf/destination-service.ts
@@ -4,7 +4,7 @@ import { errorWithCause, propertyExists } from '@sap-cloud-sdk/util';
 import axios, { AxiosError, AxiosPromise, AxiosRequestConfig } from 'axios';
 import { getAxiosConfigWithDefaults } from '../http-client';
 import { wrapJwtInHeader } from '../util';
-import { parseDestination } from './destination';
+import { parseDestination, parseDestinations } from './destination';
 import { Destination } from './destination-service-types';
 import { circuitBreakerDefaultOptions, ResilienceOptions } from './resilience-options';
 
@@ -45,7 +45,7 @@ function fetchDestinations(destinationServiceUri: string, jwt: string, type: Des
   const targetUri = `${destinationServiceUri.replace(/\/$/, '')}/destination-configuration/v1/${type}Destinations`;
 
   return callDestinationService(targetUri, jwt, options)
-    .then(response => response.data.map(d => parseDestination(d)))
+    .then(response => parseDestinations(response.data))
     .catch(error => Promise.reject(errorWithCause(`Failed to fetch ${type} destinations.${errorMessageFromResponse(error)}`, error)));
 }
 

--- a/packages/core/src/scp-cf/destination.ts
+++ b/packages/core/src/scp-cf/destination.ts
@@ -30,9 +30,7 @@ export function sanitizeDestination(destination: MapType<any>): Destination {
  * @returns An SDK compatible destination object.
  */
 export function parseDestination(destinationJson: DestinationJson | DestinationConfiguration): Destination {
-  const destinationConfig = Object.keys(destinationJson).includes('destinationConfiguration')
-    ? (destinationJson as DestinationJson).destinationConfiguration
-    : (destinationJson as DestinationConfiguration);
+  const destinationConfig = isDestinationJson(destinationJson) ? destinationJson.destinationConfiguration : destinationJson;
 
   validateDestinationConfig(destinationConfig);
 
@@ -54,7 +52,9 @@ export function parseDestination(destinationJson: DestinationJson | DestinationC
 }
 
 function validateDestinationConfig(destinationConfig: DestinationConfiguration): void {
-  if (typeof destinationConfig.URL === 'undefined') {
+  // We only consider destinations with Type 'HTTP'. Others (e. g. 'RFC') will be ignored.
+  const isHttpDestination = destinationConfig.Type === 'HTTP' || typeof destinationConfig.Type === 'undefined';
+  if (isHttpDestination && typeof destinationConfig.URL === 'undefined') {
     throw Error("Property 'URL' of destination configuration must not be undefined.");
   }
 }
@@ -152,6 +152,7 @@ export interface DestinationConfiguration {
   clientId?: string;
   clientSecret?: string;
   SystemUser?: string;
+  Type?: 'HTTP';
 }
 
 /* eslint-disable-next-line valid-jsdoc */
@@ -160,6 +161,14 @@ export interface DestinationConfiguration {
  */
 export function isDestinationConfiguration(destination: any): destination is DestinationConfiguration {
   return destination.URL !== undefined;
+}
+
+/* eslint-disable-next-line valid-jsdoc */
+/**
+ * @hidden
+ */
+export function isDestinationJson(destination: any): destination is DestinationJson {
+  return destination.destinationConfig !== undefined;
 }
 
 const configMapping: MapType<string> = {

--- a/packages/core/src/scp-cf/destination.ts
+++ b/packages/core/src/scp-cf/destination.ts
@@ -56,17 +56,23 @@ function getDestinationConfig(destinationJson: DestinationJson | DestinationConf
 }
 
 function validateDestinationConfig(destinationConfig: DestinationConfiguration): void {
-  const isHttpDestination = destinationConfig.Type === 'HTTP' || typeof destinationConfig.Type === 'undefined';
-  if (isHttpDestination && typeof destinationConfig.URL === 'undefined') {
+  if (isHttpDestination(destinationConfig) && typeof destinationConfig.URL === 'undefined') {
     throw Error("Property 'URL' of destination configuration must not be undefined.");
   }
 }
 
 function validateDestinationInput(destinationInput: MapType<any>): void {
-  const isHttpDestination = destinationInput.type === 'HTTP' || typeof destinationInput.type === 'undefined';
-  if (isHttpDestination && typeof destinationInput.url === 'undefined') {
+  if (isHttpDestination(destinationInput) && typeof destinationInput.url === 'undefined') {
     throw Error("Property 'url' of destination input must not be undefined.");
   }
+}
+
+function isHttpDestination(destinationInput: MapType<any>): boolean {
+  return (
+    destinationInput.Type === 'HTTP' ||
+    destinationInput.type === 'HTTP' ||
+    (typeof destinationInput.type === 'undefined' && typeof destinationInput.Type === 'undefined')
+  );
 }
 
 /* eslint-disable-next-line valid-jsdoc */

--- a/packages/core/src/scp-cf/destination.ts
+++ b/packages/core/src/scp-cf/destination.ts
@@ -59,7 +59,7 @@ export function parseDestination(destinationJson: DestinationJson | DestinationC
  * @param destinationJsons - JSON objects as given by the destination service.
  * @returns A list of SDK compatible destinations.
  */
-export function parseDestinations(destinationJsons: (DestinationJson | DestinationConfiguration)[]): Destination[] {
+export function parseHttpDestinations(destinationJsons: (DestinationJson | DestinationConfiguration)[]): Destination[] {
   return (
     destinationJsons
       .map(destinationJson => getDestinationConfig(destinationJson))
@@ -149,6 +149,7 @@ function getAuthenticationType(destination: Destination): AuthenticationType {
  * Destination configuration alongside authtokens and certificates.
  */
 export interface DestinationJson {
+  [key: string]: any;
   destinationConfiguration: DestinationConfiguration;
   authTokens?: MapType<string>[];
   certificates?: MapType<string>[];
@@ -158,6 +159,7 @@ export interface DestinationJson {
  * Configuration of a destination as it is available through the destination service.
  */
 export interface DestinationConfiguration {
+  [key: string]: any;
   URL: string;
   Name?: string;
   ProxyType?: string;
@@ -172,7 +174,7 @@ export interface DestinationConfiguration {
   clientId?: string;
   clientSecret?: string;
   SystemUser?: string;
-  Type?: string;
+  Type?: 'HTTP' | 'LDAP' | 'MAIL' | 'RFC';
 }
 
 /* eslint-disable-next-line valid-jsdoc */

--- a/packages/core/test/scp-cf/__snapshots__/destination.spec.ts.snap
+++ b/packages/core/test/scp-cf/__snapshots__/destination.spec.ts.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Destination parser sanitizeDestination throws an error if there is no URL given 1`] = `"Property 'URL' of destination configuration must not be undefined."`;
+exports[`Destination parser parseDestination throws an error if there is no URL given 1`] = `"Property 'URL' of destination configuration must not be undefined."`;
 
 exports[`Destination parser sanitizeDestination throws an error if there is no url given 1`] = `"Property 'url' of destination input must not be undefined."`;

--- a/packages/core/test/scp-cf/destination.spec.ts
+++ b/packages/core/test/scp-cf/destination.spec.ts
@@ -96,10 +96,10 @@ describe('Destination parser', () => {
   });
 
   it("parseDestination does not throw when there is not url for destinations with type other than 'HTTP' or undefined", () => {
-    expect(parseDestination({ Type: 'RFC' } as DestinationConfiguration)).not.toThrow();
+    expect(() => parseDestination({ Type: 'RFC' } as DestinationConfiguration)).not.toThrow();
   });
 
   it("sanitizeDestination does not throw when there is not url for destinations with type other than 'HTTP' or undefined", () => {
-    expect(sanitizeDestination({ type: 'RFC' })).not.toThrow();
+    expect(() => sanitizeDestination({ type: 'RFC' })).not.toThrow();
   });
 });

--- a/packages/core/test/scp-cf/destination.spec.ts
+++ b/packages/core/test/scp-cf/destination.spec.ts
@@ -1,5 +1,5 @@
 /* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
-import { Destination, parseDestination, sanitizeDestination, parseDestinations, DestinationConfiguration } from '../../src/scp-cf';
+import { Destination, parseDestination, sanitizeDestination, parseHttpDestinations, DestinationConfiguration } from '../../src/scp-cf';
 import { basicMultipleResponse, certificateMultipleResponse, certificateSingleResponse } from '../test-util/example-destination-service-responses';
 
 describe('Destination parser', () => {
@@ -95,10 +95,10 @@ describe('Destination parser', () => {
     ).toThrowErrorMatchingSnapshot();
   });
 
-  it("parseDestinations only considers destinations with type 'HTTP' or undefined", () => {
+  it("parseHttpDestinations only considers destinations with type 'HTTP' or undefined", () => {
     const destinationConfigs: any = [{ URL: 'undefined-type' }, { URL: 'http-type', Type: 'HTTP' }, { Name: 'rfc-type', Type: 'RFC' }];
 
-    const actual = parseDestinations(destinationConfigs);
+    const actual = parseHttpDestinations(destinationConfigs);
     const expected = [{ url: 'undefined-type' }, { url: 'http-type' }].map(expectation => expect.objectContaining(expectation));
 
     expect(actual).toEqual(expect.arrayContaining(expected));

--- a/packages/core/test/scp-cf/destination.spec.ts
+++ b/packages/core/test/scp-cf/destination.spec.ts
@@ -1,5 +1,5 @@
 /* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
-import { Destination, parseDestination, sanitizeDestination, parseDestinations, DestinationConfiguration } from '../../src/scp-cf';
+import { Destination, parseDestination, sanitizeDestination, DestinationConfiguration } from '../../src/scp-cf';
 import { basicMultipleResponse, certificateMultipleResponse, certificateSingleResponse } from '../test-util/example-destination-service-responses';
 
 describe('Destination parser', () => {

--- a/packages/core/test/scp-cf/destination.spec.ts
+++ b/packages/core/test/scp-cf/destination.spec.ts
@@ -77,23 +77,30 @@ describe('Destination parser', () => {
     expect(oneTime).toMatchObject(twoTimes);
   });
 
-  it('sanitizeDestination throws an error if there is no URL given', () => {
-    const destination: any = {
-      User: 'username',
-      Password: 'password',
-      Name: 'DEST'
-    };
+  it('parseDestination throws an error if there is no URL given', () => {
+    expect(() =>
+      parseDestination({
+        Name: 'DEST'
+      } as any)
+    ).toThrowErrorMatchingSnapshot();
+  });
 
-    expect(() => parseDestination(destination)).toThrowErrorMatchingSnapshot();
+  it("parseDestination does not consider destinations of type 'RFC'", () => {
+    expect(() =>
+      parseDestination({
+        Type: 'RFC',
+        Name: 'DEST'
+      } as any)
+    ).toThrowErrorMatchingSnapshot();
   });
 
   it('sanitizeDestination throws an error if there is no url given', () => {
-    const destination = {
-      username: 'username',
-      password: 'password',
-      name: 'DEST'
-    };
-
-    expect(() => sanitizeDestination(destination)).toThrowErrorMatchingSnapshot();
+    expect(() =>
+      sanitizeDestination({
+        username: 'username',
+        password: 'password',
+        name: 'DEST'
+      })
+    ).toThrowErrorMatchingSnapshot();
   });
 });

--- a/packages/core/test/scp-cf/destination.spec.ts
+++ b/packages/core/test/scp-cf/destination.spec.ts
@@ -1,5 +1,5 @@
 /* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
-import { Destination, parseDestination, sanitizeDestination } from '../../src/scp-cf';
+import { Destination, parseDestination, sanitizeDestination, parseDestinations, DestinationConfiguration } from '../../src/scp-cf';
 import { basicMultipleResponse, certificateMultipleResponse, certificateSingleResponse } from '../test-util/example-destination-service-responses';
 
 describe('Destination parser', () => {
@@ -85,15 +85,6 @@ describe('Destination parser', () => {
     ).toThrowErrorMatchingSnapshot();
   });
 
-  it("parseDestination does not consider destinations of type 'RFC'", () => {
-    expect(() =>
-      parseDestination({
-        Type: 'RFC',
-        Name: 'DEST'
-      } as any)
-    ).toThrowErrorMatchingSnapshot();
-  });
-
   it('sanitizeDestination throws an error if there is no url given', () => {
     expect(() =>
       sanitizeDestination({
@@ -102,5 +93,15 @@ describe('Destination parser', () => {
         name: 'DEST'
       })
     ).toThrowErrorMatchingSnapshot();
+  });
+
+  it("parseDestinations only considers destinations with type 'HTTP' or undefined", () => {
+    const destinationConfigs: any = [{ URL: 'undefined-type' }, { URL: 'http-type', Type: 'HTTP' }, { Name: 'rfc-type', Type: 'RFC' }];
+
+    const actual = parseDestinations(destinationConfigs);
+    const expected = [{ url: 'undefined-type' }, { url: 'http-type' }].map(expectation => expect.objectContaining(expectation));
+
+    expect(actual).toEqual(expect.arrayContaining(expected));
+    expect(actual).toHaveLength(2);
   });
 });

--- a/packages/core/test/scp-cf/destination.spec.ts
+++ b/packages/core/test/scp-cf/destination.spec.ts
@@ -1,5 +1,5 @@
 /* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
-import { Destination, parseDestination, sanitizeDestination, parseHttpDestinations, DestinationConfiguration } from '../../src/scp-cf';
+import { Destination, parseDestination, sanitizeDestination, parseDestinations, DestinationConfiguration } from '../../src/scp-cf';
 import { basicMultipleResponse, certificateMultipleResponse, certificateSingleResponse } from '../test-util/example-destination-service-responses';
 
 describe('Destination parser', () => {
@@ -95,13 +95,11 @@ describe('Destination parser', () => {
     ).toThrowErrorMatchingSnapshot();
   });
 
-  it("parseHttpDestinations only considers destinations with type 'HTTP' or undefined", () => {
-    const destinationConfigs: any = [{ URL: 'undefined-type' }, { URL: 'http-type', Type: 'HTTP' }, { Name: 'rfc-type', Type: 'RFC' }];
+  it("parseDestination does not throw when there is not url for destinations with type other than 'HTTP' or undefined", () => {
+    expect(parseDestination({ Type: 'RFC' } as DestinationConfiguration)).not.toThrow();
+  });
 
-    const actual = parseHttpDestinations(destinationConfigs);
-    const expected = [{ url: 'undefined-type' }, { url: 'http-type' }].map(expectation => expect.objectContaining(expectation));
-
-    expect(actual).toEqual(expect.arrayContaining(expected));
-    expect(actual).toHaveLength(2);
+  it("sanitizeDestination does not throw when there is not url for destinations with type other than 'HTTP' or undefined", () => {
+    expect(sanitizeDestination({ type: 'RFC' })).not.toThrow();
   });
 });

--- a/packages/core/test/test-util/example-destination-service-responses.ts
+++ b/packages/core/test/test-util/example-destination-service-responses.ts
@@ -1,5 +1,5 @@
 /* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
-import { AuthenticationType, DestinationConfiguration } from '../../src';
+import { AuthenticationType, DestinationConfiguration, DestinationJson } from '../../src';
 
 export const certificateMultipleResponse: DestinationConfiguration[] = [
   {
@@ -47,7 +47,7 @@ export const oauthMultipleResponse: DestinationConfiguration[] = [
   }
 ];
 
-export const oauthSingleResponse = {
+export const oauthSingleResponse: DestinationJson = {
   owner: {
     SubaccountId: 'a89ea924-d9c2-4eab-84fb-3ffcaadf5d24',
     InstanceId: null

--- a/packages/core/test/test-util/example-destination-service-responses.ts
+++ b/packages/core/test/test-util/example-destination-service-responses.ts
@@ -1,7 +1,7 @@
 /* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
-import { AuthenticationType } from '../../src';
+import { AuthenticationType, DestinationConfiguration } from '../../src';
 
-export const certificateMultipleResponse = [
+export const certificateMultipleResponse: DestinationConfiguration[] = [
   {
     Name: 'ERNIE-UND-CERT',
     Type: 'HTTP',
@@ -28,7 +28,7 @@ export const certificateSingleResponse = {
   ]
 };
 
-export const oauthMultipleResponse = [
+export const oauthMultipleResponse: DestinationConfiguration[] = [
   {
     Name: 'FINAL-DESTINATION',
     Type: 'HTTP',
@@ -62,7 +62,7 @@ export const oauthSingleResponse = {
   ]
 };
 
-export const onPremiseMultipleResponse = [
+export const onPremiseMultipleResponse: DestinationConfiguration[] = [
   {
     Name: 'OnPremise',
     URL: 'my.on.premise.system:54321',
@@ -71,7 +71,7 @@ export const onPremiseMultipleResponse = [
   }
 ];
 
-export const basicMultipleResponse = [
+export const basicMultipleResponse: DestinationConfiguration[] = [
   {
     Name: 'FINAL-DESTINATION',
     Type: 'HTTP',


### PR DESCRIPTION
We recently introduced validation of configurations from env vars and the destination service (https://github.com/SAP/cloud-sdk/pull/44). As we currently parse all given destinations this will lead to errors, if there are destinations without 'URL'. This is the case for RFC type destinations, for example. This PR fixes that behavior and skips parsing of non HTTP destinations.