### PR TITLE
Fix: Adjust Generated Docs

### DIFF
--- a/packages/generator/src/batch/function.ts
+++ b/packages/generator/src/batch/function.ts
@@ -1,7 +1,7 @@
 /* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
 
 import { FunctionDeclarationStructure, StructureKind } from 'ts-morph';
-import { getFunctionDoc } from '../typedoc';
+import { addLeadingNewline, getFunctionDoc } from '../typedoc';
 import { VdmServiceMetadata } from '../vdm-types';
 
 export function batchFunction(
@@ -15,21 +15,23 @@ export function batchFunction(
     returnType: 'ODataBatchRequestBuilder',
     statements: `return new ODataBatchRequestBuilder(default${service.className}Path, requests, map);`,
     docs: [
-      getFunctionDoc(
-        `Batch builder for operations supported on the ${service.speakingModuleName}.`,
-        {
-          params: [
-            {
-              name: 'requests',
-              type: 'MethodRequestBuilderBase<ODataRequestConfig>[]',
-              description: 'The requests of the batch'
+      addLeadingNewline(
+        getFunctionDoc(
+          `Batch builder for operations supported on the ${service.speakingModuleName}.`,
+          {
+            params: [
+              {
+                name: 'requests',
+                type: 'MethodRequestBuilderBase<ODataRequestConfig>[]',
+                description: 'The requests of the batch'
+              }
+            ],
+            returns: {
+              type: 'ODataBatchRequestBuilder',
+              description: 'A request builder for batch.'
             }
-          ],
-          returns: {
-            type: 'ODataBatchRequestBuilder',
-            description: 'A request builder for batch.'
           }
-        }
+        )
       )
     ]
   };
@@ -48,21 +50,23 @@ export function changesetFunction(
     returnType: `ODataBatchChangeSet<Write${service.className}RequestBuilder>`,
     statements: 'return new ODataBatchChangeSet(requests);',
     docs: [
-      getFunctionDoc(
-        `Change set constructor consists of write operations supported on the ${service.speakingModuleName}.`,
-        {
-          params: [
-            {
-              name: 'requests',
-              type: `Write${service.className}RequestBuilder[]`,
-              description: 'The requests of the change set'
+      addLeadingNewline(
+        getFunctionDoc(
+          `Change set constructor consists of write operations supported on the ${service.speakingModuleName}.`,
+          {
+            params: [
+              {
+                name: 'requests',
+                type: `Write${service.className}RequestBuilder[]`,
+                description: 'The requests of the change set'
+              }
+            ],
+            returns: {
+              type: 'ODataBatchChangeSet',
+              description: 'A change set for batch.'
             }
-          ],
-          returns: {
-            type: 'ODataBatchChangeSet',
-            description: 'A change set for batch.'
           }
-        }
+        )
       )
     ]
   };

--- a/packages/generator/src/complex-type/builder-function.ts
+++ b/packages/generator/src/complex-type/builder-function.ts
@@ -2,6 +2,7 @@
 
 import { FunctionDeclarationStructure, StructureKind } from 'ts-morph';
 import { VdmComplexType } from '../vdm-types';
+import { makeBlockComment } from '../typedoc';
 
 export function builderFunction(
   complexType: VdmComplexType
@@ -19,7 +20,9 @@ export function builderFunction(
     returnType: complexType.typeName,
     statements: `return ${complexType.typeName}.build(json);`,
     docs: [
-      `@deprecated since v1.6.0. Use [[${complexType.typeName}.build]] instead.`
+      makeBlockComment(
+        `@deprecated since v1.6.0. Use [[${complexType.typeName}.build]] instead.`
+      )
     ]
   };
 }

--- a/packages/generator/src/complex-type/builder-function.ts
+++ b/packages/generator/src/complex-type/builder-function.ts
@@ -2,7 +2,7 @@
 
 import { FunctionDeclarationStructure, StructureKind } from 'ts-morph';
 import { VdmComplexType } from '../vdm-types';
-import { makeBlockComment } from '../typedoc';
+import { addLeadingNewline } from '../typedoc';
 
 export function builderFunction(
   complexType: VdmComplexType
@@ -20,7 +20,7 @@ export function builderFunction(
     returnType: complexType.typeName,
     statements: `return ${complexType.typeName}.build(json);`,
     docs: [
-      makeBlockComment(
+      addLeadingNewline(
         `@deprecated since v1.6.0. Use [[${complexType.typeName}.build]] instead.`
       )
     ]

--- a/packages/generator/src/complex-type/interface.ts
+++ b/packages/generator/src/complex-type/interface.ts
@@ -5,7 +5,7 @@ import {
   PropertySignatureStructure,
   StructureKind
 } from 'ts-morph';
-import { getPropertyDescription, makeBlockComment } from '../typedoc';
+import { getPropertyDescription, addLeadingNewline } from '../typedoc';
 import { VdmComplexType, VdmProperty } from '../vdm-types';
 
 export function complexTypeInterface(
@@ -16,7 +16,7 @@ export function complexTypeInterface(
     name: complexType.typeName,
     isExported: true,
     properties: properties(complexType),
-    docs: [makeBlockComment(complexType.typeName)]
+    docs: [addLeadingNewline(complexType.typeName)]
   };
 }
 
@@ -31,10 +31,12 @@ function property(prop: VdmProperty): PropertySignatureStructure {
     type: prop.jsType,
     hasQuestionToken: prop.nullable,
     docs: [
-      getPropertyDescription(prop, {
-        nullable: prop.nullable,
-        maxLength: prop.maxLength
-      })
+      addLeadingNewline(
+        getPropertyDescription(prop, {
+          nullable: prop.nullable,
+          maxLength: prop.maxLength
+        })
+      )
     ]
   };
 }

--- a/packages/generator/src/complex-type/interface.ts
+++ b/packages/generator/src/complex-type/interface.ts
@@ -5,7 +5,7 @@ import {
   PropertySignatureStructure,
   StructureKind
 } from 'ts-morph';
-import { getPropertyDescription } from '../typedoc';
+import { getPropertyDescription, makeBlockComment } from '../typedoc';
 import { VdmComplexType, VdmProperty } from '../vdm-types';
 
 export function complexTypeInterface(
@@ -16,7 +16,7 @@ export function complexTypeInterface(
     name: complexType.typeName,
     isExported: true,
     properties: properties(complexType),
-    docs: [complexType.typeName]
+    docs: [makeBlockComment(complexType.typeName)]
   };
 }
 

--- a/packages/generator/src/entity/class.ts
+++ b/packages/generator/src/entity/class.ts
@@ -12,7 +12,7 @@ import {
   getFunctionDoc,
   getNavPropertyDescription,
   getPropertyDescription,
-  makeBlockComment
+  addLeadingNewline
 } from '../typedoc';
 import {
   VdmEntity,
@@ -37,7 +37,7 @@ export function entityClass(
     ],
     methods: methods(entity),
     isExported: true,
-    docs: [getEntityDescription(entity, service)]
+    docs: [addLeadingNewline(getEntityDescription(entity, service))]
   };
 }
 
@@ -58,7 +58,7 @@ function entityName(entity: VdmEntity): PropertyDeclarationStructure {
     name: prependPrefix('entityName'),
     isStatic: true,
     initializer: `\'${entity.entitySetName}\'`,
-    docs: [makeBlockComment(`Technical entity name for ${entity.className}.`)]
+    docs: [addLeadingNewline(`Technical entity name for ${entity.className}.`)]
   };
 }
 
@@ -87,7 +87,7 @@ function defaultServicePath(
     name: prependPrefix('defaultServicePath'),
     isStatic: true,
     initializer: `\'${service.servicePath}\'`,
-    docs: [makeBlockComment('Default url path for the according service.')]
+    docs: [addLeadingNewline('Default url path for the according service.')]
   };
 }
 
@@ -101,10 +101,12 @@ function property(prop: VdmProperty): PropertyDeclarationStructure {
     name: prop.instancePropertyName + (prop.nullable ? '?' : '!'),
     type: prop.jsType,
     docs: [
-      getPropertyDescription(prop, {
-        nullable: prop.nullable,
-        maxLength: prop.maxLength
-      })
+      addLeadingNewline(
+        getPropertyDescription(prop, {
+          nullable: prop.nullable,
+          maxLength: prop.maxLength
+        })
+      )
     ]
   };
 }
@@ -134,7 +136,7 @@ function navProperty(
     kind: StructureKind.Property,
     name: navProp.instancePropertyName + '!',
     type: entity.className + (navProp.isMultiLink ? '[]' : ''),
-    docs: [getNavPropertyDescription(navProp)]
+    docs: [addLeadingNewline(getNavPropertyDescription(navProp))]
   };
 }
 

--- a/packages/generator/src/entity/class.ts
+++ b/packages/generator/src/entity/class.ts
@@ -157,14 +157,16 @@ function builder(entity: VdmEntity): MethodDeclarationStructure {
     statements: `return Entity.entityBuilder(${entity.className});`,
     returnType: `EntityBuilderType<${entity.className}, ${entity.className}TypeForceMandatory>`,
     docs: [
-      getFunctionDoc(
-        `Returns an entity builder to construct instances \`${entity.className}\`.`,
-        {
-          returns: {
-            type: `EntityBuilderType<${entity.className}, ${entity.className}TypeForceMandatory>`,
-            description: `A builder that constructs instances of entity type \`${entity.className}\`.`
+      addLeadingNewline(
+        getFunctionDoc(
+          `Returns an entity builder to construct instances \`${entity.className}\`.`,
+          {
+            returns: {
+              type: `EntityBuilderType<${entity.className}, ${entity.className}TypeForceMandatory>`,
+              description: `A builder that constructs instances of entity type \`${entity.className}\`.`
+            }
           }
-        }
+        )
       )
     ]
   };
@@ -178,14 +180,16 @@ function requestBuilder(entity: VdmEntity): MethodDeclarationStructure {
     returnType: `${entity.className}RequestBuilder`,
     statements: `return new ${entity.className}RequestBuilder();`,
     docs: [
-      getFunctionDoc(
-        `Returns a request builder to construct requests for operations on the \`${entity.className}\` entity type.`,
-        {
-          returns: {
-            type: `${entity.className}RequestBuilder`,
-            description: `A \`${entity.className}\` request builder.`
+      addLeadingNewline(
+        getFunctionDoc(
+          `Returns a request builder to construct requests for operations on the \`${entity.className}\` entity type.`,
+          {
+            returns: {
+              type: `${entity.className}RequestBuilder`,
+              description: `A \`${entity.className}\` request builder.`
+            }
           }
-        }
+        )
       )
     ]
   };
@@ -205,21 +209,23 @@ function customField(entity: VdmEntity): MethodDeclarationStructure {
     statements: `return Entity.customFieldSelector(fieldName, ${entity.className});`,
     returnType: `CustomField<${entity.className}>`,
     docs: [
-      getFunctionDoc(
-        `Returns a selectable object that allows the selection of custom field in a get request for the entity \`${entity.className}\`.`,
-        {
-          params: [
-            {
-              name: 'fieldName',
-              description: 'Name of the custom field to select',
-              type: 'string'
+      addLeadingNewline(
+        getFunctionDoc(
+          `Returns a selectable object that allows the selection of custom field in a get request for the entity \`${entity.className}\`.`,
+          {
+            params: [
+              {
+                name: 'fieldName',
+                description: 'Name of the custom field to select',
+                type: 'string'
+              }
+            ],
+            returns: {
+              type: `CustomField<${entity.className}>`,
+              description: `A builder that constructs instances of entity type \`${entity.className}\`.`
             }
-          ],
-          returns: {
-            type: `CustomField<${entity.className}>`,
-            description: `A builder that constructs instances of entity type \`${entity.className}\`.`
           }
-        }
+        )
       )
     ]
   };
@@ -233,15 +239,17 @@ function toJSON(entity: VdmEntity): MethodDeclarationStructure {
     statements: 'return { ...this, ...this._customFields };',
     returnType: '{ [key: string]: any }',
     docs: [
-      getFunctionDoc(
-        'Overwrites the default toJSON method so that all instance variables as well as all custom fields of the entity are returned.',
-        {
-          returns: {
-            type: '{ [key: string]: any }',
-            description:
-              'An object containing all instance variables + custom fields.'
+      addLeadingNewline(
+        getFunctionDoc(
+          'Overwrites the default toJSON method so that all instance variables as well as all custom fields of the entity are returned.',
+          {
+            returns: {
+              type: '{ [key: string]: any }',
+              description:
+                'An object containing all instance variables + custom fields.'
+            }
           }
-        }
+        )
       )
     ]
   };

--- a/packages/generator/src/entity/class.ts
+++ b/packages/generator/src/entity/class.ts
@@ -11,7 +11,8 @@ import {
   getEntityDescription,
   getFunctionDoc,
   getNavPropertyDescription,
-  getPropertyDescription
+  getPropertyDescription,
+  makeBlockComment
 } from '../typedoc';
 import {
   VdmEntity,
@@ -57,7 +58,7 @@ function entityName(entity: VdmEntity): PropertyDeclarationStructure {
     name: prependPrefix('entityName'),
     isStatic: true,
     initializer: `\'${entity.entitySetName}\'`,
-    docs: [`Technical entity name for ${entity.className}.`]
+    docs: [makeBlockComment(`Technical entity name for ${entity.className}.`)]
   };
 }
 
@@ -86,7 +87,7 @@ function defaultServicePath(
     name: prependPrefix('defaultServicePath'),
     isStatic: true,
     initializer: `\'${service.servicePath}\'`,
-    docs: ['Default url path for the according service.']
+    docs: [makeBlockComment('Default url path for the according service.')]
   };
 }
 

--- a/packages/generator/src/entity/namespace.ts
+++ b/packages/generator/src/entity/namespace.ts
@@ -11,7 +11,8 @@ import { linkClass } from '../generator-utils';
 import { prependPrefix } from '../internal-prefix';
 import {
   getStaticNavPropertyDescription,
-  getStaticPropertyDescription
+  getStaticPropertyDescription,
+  makeBlockComment
 } from '../typedoc';
 import {
   VdmEntity,
@@ -141,7 +142,7 @@ function allFields(entity: VdmEntity): VariableStatementStructure {
           ]`
       }
     ],
-    docs: [`All fields of the ${entity.className} entity.`],
+    docs: [makeBlockComment(`All fields of the ${entity.className} entity.`)],
     isExported: true
   };
 }
@@ -157,7 +158,7 @@ function allFieldSelector(entity: VdmEntity): VariableStatementStructure {
         initializer: `new AllFields('*', ${entity.className})`
       }
     ],
-    docs: ['All fields selector.'],
+    docs: [makeBlockComment('All fields selector.')],
     isExported: true
   };
 }
@@ -178,7 +179,9 @@ function keyFields(entity: VdmEntity): VariableStatementStructure {
           ']'
       }
     ],
-    docs: [`All key fields of the ${entity.className} entity.`],
+    docs: [
+      makeBlockComment(`All key fields of the ${entity.className} entity.`)
+    ],
     isExported: true
   };
 }
@@ -202,7 +205,9 @@ function keys(entity: VdmEntity): VariableStatementStructure {
       }
     ],
     docs: [
-      `Mapping of all key field names to the respective static field property ${entity.className}.`
+      makeBlockComment(
+        `Mapping of all key field names to the respective static field property ${entity.className}.`
+      )
     ],
     isExported: true
   };

--- a/packages/generator/src/entity/namespace.ts
+++ b/packages/generator/src/entity/namespace.ts
@@ -12,7 +12,7 @@ import { prependPrefix } from '../internal-prefix';
 import {
   getStaticNavPropertyDescription,
   getStaticPropertyDescription,
-  makeBlockComment
+  addLeadingNewline
 } from '../typedoc';
 import {
   VdmEntity,
@@ -142,7 +142,7 @@ function allFields(entity: VdmEntity): VariableStatementStructure {
           ]`
       }
     ],
-    docs: [makeBlockComment(`All fields of the ${entity.className} entity.`)],
+    docs: [addLeadingNewline(`All fields of the ${entity.className} entity.`)],
     isExported: true
   };
 }
@@ -158,7 +158,7 @@ function allFieldSelector(entity: VdmEntity): VariableStatementStructure {
         initializer: `new AllFields('*', ${entity.className})`
       }
     ],
-    docs: [makeBlockComment('All fields selector.')],
+    docs: [addLeadingNewline('All fields selector.')],
     isExported: true
   };
 }
@@ -180,7 +180,7 @@ function keyFields(entity: VdmEntity): VariableStatementStructure {
       }
     ],
     docs: [
-      makeBlockComment(`All key fields of the ${entity.className} entity.`)
+      addLeadingNewline(`All key fields of the ${entity.className} entity.`)
     ],
     isExported: true
   };
@@ -205,7 +205,7 @@ function keys(entity: VdmEntity): VariableStatementStructure {
       }
     ],
     docs: [
-      makeBlockComment(
+      addLeadingNewline(
         `Mapping of all key field names to the respective static field property ${entity.className}.`
       )
     ],

--- a/packages/generator/src/function-import/parameters-interface.ts
+++ b/packages/generator/src/function-import/parameters-interface.ts
@@ -2,7 +2,7 @@
 
 import { InterfaceDeclarationStructure, StructureKind } from 'ts-morph';
 import { VdmFunctionImport } from '../vdm-types';
-import { makeBlockComment } from '../typedoc';
+import { addLeadingNewline } from '../typedoc';
 
 export function functionImportParametersInterface(
   functionImport: VdmFunctionImport
@@ -15,10 +15,10 @@ export function functionImportParametersInterface(
       name: parameter.parameterName,
       type: parameter.jsType,
       hasQuestionToken: parameter.nullable,
-      docs: [makeBlockComment(parameter.description)]
+      docs: [addLeadingNewline(parameter.description)]
     })),
     docs: [
-      makeBlockComment(
+      addLeadingNewline(
         `Type of the parameters to be passed to [[${functionImport.functionName}]].`
       )
     ]

--- a/packages/generator/src/function-import/parameters-interface.ts
+++ b/packages/generator/src/function-import/parameters-interface.ts
@@ -2,6 +2,7 @@
 
 import { InterfaceDeclarationStructure, StructureKind } from 'ts-morph';
 import { VdmFunctionImport } from '../vdm-types';
+import { makeBlockComment } from '../typedoc';
 
 export function functionImportParametersInterface(
   functionImport: VdmFunctionImport
@@ -14,10 +15,12 @@ export function functionImportParametersInterface(
       name: parameter.parameterName,
       type: parameter.jsType,
       hasQuestionToken: parameter.nullable,
-      docs: [parameter.description]
+      docs: [makeBlockComment(parameter.description)]
     })),
     docs: [
-      `Type of the parameters to be passed to [[${functionImport.functionName}]].`
+      makeBlockComment(
+        `Type of the parameters to be passed to [[${functionImport.functionName}]].`
+      )
     ]
   };
 }

--- a/packages/generator/src/request-builder/class.ts
+++ b/packages/generator/src/request-builder/class.ts
@@ -60,19 +60,21 @@ function getByKeyRequestBuilder(entity: VdmEntity): MethodDeclarationStructure {
     returnType: `GetByKeyRequestBuilder<${entity.className}>`,
     statements: buildParametrizedStatements(entity, 'GetByKeyRequestBuilder'),
     docs: [
-      getFunctionDoc(
-        `Returns a request builder for retrieving one \`${entity.className}\` entity based on its keys.`,
-        {
-          returns: {
-            type: `GetByKeyRequestBuilder<${entity.className}>`,
-            description: `A request builder for creating requests to retrieve one \`${entity.className}\` entity based on its keys.`
-          },
-          params: entity.keys.map(key => ({
-            name: key.propertyNameAsParam,
-            type: key.jsType,
-            description: `Key property. See [[${entity.className}.${key.instancePropertyName}]].`
-          }))
-        }
+      addLeadingNewline(
+        getFunctionDoc(
+          `Returns a request builder for retrieving one \`${entity.className}\` entity based on its keys.`,
+          {
+            returns: {
+              type: `GetByKeyRequestBuilder<${entity.className}>`,
+              description: `A request builder for creating requests to retrieve one \`${entity.className}\` entity based on its keys.`
+            },
+            params: entity.keys.map(key => ({
+              name: key.propertyNameAsParam,
+              type: key.jsType,
+              description: `Key property. See [[${entity.className}.${key.instancePropertyName}]].`
+            }))
+          }
+        )
       )
     ]
   };
@@ -85,14 +87,16 @@ function getAllRequestBuilder(entity: VdmEntity): MethodDeclarationStructure {
     returnType: `GetAllRequestBuilder<${entity.className}>`,
     statements: `return new GetAllRequestBuilder(${entity.className});`,
     docs: [
-      getFunctionDoc(
-        `Returns a request builder for querying all \`${entity.className}\` entities.`,
-        {
-          returns: {
-            type: `GetAllRequestBuilder<${entity.className}>`,
-            description: `A request builder for creating requests to retrieve all \`${entity.className}\` entities.`
+      addLeadingNewline(
+        getFunctionDoc(
+          `Returns a request builder for querying all \`${entity.className}\` entities.`,
+          {
+            returns: {
+              type: `GetAllRequestBuilder<${entity.className}>`,
+              description: `A request builder for creating requests to retrieve all \`${entity.className}\` entities.`
+            }
           }
-        }
+        )
       )
     ]
   };
@@ -111,21 +115,23 @@ function createRequestBuilder(entity: VdmEntity): MethodDeclarationStructure {
     ],
     statements: `return new CreateRequestBuilder(${entity.className}, entity);`,
     docs: [
-      getFunctionDoc(
-        `Returns a request builder for creating a \`${entity.className}\` entity.`,
-        {
-          returns: {
-            type: `CreateRequestBuilder<${entity.className}>`,
-            description: `A request builder for creating requests that create an entity of type \`${entity.className}\`.`
-          },
-          params: [
-            {
-              name: 'entity',
-              type: entity.className,
-              description: 'The entity to be created'
-            }
-          ]
-        }
+      addLeadingNewline(
+        getFunctionDoc(
+          `Returns a request builder for creating a \`${entity.className}\` entity.`,
+          {
+            returns: {
+              type: `CreateRequestBuilder<${entity.className}>`,
+              description: `A request builder for creating requests that create an entity of type \`${entity.className}\`.`
+            },
+            params: [
+              {
+                name: 'entity',
+                type: entity.className,
+                description: 'The entity to be created'
+              }
+            ]
+          }
+        )
       )
     ]
   };
@@ -144,21 +150,23 @@ function updateRequestBuilder(entity: VdmEntity): MethodDeclarationStructure {
     ],
     statements: `return new UpdateRequestBuilder(${entity.className}, entity);`,
     docs: [
-      getFunctionDoc(
-        `Returns a request builder for updating an entity of type \`${entity.className}\`.`,
-        {
-          returns: {
-            type: `UpdateRequestBuilder<${entity.className}>`,
-            description: `A request builder for creating requests that update an entity of type \`${entity.className}\`.`
-          },
-          params: [
-            {
-              name: 'entity',
-              type: entity.className,
-              description: 'The entity to be updated'
-            }
-          ]
-        }
+      addLeadingNewline(
+        getFunctionDoc(
+          `Returns a request builder for updating an entity of type \`${entity.className}\`.`,
+          {
+            returns: {
+              type: `UpdateRequestBuilder<${entity.className}>`,
+              description: `A request builder for creating requests that update an entity of type \`${entity.className}\`.`
+            },
+            params: [
+              {
+                name: 'entity',
+                type: entity.className,
+                description: 'The entity to be updated'
+              }
+            ]
+          }
+        )
       )
     ]
   };
@@ -216,19 +224,21 @@ function deleteRequestBuilderOverload(
         type: key.jsType
       })),
       docs: [
-        getFunctionDoc(
-          `Returns a request builder for deleting an entity of type \`${entity.className}\`.`,
-          {
-            returns: {
-              type: `DeleteRequestBuilder<${entity.className}>`,
-              description: `A request builder for creating requests that delete an entity of type \`${entity.className}\`.`
-            },
-            params: entity.keys.map(key => ({
-              name: key.propertyNameAsParam,
-              type: key.jsType,
-              description: `Key property. See [[${entity.className}.${key.instancePropertyName}]].`
-            }))
-          }
+        addLeadingNewline(
+          getFunctionDoc(
+            `Returns a request builder for deleting an entity of type \`${entity.className}\`.`,
+            {
+              returns: {
+                type: `DeleteRequestBuilder<${entity.className}>`,
+                description: `A request builder for creating requests that delete an entity of type \`${entity.className}\`.`
+              },
+              params: entity.keys.map(key => ({
+                name: key.propertyNameAsParam,
+                type: key.jsType,
+                description: `Key property. See [[${entity.className}.${key.instancePropertyName}]].`
+              }))
+            }
+          )
         )
       ]
     },
@@ -242,21 +252,23 @@ function deleteRequestBuilderOverload(
         }
       ],
       docs: [
-        getFunctionDoc(
-          `Returns a request builder for deleting an entity of type \`${entity.className}\`.`,
-          {
-            returns: {
-              type: `DeleteRequestBuilder<${entity.className}>`,
-              description: `A request builder for creating requests that delete an entity of type \`${entity.className}\` by taking the entity as a parameter.`
-            },
-            params: [
-              {
-                name: 'entity',
-                type: entity.className,
-                description: 'Pass the entity to be deleted.'
-              }
-            ]
-          }
+        addLeadingNewline(
+          getFunctionDoc(
+            `Returns a request builder for deleting an entity of type \`${entity.className}\`.`,
+            {
+              returns: {
+                type: `DeleteRequestBuilder<${entity.className}>`,
+                description: `A request builder for creating requests that delete an entity of type \`${entity.className}\` by taking the entity as a parameter.`
+              },
+              params: [
+                {
+                  name: 'entity',
+                  type: entity.className,
+                  description: 'Pass the entity to be deleted.'
+                }
+              ]
+            }
+          )
         )
       ]
     }

--- a/packages/generator/src/request-builder/class.ts
+++ b/packages/generator/src/request-builder/class.ts
@@ -8,7 +8,11 @@ import {
   ParameterDeclarationStructure,
   StructureKind
 } from 'ts-morph';
-import { getFunctionDoc, getRequestBuilderDescription } from '../typedoc';
+import {
+  addLeadingNewline,
+  getFunctionDoc,
+  getRequestBuilderDescription
+} from '../typedoc';
 import { VdmEntity } from '../vdm-types';
 
 export function requestBuilderClass(
@@ -20,7 +24,7 @@ export function requestBuilderClass(
     isExported: true,
     extends: `RequestBuilder<${entity.className}>`,
     methods: requestBuilderMethods(entity),
-    docs: [getRequestBuilderDescription(entity)]
+    docs: [addLeadingNewline(getRequestBuilderDescription(entity))]
   };
 }
 

--- a/packages/generator/src/typedoc.ts
+++ b/packages/generator/src/typedoc.ts
@@ -37,7 +37,7 @@ export function getFunctionDoc(
       description += tagToText('returns', `${tags.returns.description}`);
     }
   }
-  return addLeadingNewline(description);
+  return description;
 }
 
 export function getComplexTypeFieldDescription(

--- a/packages/generator/src/typedoc.ts
+++ b/packages/generator/src/typedoc.ts
@@ -37,7 +37,7 @@ export function getFunctionDoc(
       description += tagToText('returns', `${tags.returns.description}`);
     }
   }
-  return description;
+  return makeBlockComment(description);
 }
 
 export function getComplexTypeFieldDescription(
@@ -50,21 +50,32 @@ export function getPropertyDescription(
   property: VdmProperty,
   constraints: VdmPropertyValueConstraints = { nullable: false }
 ): string {
-  return addConstraints(
-    property.description ||
-      endWithDot(toTitleFormat(property.instancePropertyName).trim()),
-    constraints
+  return makeBlockComment(
+    addConstraints(
+      property.description ||
+        endWithDot(toTitleFormat(property.instancePropertyName).trim()),
+      constraints
+    )
   );
+}
+
+export function makeBlockComment(documentation: string): string {
+  if (!documentation.startsWith('\n')) {
+    return '\n' + documentation;
+  }
+  return documentation;
 }
 
 export function getNavPropertyDescription(
   property: VdmNavigationProperty
 ): string {
-  return `${
-    property.isMultiLink ? 'One-to-many' : 'One-to-one'
-  } navigation property to the [[${
-    property.toEntityClassName
-  }]] entity.`.trim();
+  return makeBlockComment(
+    `${
+      property.isMultiLink ? 'One-to-many' : 'One-to-one'
+    } navigation property to the [[${
+      property.toEntityClassName
+    }]] entity.`.trim()
+  );
 }
 
 export function getComplexTypePropertyDescription(
@@ -98,32 +109,35 @@ export function getEntityDescription(
     service.apiBusinessHubMetadata &&
     service.apiBusinessHubMetadata.communicationScenario
   ) {
-    description +=
-      '\n' +
-      partOfCommunicationScenarios(
-        service.apiBusinessHubMetadata.communicationScenario
-      );
+    description = partOfCommunicationScenarios(
+      service.apiBusinessHubMetadata.communicationScenario
+    );
   }
 
   if (service.apiBusinessHubMetadata) {
-    description +=
-      '\n' + seeForMoreInformation(service.apiBusinessHubMetadata.url);
+    description = seeForMoreInformation(service.apiBusinessHubMetadata.url);
   }
 
   return description;
 }
 
 const entityDescription = (entitySetName: string, speakingModuleName: string) =>
-  `This class represents the entity "${entitySetName}" of service "${speakingModuleName}".`;
+  makeBlockComment(
+    `This class represents the entity "${entitySetName}" of service "${speakingModuleName}".`
+  );
 
 const seeForMoreInformation = (url: string) =>
   `See ${url} for more information.`;
 
 const partOfCommunicationScenarios = (communicationScenarios: string) =>
-  `This service is part of the following communication scenarios: ${communicationScenarios}.`;
+  makeBlockComment(
+    `This service is part of the following communication scenarios: ${communicationScenarios}.`
+  );
 
 export function getRequestBuilderDescription(entity: VdmEntity) {
-  return `Request builder class for operations supported on the [[${entity.className}]] entity.`;
+  return makeBlockComment(
+    `Request builder class for operations supported on the [[${entity.className}]] entity.`
+  );
 }
 
 export function getLookupDescription(service: VdmServiceMetadata) {

--- a/packages/generator/src/typedoc.ts
+++ b/packages/generator/src/typedoc.ts
@@ -37,7 +37,7 @@ export function getFunctionDoc(
       description += tagToText('returns', `${tags.returns.description}`);
     }
   }
-  return makeBlockComment(description);
+  return addLeadingNewline(description);
 }
 
 export function getComplexTypeFieldDescription(
@@ -50,16 +50,19 @@ export function getPropertyDescription(
   property: VdmProperty,
   constraints: VdmPropertyValueConstraints = { nullable: false }
 ): string {
-  return makeBlockComment(
-    addConstraints(
-      property.description ||
-        endWithDot(toTitleFormat(property.instancePropertyName).trim()),
-      constraints
-    )
+  return addConstraints(
+    property.description ||
+      endWithDot(toTitleFormat(property.instancePropertyName).trim()),
+    constraints
   );
 }
 
-export function makeBlockComment(documentation: string): string {
+/**
+ * Adds a leading \n to a documentation string so that the ts-morph makes a block comment out of it.
+ * @param documentation text.
+ * @returns documentation text with leading \n.
+ */
+export function addLeadingNewline(documentation: string): string {
   if (!documentation.startsWith('\n')) {
     return '\n' + documentation;
   }
@@ -69,13 +72,11 @@ export function makeBlockComment(documentation: string): string {
 export function getNavPropertyDescription(
   property: VdmNavigationProperty
 ): string {
-  return makeBlockComment(
-    `${
-      property.isMultiLink ? 'One-to-many' : 'One-to-one'
-    } navigation property to the [[${
-      property.toEntityClassName
-    }]] entity.`.trim()
-  );
+  return `${
+    property.isMultiLink ? 'One-to-many' : 'One-to-one'
+  } navigation property to the [[${
+    property.toEntityClassName
+  }]] entity.`.trim();
 }
 
 export function getComplexTypePropertyDescription(
@@ -122,22 +123,14 @@ export function getEntityDescription(
 }
 
 const entityDescription = (entitySetName: string, speakingModuleName: string) =>
-  makeBlockComment(
-    `This class represents the entity "${entitySetName}" of service "${speakingModuleName}".`
-  );
-
+  `This class represents the entity "${entitySetName}" of service "${speakingModuleName}".`;
 const seeForMoreInformation = (url: string) =>
   `See ${url} for more information.`;
 
 const partOfCommunicationScenarios = (communicationScenarios: string) =>
-  makeBlockComment(
-    `This service is part of the following communication scenarios: ${communicationScenarios}.`
-  );
-
+  `This service is part of the following communication scenarios: ${communicationScenarios}.`;
 export function getRequestBuilderDescription(entity: VdmEntity) {
-  return makeBlockComment(
-    `Request builder class for operations supported on the [[${entity.className}]] entity.`
-  );
+  return `Request builder class for operations supported on the [[${entity.className}]] entity.`;
 }
 
 export function getLookupDescription(service: VdmServiceMetadata) {

--- a/packages/generator/test/complex-type/builder-function.spec.ts
+++ b/packages/generator/test/complex-type/builder-function.spec.ts
@@ -13,7 +13,9 @@ describe('builder-function', () => {
       parameters: [{ name: 'json', type: 'any' }],
       returnType: 'ComplexMealType',
       statements: 'return ComplexMealType.build(json);',
-      docs: ['\n@deprecated since v1.6.0. Use [[ComplexMealType.build]] instead.']
+      docs: [
+        '\n@deprecated since v1.6.0. Use [[ComplexMealType.build]] instead.'
+      ]
     });
   });
 

--- a/packages/generator/test/complex-type/builder-function.spec.ts
+++ b/packages/generator/test/complex-type/builder-function.spec.ts
@@ -13,7 +13,7 @@ describe('builder-function', () => {
       parameters: [{ name: 'json', type: 'any' }],
       returnType: 'ComplexMealType',
       statements: 'return ComplexMealType.build(json);',
-      docs: ['@deprecated since v1.6.0. Use [[ComplexMealType.build]] instead.']
+      docs: ['\n@deprecated since v1.6.0. Use [[ComplexMealType.build]] instead.']
     });
   });
 
