### PR TITLE
chore: Improve the Docs overview Page

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,5 +1,4 @@
 # API Documentation
 
+- [Version 1.18.1](1.18.1),
 - [Version 1.18.0](1.18.0)
-
-- [Version 1.18.1](1.18.1)

--- a/docs/api/latest.html
+++ b/docs/api/latest.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta http-equiv="refresh" content="0; url=https://sap.github.io/cloud-sdk/api/1.18.1">
+    <style>
+        * {
+            font-family: Helvetica,Arial,sans-serif;
+            color: #333333;
+        }
+    </style>
+</head>
+<body>
+    <p>Click <a href="https://sap.github.io/cloud-sdk/api/1.18.1">here</a> to redirect...</p>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4023,6 +4023,12 @@
 				}
 			}
 		},
+		"compare-versions": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
+			"integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
+			"dev": true
+		},
 		"component-emitter": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@typescript-eslint/eslint-plugin": "^2.23.0",
     "@typescript-eslint/parser": "^2.23.0",
     "audit-ci": "^2.5.1",
+    "compare-versions": "^3.6.0",
     "eslint": "^6.8.0",
     "eslint-plugin-header": "^3.0.0",
     "eslint-plugin-import": "^2.20.1",


### PR DESCRIPTION
## Context

This PR adds two things to the docs provided by the github pages:
- The index.html in `docs/api`  contains now the version sorted by latest on top
- There is a `latest.html` which redirects to the latest doc

It also changes the way the index is created. Instead of relying on the old file it considers all folders in the `docs/api` as a version so there is no risk of having multiple times the same line or a link to a non existing entry.

## Testing

Testing is a bit difficult. What I did was adding a higher version in the `lerna.json` and then executed `npm run doc`. A new version appeared in the docs, index.html and the latest.html was adjusted. I then uploaded it to a private repo and it was working to. The redirect in the test was to the productive repo but I think this is ok.