@@ -27,7 +27,7 @@ describe('builder-function', () => {
       returnType: 'ComplexMealWithDesertType',
       statements: 'return ComplexMealWithDesertType.build(json);',
       docs: [
-        '@deprecated since v1.6.0. Use [[ComplexMealWithDesertType.build]] instead.'
+        '\n@deprecated since v1.6.0. Use [[ComplexMealWithDesertType.build]] instead.'
       ]
     });
   });

--- a/packages/generator/test/complex-type/interface.spec.ts
+++ b/packages/generator/test/complex-type/interface.spec.ts
@@ -16,17 +16,17 @@ describe('interface', () => {
           name: 'complexity',
           type: 'string',
           hasQuestionToken: false,
-          docs: ['something something very good']
+          docs: ['\nsomething something very good']
         },
         {
           kind: StructureKind.PropertySignature,
           name: 'amount',
           type: 'number',
           hasQuestionToken: false,
-          docs: ['something something very much']
+          docs: ['\nsomething something very much']
         }
       ],
-      docs: ['ComplexMealType']
+      docs: ['\nComplexMealType']
     });
   });
 
@@ -42,17 +42,17 @@ describe('interface', () => {
           name: 'complexDesert',
           type: 'ComplexDesert',
           hasQuestionToken: false,
-          docs: ['the desert']
+          docs: ['\nthe desert']
         },
         {
           kind: StructureKind.PropertySignature,
           name: 'amount',
           type: 'number',
           hasQuestionToken: false,
-          docs: ['something something very much']
+          docs: ['\nsomething something very much']
         }
       ],
-      docs: ['ComplexMealWithDesertType']
+      docs: ['\nComplexMealWithDesertType']
     });
   });
 });

--- a/packages/generator/test/function-import/parameters-interface.spec.ts
+++ b/packages/generator/test/function-import/parameters-interface.spec.ts
@@ -14,10 +14,10 @@ describe('parameters-interface', () => {
           name: 'withHoneyToast',
           type: 'boolean',
           hasQuestionToken: true,
-          docs: ['Breakfast includes a honey toast']
+          docs: ['\nBreakfast includes a honey toast']
         }
       ],
-      docs: ['Type of the parameters to be passed to [[orderBreakfast]].']
+      docs: ['\nType of the parameters to be passed to [[orderBreakfast]].']
     });
   });
 });

--- a/packages/generator/test/vdm-typedoc-generator.spec.ts
+++ b/packages/generator/test/vdm-typedoc-generator.spec.ts
@@ -10,7 +10,7 @@ describe('typedoc', () => {
   it('get normal property description', () => {
     const property: VdmProperty = {
       originalName: 'OnePropertyName',
-      description: 'entity info',
+      description: '\n  entity info',
       jsType: 'string',
       edmType: 'Edm:String',
       nullable: true,
@@ -35,7 +35,7 @@ describe('typedoc', () => {
       staticPropertyName: 'ONE_PROPERTY_NAME',
       propertyNameAsParam: 'onePropertyName'
     };
-    expect(getPropertyDescription(property)).toBe('One Property Name.');
+    expect(getPropertyDescription(property)).toBe('\nOne Property Name.');
   });
 
   it('get navigation property description', () => {
@@ -52,7 +52,7 @@ describe('typedoc', () => {
     };
 
     expect(getNavPropertyDescription(navProp)).toBe(
-      'One-to-many navigation property to the [[OtherEntity]] entity.'
+      '\nOne-to-many navigation property to the [[OtherEntity]] entity.'
     );
   });
 
@@ -67,7 +67,7 @@ describe('typedoc', () => {
       ],
       returns: { type: 'string', description: returnDescription }
     });
-    const expected = `function description\n@param ${paramName} ${paramDescription}\n@returns ${returnDescription}`;
+    const expected = `\nfunction description\n@param ${paramName} ${paramDescription}\n@returns ${returnDescription}`;
     expect(actual).toBe(expected);
   });
 
@@ -84,7 +84,7 @@ describe('typedoc', () => {
       propertyNameAsParam: 'onePropertyName'
     };
     expect(getPropertyDescription(property, { nullable: true })).toBe(
-      'Property Description\n@nullable'
+      '\nProperty Description\n@nullable'
     );
   });
 });

--- a/packages/generator/test/vdm-typedoc-generator.spec.ts
+++ b/packages/generator/test/vdm-typedoc-generator.spec.ts
@@ -35,7 +35,7 @@ describe('typedoc', () => {
       staticPropertyName: 'ONE_PROPERTY_NAME',
       propertyNameAsParam: 'onePropertyName'
     };
-    expect(getPropertyDescription(property)).toBe('\nOne Property Name.');
+    expect(getPropertyDescription(property)).toBe('One Property Name.');
   });
 
   it('get navigation property description', () => {
@@ -52,7 +52,7 @@ describe('typedoc', () => {
     };
 
     expect(getNavPropertyDescription(navProp)).toBe(
-      '\nOne-to-many navigation property to the [[OtherEntity]] entity.'
+      'One-to-many navigation property to the [[OtherEntity]] entity.'
     );
   });
 
@@ -84,7 +84,7 @@ describe('typedoc', () => {
       propertyNameAsParam: 'onePropertyName'
     };
     expect(getPropertyDescription(property, { nullable: true })).toBe(
-      '\nProperty Description\n@nullable'
+      'Property Description\n@nullable'
     );
   });
 });

--- a/packages/generator/test/vdm-typedoc-generator.spec.ts
+++ b/packages/generator/test/vdm-typedoc-generator.spec.ts
@@ -67,7 +67,7 @@ describe('typedoc', () => {
       ],
       returns: { type: 'string', description: returnDescription }
     });
-    const expected = `\nfunction description\n@param ${paramName} ${paramDescription}\n@returns ${returnDescription}`;
+    const expected = `function description\n@param ${paramName} ${paramDescription}\n@returns ${returnDescription}`;
     expect(actual).toBe(expected);
   });
 


### PR DESCRIPTION
## Context

Due to the changed linting also the generated docs of the entities are changed. In the past the doc was created not in block form but the linter took accidentally care.

In this PR, empty lines are added so that the entities keep their nice block style as before.

In order to test, please run `npm run generate:tes-sources` and see if no changes are induced. I tried it, but you never know.