### PR TITLE
chore: Re-enable proxy test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -482,13 +482,13 @@
 			"integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw=="
 		},
 		"@jest/console": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-25.2.1.tgz",
-			"integrity": "sha512-v3tkMr5AeVm6R23wnZdC5dzXdHPFa6j2uiTC15iHISYkGIilE9O1qmAYKELHPXZifDbz9c8WwzsqoN8K8uG4jg==",
+			"version": "25.2.3",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-25.2.3.tgz",
+			"integrity": "sha512-k+37B1aSvOt9tKHWbZZSOy1jdgzesB0bj96igCVUG1nAH1W5EoUfgc5EXbBVU08KSLvkVdWopLXaO3xfVGlxtQ==",
 			"requires": {
 				"@jest/source-map": "^25.2.1",
 				"chalk": "^3.0.0",
-				"jest-util": "^25.2.1",
+				"jest-util": "^25.2.3",
 				"slash": "^3.0.0"
 			},
 			"dependencies": {
@@ -500,32 +500,32 @@
 			}
 		},
 		"@jest/core": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-25.2.1.tgz",
-			"integrity": "sha512-Pe7CVcysOmm69BgdgAuMjRCp6vmcCJy32PxPtArQDgiizIBQElHhE9P34afGwPgSb3+e3WC6XtEm4de7d9BtfQ==",
+			"version": "25.2.4",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-25.2.4.tgz",
+			"integrity": "sha512-WcWYShl0Bqfcb32oXtjwbiR78D/djhMdJW+ulp4/bmHgeODcsieqUJfUH+kEv8M7VNV77E6jds5aA+WuGh1nmg==",
 			"requires": {
-				"@jest/console": "^25.2.1",
-				"@jest/reporters": "^25.2.1",
-				"@jest/test-result": "^25.2.1",
-				"@jest/transform": "^25.2.1",
-				"@jest/types": "^25.2.1",
+				"@jest/console": "^25.2.3",
+				"@jest/reporters": "^25.2.4",
+				"@jest/test-result": "^25.2.4",
+				"@jest/transform": "^25.2.4",
+				"@jest/types": "^25.2.3",
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^3.0.0",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.2.3",
-				"jest-changed-files": "^25.2.1",
-				"jest-config": "^25.2.1",
-				"jest-haste-map": "^25.2.1",
-				"jest-message-util": "^25.2.1",
+				"jest-changed-files": "^25.2.3",
+				"jest-config": "^25.2.4",
+				"jest-haste-map": "^25.2.3",
+				"jest-message-util": "^25.2.4",
 				"jest-regex-util": "^25.2.1",
-				"jest-resolve": "^25.2.1",
-				"jest-resolve-dependencies": "^25.2.1",
-				"jest-runner": "^25.2.1",
-				"jest-runtime": "^25.2.1",
-				"jest-snapshot": "^25.2.1",
-				"jest-util": "^25.2.1",
-				"jest-validate": "^25.2.1",
-				"jest-watcher": "^25.2.1",
+				"jest-resolve": "^25.2.3",
+				"jest-resolve-dependencies": "^25.2.4",
+				"jest-runner": "^25.2.4",
+				"jest-runtime": "^25.2.4",
+				"jest-snapshot": "^25.2.4",
+				"jest-util": "^25.2.3",
+				"jest-validate": "^25.2.3",
+				"jest-watcher": "^25.2.4",
 				"micromatch": "^4.0.2",
 				"p-each-series": "^2.1.0",
 				"realpath-native": "^2.0.0",
@@ -614,37 +614,37 @@
 			}
 		},
 		"@jest/environment": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-25.2.1.tgz",
-			"integrity": "sha512-aeA3UlUmpblmv2CHBcNA7LvcXlcCtRpXaKKFVooRy9/Jk8B4IZAZMfrML/d+1cG5FpF17s4JVdu1kx0mbnaqTQ==",
+			"version": "25.2.4",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-25.2.4.tgz",
+			"integrity": "sha512-wA4xlhD19/gukkDpJ5HQsTle0pgnzI5qMFEjw267lpTDC8d9N7Ihqr5pI+l0p8Qn1SQhai+glSqxrGdzKy4jxw==",
 			"requires": {
-				"@jest/fake-timers": "^25.2.1",
-				"@jest/types": "^25.2.1",
-				"jest-mock": "^25.2.1"
+				"@jest/fake-timers": "^25.2.4",
+				"@jest/types": "^25.2.3",
+				"jest-mock": "^25.2.3"
 			}
 		},
 		"@jest/fake-timers": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-25.2.1.tgz",
-			"integrity": "sha512-H1OC8AktrGTD10NHBauICkRCv7VOOrsgI8xokifAsxJMYhqoKBtJZbk2YpbrtnmdTUnk+qoxPUk+Mufwnl44iQ==",
+			"version": "25.2.4",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-25.2.4.tgz",
+			"integrity": "sha512-oC1TJiwfMcBttVN7Wz+VZnqEAgYTiEMu0QLOXpypR89nab0uCB31zm/QeBZddhSstn20qe3yqOXygp6OwvKT/Q==",
 			"requires": {
-				"@jest/types": "^25.2.1",
-				"jest-message-util": "^25.2.1",
-				"jest-mock": "^25.2.1",
-				"jest-util": "^25.2.1",
+				"@jest/types": "^25.2.3",
+				"jest-message-util": "^25.2.4",
+				"jest-mock": "^25.2.3",
+				"jest-util": "^25.2.3",
 				"lolex": "^5.0.0"
 			}
 		},
 		"@jest/reporters": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-25.2.1.tgz",
-			"integrity": "sha512-jAnIECIIFVHiASKLpPBpZ9fIgWolKdMwUuyjSlNVixmtX6G83fyiGaOquaAU1ukAxnlKdCLjvH6BYdY+GGbd5Q==",
+			"version": "25.2.4",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-25.2.4.tgz",
+			"integrity": "sha512-VHbLxM03jCc+bTLOluW/IqHR2G0Cl0iATwIQbuZtIUast8IXO4fD0oy4jpVGpG5b20S6REA8U3BaQoCW/CeVNQ==",
 			"requires": {
 				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "^25.2.1",
-				"@jest/test-result": "^25.2.1",
-				"@jest/transform": "^25.2.1",
-				"@jest/types": "^25.2.1",
+				"@jest/console": "^25.2.3",
+				"@jest/test-result": "^25.2.4",
+				"@jest/transform": "^25.2.4",
+				"@jest/types": "^25.2.3",
 				"chalk": "^3.0.0",
 				"collect-v8-coverage": "^1.0.0",
 				"exit": "^0.1.2",
@@ -654,9 +654,9 @@
 				"istanbul-lib-report": "^3.0.0",
 				"istanbul-lib-source-maps": "^4.0.0",
 				"istanbul-reports": "^3.0.0",
-				"jest-haste-map": "^25.2.1",
-				"jest-resolve": "^25.2.1",
-				"jest-util": "^25.2.1",
+				"jest-haste-map": "^25.2.3",
+				"jest-resolve": "^25.2.3",
+				"jest-util": "^25.2.3",
 				"jest-worker": "^25.2.1",
 				"node-notifier": "^6.0.0",
 				"slash": "^3.0.0",
@@ -701,43 +701,43 @@
 			}
 		},
 		"@jest/test-result": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-25.2.1.tgz",
-			"integrity": "sha512-E0tlWh2iOELRLbbPEngs3Dsx88vGBQOs6O3w46YeXfMHlwwqzWrlvoeUq6kRlHRm1O8H+EBr60Wtrwh20C+zWQ==",
+			"version": "25.2.4",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-25.2.4.tgz",
+			"integrity": "sha512-AI7eUy+q2lVhFnaibDFg68NGkrxVWZdD6KBr9Hm6EvN0oAe7GxpEwEavgPfNHQjU2mi6g+NsFn/6QPgTUwM1qg==",
 			"requires": {
-				"@jest/console": "^25.2.1",
-				"@jest/transform": "^25.2.1",
-				"@jest/types": "^25.2.1",
+				"@jest/console": "^25.2.3",
+				"@jest/transform": "^25.2.4",
+				"@jest/types": "^25.2.3",
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"collect-v8-coverage": "^1.0.0"
 			}
 		},
 		"@jest/test-sequencer": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-25.2.1.tgz",
-			"integrity": "sha512-yEhVlBRS7pg3MGBIQQafYfm2NT5trFa/qoxtLftQoZmyzKx3rPy0oJ+d/8QljK4X2RGY/i7mmQDxE6sGR9UqeQ==",
+			"version": "25.2.4",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-25.2.4.tgz",
+			"integrity": "sha512-TEZm/Rkd6YgskdpTJdYLBtu6Gc11tfWPuSpatq0duH77ekjU8dpqX2zkPdY/ayuHxztV5LTJoV5BLtI9mZfXew==",
 			"requires": {
-				"@jest/test-result": "^25.2.1",
-				"jest-haste-map": "^25.2.1",
-				"jest-runner": "^25.2.1",
-				"jest-runtime": "^25.2.1"
+				"@jest/test-result": "^25.2.4",
+				"jest-haste-map": "^25.2.3",
+				"jest-runner": "^25.2.4",
+				"jest-runtime": "^25.2.4"
 			}
 		},
 		"@jest/transform": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-25.2.1.tgz",
-			"integrity": "sha512-puoD5EfqPeZ5m0dV9l8+PMdOVdRjeWcaEjGkH+eG45l0nPJ2vRcxu8J6CRl/6nQ5ZTHgg7LuM9C6FauNpdRpUA==",
+			"version": "25.2.4",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-25.2.4.tgz",
+			"integrity": "sha512-6eRigvb+G6bs4kW5j1/y8wu4nCrmVuIe0epPBbiWaYlwawJ8yi1EIyK3d/btDqmBpN5GpN4YhR6iPPnDmkYdTA==",
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/types": "^25.2.1",
+				"@jest/types": "^25.2.3",
 				"babel-plugin-istanbul": "^6.0.0",
 				"chalk": "^3.0.0",
 				"convert-source-map": "^1.4.0",
 				"fast-json-stable-stringify": "^2.0.0",
 				"graceful-fs": "^4.2.3",
-				"jest-haste-map": "^25.2.1",
+				"jest-haste-map": "^25.2.3",
 				"jest-regex-util": "^25.2.1",
-				"jest-util": "^25.2.1",
+				"jest-util": "^25.2.3",
 				"micromatch": "^4.0.2",
 				"pirates": "^4.0.1",
 				"realpath-native": "^2.0.0",
@@ -808,9 +808,9 @@
 			}
 		},
 		"@jest/types": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.1.tgz",
-			"integrity": "sha512-WuGFGJ3Rrycg+5ZwQTWKjr21M9psANPAWYD28K42hSeUzhv1H591VXIoq0tjs00mydhNOgVOkKSpzRS3CrOYFw==",
+			"version": "25.2.3",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-25.2.3.tgz",
+			"integrity": "sha512-6oLQwO9mKif3Uph3RX5J1i3S7X7xtDHWBaaaoeKw8hOzV6YUd0qDcYcHZ6QXMHDIzSr7zzrEa51o2Ovlj6AtKQ==",
 			"requires": {
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"@types/istanbul-reports": "^1.1.1",
@@ -2742,9 +2742,9 @@
 			}
 		},
 		"@types/babel__core": {
-			"version": "7.1.6",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.6.tgz",
-			"integrity": "sha512-tTnhWszAqvXnhW7m5jQU9PomXSiKXk2sFxpahXvI20SZKu9ylPi8WtIxueZ6ehDWikPT0jeFujMj3X4ZHuf3Tg==",
+			"version": "7.1.7",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.7.tgz",
+			"integrity": "sha512-RL62NqSFPCDK2FM1pSDH0scHpJvsXtZNiYlMB73DgPBaG1E38ZYVL+ei5EkWRbr+KC4YNiAUNBnRj+bgwpgjMw==",
 			"requires": {
 				"@babel/parser": "^7.1.0",
 				"@babel/types": "^7.0.0",
@@ -2803,6 +2803,14 @@
 			"requires": {
 				"@types/events": "*",
 				"@types/minimatch": "*",
+				"@types/node": "*"
+			}
+		},
+		"@types/http-proxy": {
+			"version": "1.17.4",
+			"resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.4.tgz",
+			"integrity": "sha512-IrSHl2u6AWXduUaDLqYpt45tLVCtYv7o4Z0s1KghBCDgIIS9oW5K1H8mZG/A2CfeLdEa7rTd1ACOiHBc1EMT2Q==",
+			"requires": {
 				"@types/node": "*"
 			}
 		},
@@ -2881,9 +2889,9 @@
 			"integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ=="
 		},
 		"@types/sinonjs__fake-timers": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.0.tgz",
-			"integrity": "sha512-SN1/rp+bK//QIIXtizXQwfs2xjYhp35FIIViG5fy+ugQ35AAes0z6ANGXbyHUwnczfL8NQWiH35/E5e2SC5+9w=="
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz",
+			"integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA=="
 		},
 		"@types/stack-utils": {
 			"version": "1.0.1",
@@ -3381,12 +3389,12 @@
 			}
 		},
 		"babel-jest": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-25.2.1.tgz",
-			"integrity": "sha512-OiBpQGYtV4rWMuFneIaEsqJB0VdoOBw4SqwO4hA2EhDY/O8RylQ20JwALkxv8iv+CYnyrZZfF+DELPgrdrkRIw==",
+			"version": "25.2.4",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-25.2.4.tgz",
+			"integrity": "sha512-+yDzlyJVWrqih9i2Cvjpt7COaN8vUwCsKGtxJLzg6I0xhxD54K8mvDUCliPKLufyzHh/c5C4MRj4Vk7VMjOjIg==",
 			"requires": {
-				"@jest/transform": "^25.2.1",
-				"@jest/types": "^25.2.1",
+				"@jest/transform": "^25.2.4",
+				"@jest/types": "^25.2.3",
 				"@types/babel__core": "^7.1.0",
 				"babel-plugin-istanbul": "^6.0.0",
 				"babel-preset-jest": "^25.2.1",
@@ -4671,9 +4679,9 @@
 			}
 		},
 		"dtslint": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/dtslint/-/dtslint-3.4.0.tgz",
-			"integrity": "sha512-nNAbRh4hl9HOLllmI/CGHRHq4Ib8BSrLmQ1Nid7oGGh+jUAUNWxf5Uo4p+eqjMeLRP4ep1u/IdLc0WtTSEIPKA==",
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/dtslint/-/dtslint-3.4.1.tgz",
+			"integrity": "sha512-gIFYwlAO8vY17zGMqdJ7x2DA2swrQsKCwrtX0TUP4A36dlXjdFpj6NWMWc1HW5mYkWOkQFHwTWMOdkP6DLsrfA==",
 			"requires": {
 				"definitelytyped-header-parser": "3.9.0",
 				"dts-critic": "^3.0.0",
@@ -4681,7 +4689,7 @@
 				"json-stable-stringify": "^1.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "5.14.0",
-				"typescript": "^3.9.0-dev.20200326",
+				"typescript": "^3.9.0-dev.20200330",
 				"yargs": "^15.1.0"
 			},
 			"dependencies": {
@@ -4701,9 +4709,9 @@
 					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 				},
 				"typescript": {
-					"version": "3.9.0-dev.20200326",
-					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200326.tgz",
-					"integrity": "sha512-CZnDaobfkaWdnTHWmHykExHvXnHiKFMB8OSyiGOMINAaZO8iy3RbCwELIjQBaCOpX2k8mYVf9zPoRcmS7+Wucw=="
+					"version": "3.9.0-dev.20200330",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200330.tgz",
+					"integrity": "sha512-RI1hwkdnHUbQ78PT/VbLgrMjyb47/8+G2CIfuWW6lBAQIwgqjEyYlKW9PbDRG3WlHXieTMkE3Rjwn9hF08dU3Q=="
 				}
 			}
 		},
@@ -5632,15 +5640,15 @@
 			}
 		},
 		"expect": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-25.2.1.tgz",
-			"integrity": "sha512-mRvuu0xujdgYuS0S2dZ489PGAcXl60blmsLofaq7heqn+ZcUOox+VWQvrCee/x+/0WBpxDs7pBWuFYNO5U+txQ==",
+			"version": "25.2.4",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-25.2.4.tgz",
+			"integrity": "sha512-hfuPhPds4yOsZtIw4kwAg70r0hqGmpqekgA+VX7pf/3wZ6FY+xIOXZhNsPMMMsspYG/YIsbAiwqsdnD4Ht+bCA==",
 			"requires": {
-				"@jest/types": "^25.2.1",
+				"@jest/types": "^25.2.3",
 				"ansi-styles": "^4.0.0",
 				"jest-get-type": "^25.2.1",
-				"jest-matcher-utils": "^25.2.1",
-				"jest-message-util": "^25.2.1",
+				"jest-matcher-utils": "^25.2.3",
+				"jest-message-util": "^25.2.4",
 				"jest-regex-util": "^25.2.1"
 			},
 			"dependencies": {
@@ -6670,15 +6678,32 @@
 			}
 		},
 		"html-escaper": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.1.tgz",
-			"integrity": "sha512-hNX23TjWwD3q56HpWjUHOKj1+4KKlnjv9PcmBUYKVpga+2cnb9nDx/B1o0yO4n+RZXZdiNxzx6B24C9aNMTkkQ=="
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
 		},
 		"http-cache-semantics": {
 			"version": "3.8.1",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
 			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
 			"dev": true
+		},
+		"http-proxy": {
+			"version": "1.18.0",
+			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
+			"integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+			"requires": {
+				"eventemitter3": "^4.0.0",
+				"follow-redirects": "^1.0.0",
+				"requires-port": "^1.0.0"
+			},
+			"dependencies": {
+				"eventemitter3": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+					"integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
+				}
+			}
 		},
 		"http-proxy-agent": {
 			"version": "3.0.0",
@@ -7298,22 +7323,22 @@
 			}
 		},
 		"istanbul-reports": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-			"integrity": "sha512-2osTcC8zcOSUkImzN2EWQta3Vdi4WjjKw99P2yWx5mLnigAM0Rd5uYFn1cf2i/Ois45GkNjaoTqc5CxgMSX80A==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
+			"integrity": "sha512-Vm9xwCiQ8t2cNNnckyeAV0UdxKpcQUz4nMxsBvIu8n2kmPSiyb5uaF/8LpmKr+yqL/MdOXaX2Nmdo4Qyxium9Q==",
 			"requires": {
 				"html-escaper": "^2.0.0",
 				"istanbul-lib-report": "^3.0.0"
 			}
 		},
 		"jest": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-25.2.1.tgz",
-			"integrity": "sha512-YXvGtrb4YmfM/JraXaM3jc3NnvhVTHxkdRC9Oof4JtJWwgvIdy0/X01QxeWXqKfCaHmlXi/nKrcPI1+bf0w/Ww==",
+			"version": "25.2.4",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-25.2.4.tgz",
+			"integrity": "sha512-Lu4LXxf4+durzN/IFilcAoQSisOwgHIXgl9vffopePpSSwFqfj1Pj4y+k3nL8oTbnvjxgDIsEcepy6he4bWqnQ==",
 			"requires": {
-				"@jest/core": "^25.2.1",
+				"@jest/core": "^25.2.4",
 				"import-local": "^3.0.2",
-				"jest-cli": "^25.2.1"
+				"jest-cli": "^25.2.4"
 			},
 			"dependencies": {
 				"find-up": {
@@ -7335,20 +7360,20 @@
 					}
 				},
 				"jest-cli": {
-					"version": "25.2.1",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-25.2.1.tgz",
-					"integrity": "sha512-7moIaOsKvifiHpCUorpSHb3ALHpyZB9SlrFsvkloEo31KTTgFkHZuQw68LJX8FJwY6pg9LoxJJ2Vy4AFmHMclQ==",
+					"version": "25.2.4",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-25.2.4.tgz",
+					"integrity": "sha512-zeY2pRDWKj2LZudIncvvguwLMEdcnJqc2jJbwza1beqi80qqLvkPF/BjbFkK2sIV3r+mfTJS+7ITrvK6pCdRjg==",
 					"requires": {
-						"@jest/core": "^25.2.1",
-						"@jest/test-result": "^25.2.1",
-						"@jest/types": "^25.2.1",
+						"@jest/core": "^25.2.4",
+						"@jest/test-result": "^25.2.4",
+						"@jest/types": "^25.2.3",
 						"chalk": "^3.0.0",
 						"exit": "^0.1.2",
 						"import-local": "^3.0.2",
 						"is-ci": "^2.0.0",
-						"jest-config": "^25.2.1",
-						"jest-util": "^25.2.1",
-						"jest-validate": "^25.2.1",
+						"jest-config": "^25.2.4",
+						"jest-util": "^25.2.3",
+						"jest-validate": "^25.2.3",
 						"prompts": "^2.0.1",
 						"realpath-native": "^2.0.0",
 						"yargs": "^15.3.1"
@@ -7399,11 +7424,11 @@
 			}
 		},
 		"jest-changed-files": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-25.2.1.tgz",
-			"integrity": "sha512-BB4XjM/dJNUAUtchZ2yJq50VK8XXbmgvt1MUD6kzgzoyz9F0+1ZDQ1yNvLl6pfDwKrMBG9GBY1lzaIBO3JByMg==",
+			"version": "25.2.3",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-25.2.3.tgz",
+			"integrity": "sha512-EFxy94dvvbqRB36ezIPLKJ4fDIC+jAdNs8i8uTwFpaXd6H3LVc3ova1lNS4ZPWk09OCR2vq5kSdSQgar7zMORg==",
 			"requires": {
-				"@jest/types": "^25.2.1",
+				"@jest/types": "^25.2.3",
 				"execa": "^3.2.0",
 				"throat": "^5.0.0"
 			},
@@ -7498,27 +7523,27 @@
 			}
 		},
 		"jest-config": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-25.2.1.tgz",
-			"integrity": "sha512-Kh6a3stGSCtVwucvD9wSMaEQBmU0CfqVjHvf0X0iLfCrZfsezvV+sGgRWQAidaTIvo51yAaL217xOwEETMqh6w==",
+			"version": "25.2.4",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-25.2.4.tgz",
+			"integrity": "sha512-fxy3nIpwJqOUQJRVF/q+pNQb6dv5b9YufOeCbpPZJ/md1zXpiupbhfehpfODhnKOfqbzSiigtSLzlWWmbRxnqQ==",
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/test-sequencer": "^25.2.1",
-				"@jest/types": "^25.2.1",
-				"babel-jest": "^25.2.1",
+				"@jest/test-sequencer": "^25.2.4",
+				"@jest/types": "^25.2.3",
+				"babel-jest": "^25.2.4",
 				"chalk": "^3.0.0",
 				"deepmerge": "^4.2.2",
 				"glob": "^7.1.1",
-				"jest-environment-jsdom": "^25.2.1",
-				"jest-environment-node": "^25.2.1",
+				"jest-environment-jsdom": "^25.2.4",
+				"jest-environment-node": "^25.2.4",
 				"jest-get-type": "^25.2.1",
-				"jest-jasmine2": "^25.2.1",
+				"jest-jasmine2": "^25.2.4",
 				"jest-regex-util": "^25.2.1",
-				"jest-resolve": "^25.2.1",
-				"jest-util": "^25.2.1",
-				"jest-validate": "^25.2.1",
+				"jest-resolve": "^25.2.3",
+				"jest-util": "^25.2.3",
+				"jest-validate": "^25.2.3",
 				"micromatch": "^4.0.2",
-				"pretty-format": "^25.2.1",
+				"pretty-format": "^25.2.3",
 				"realpath-native": "^2.0.0"
 			},
 			"dependencies": {
@@ -7563,59 +7588,60 @@
 			}
 		},
 		"jest-diff": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.2.1.tgz",
-			"integrity": "sha512-e/TU8VLBBGQQS9tXA5B5LeT806jh7CHUeHbBfrU9UvA2zTbOTRz71UD6fAP1HAhzUEyCVLU2ZP5e8X16A9b0Fg==",
+			"version": "25.2.3",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.2.3.tgz",
+			"integrity": "sha512-VtZ6LAQtaQpFsmEzps15dQc5ELbJxy4L2DOSo2Ev411TUEtnJPkAMD7JneVypeMJQ1y3hgxN9Ao13n15FAnavg==",
 			"requires": {
 				"chalk": "^3.0.0",
 				"diff-sequences": "^25.2.1",
 				"jest-get-type": "^25.2.1",
-				"pretty-format": "^25.2.1"
+				"pretty-format": "^25.2.3"
 			}
 		},
 		"jest-docblock": {
-			"version": "25.2.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-25.2.0.tgz",
-			"integrity": "sha512-M7ZDbghaxFd2unWkyDFGLZDjPpIbDtEbICXSzwGrUBccFwVG/1dhLLAYX3D+98bFksaJuM0iMZGuIQUzKgnkQw==",
+			"version": "25.2.3",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-25.2.3.tgz",
+			"integrity": "sha512-d3/tmjLLrH5fpRGmIm3oFa3vOaD/IjPxtXVOrfujpfJ9y1tCDB1x/tvunmdOVAyF03/xeMwburl6ITbiQT1mVA==",
 			"requires": {
 				"detect-newline": "^3.0.0"
 			}
 		},
 		"jest-each": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-25.2.1.tgz",
-			"integrity": "sha512-2vWAaf11IJsSwkEzGph3un4OMSG4v/3hpM2UqJdeU3peGUgUSn75TlXZGQnT0smbnAr4eE+URW1OpE8U9wl0TA==",
+			"version": "25.2.3",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-25.2.3.tgz",
+			"integrity": "sha512-RTlmCjsBDK2c9T5oO4MqccA3/5Y8BUtiEy7OOQik1iyCgdnNdHbI0pNEpyapZPBG0nlvZ4mIu7aY6zNUvLraAQ==",
 			"requires": {
-				"@jest/types": "^25.2.1",
+				"@jest/types": "^25.2.3",
 				"chalk": "^3.0.0",
 				"jest-get-type": "^25.2.1",
-				"jest-util": "^25.2.1",
-				"pretty-format": "^25.2.1"
+				"jest-util": "^25.2.3",
+				"pretty-format": "^25.2.3"
 			}
 		},
 		"jest-environment-jsdom": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-25.2.1.tgz",
-			"integrity": "sha512-bUhhhXtgrOgLhsFQFXgao8CQPYAEwtaVvhsF6O0A7Ie2uPONtAKCwuxyOM9WJaz9ag2ci5Pg7i2V2PRfGLl95w==",
+			"version": "25.2.4",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-25.2.4.tgz",
+			"integrity": "sha512-5dm+tNwrLmhELdjAwiQnVGf/U9iFMWdTL4/wyrMg2HU6RQnCiuxpWbIigLHUhuP1P2Ak0F4k3xhjrikboKyShA==",
 			"requires": {
-				"@jest/environment": "^25.2.1",
-				"@jest/fake-timers": "^25.2.1",
-				"@jest/types": "^25.2.1",
-				"jest-mock": "^25.2.1",
-				"jest-util": "^25.2.1",
+				"@jest/environment": "^25.2.4",
+				"@jest/fake-timers": "^25.2.4",
+				"@jest/types": "^25.2.3",
+				"jest-mock": "^25.2.3",
+				"jest-util": "^25.2.3",
 				"jsdom": "^15.2.1"
 			}
 		},
 		"jest-environment-node": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-25.2.1.tgz",
-			"integrity": "sha512-HiAAwx4HrkaV9YAyuI56dmPDuTDckJyPpO0BwCu7+Ht2fmlMDhX13HZyyuIGTAIjUrjJiM3paB8tht+0mXtiIA==",
+			"version": "25.2.4",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-25.2.4.tgz",
+			"integrity": "sha512-Jkc5Y8goyXPrLRHnrUlqC7P4o5zn2m4zw6qWoRJ59kxV1f2a5wK+TTGhrhCwnhW/Ckpdl/pm+LufdvhJkvJbiw==",
 			"requires": {
-				"@jest/environment": "^25.2.1",
-				"@jest/fake-timers": "^25.2.1",
-				"@jest/types": "^25.2.1",
-				"jest-mock": "^25.2.1",
-				"jest-util": "^25.2.1"
+				"@jest/environment": "^25.2.4",
+				"@jest/fake-timers": "^25.2.4",
+				"@jest/types": "^25.2.3",
+				"jest-mock": "^25.2.3",
+				"jest-util": "^25.2.3",
+				"semver": "^6.3.0"
 			}
 		},
 		"jest-get-type": {
@@ -7624,17 +7650,17 @@
 			"integrity": "sha512-EYjTiqcDTCRJDcSNKbLTwn/LcDPEE7ITk8yRMNAOjEsN6yp+Uu+V1gx4djwnuj/DvWg0YGmqaBqPVGsPxlvE7w=="
 		},
 		"jest-haste-map": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.2.1.tgz",
-			"integrity": "sha512-svz3KbQmv9qeomR0LlRjQfoi7lQbZQkC39m7uHFKhqyEuX4F6DH6HayNPSEbTCZDx6d9/ljxfAcxlPpgQvrpvQ==",
+			"version": "25.2.3",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-25.2.3.tgz",
+			"integrity": "sha512-pAP22OHtPr4qgZlJJFks2LLgoQUr4XtM1a+F5UaPIZNiCRnePA0hM3L7aiJ0gzwiNIYwMTfKRwG/S1L28J3A3A==",
 			"requires": {
-				"@jest/types": "^25.2.1",
+				"@jest/types": "^25.2.3",
 				"anymatch": "^3.0.3",
 				"fb-watchman": "^2.0.0",
 				"fsevents": "^2.1.2",
 				"graceful-fs": "^4.2.3",
 				"jest-serializer": "^25.2.1",
-				"jest-util": "^25.2.1",
+				"jest-util": "^25.2.3",
 				"jest-worker": "^25.2.1",
 				"micromatch": "^4.0.2",
 				"sane": "^4.0.3",
@@ -7691,26 +7717,26 @@
 			}
 		},
 		"jest-jasmine2": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-25.2.1.tgz",
-			"integrity": "sha512-He8HdO9jx1LdEaof2vjnvKeJeRPYnn+zXz32X8Z/iOUgAgmP7iZActUkiCCiTazSZlaGlY1iK+LOrqnpGQ0+UA==",
+			"version": "25.2.4",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-25.2.4.tgz",
+			"integrity": "sha512-juoKrmNmLwaheNbAg71SuUF9ovwUZCFNTpKVhvCXWk+SSeORcIUMptKdPCoLXV3D16htzhTSKmNxnxSk4SrTjA==",
 			"requires": {
 				"@babel/traverse": "^7.1.0",
-				"@jest/environment": "^25.2.1",
+				"@jest/environment": "^25.2.4",
 				"@jest/source-map": "^25.2.1",
-				"@jest/test-result": "^25.2.1",
-				"@jest/types": "^25.2.1",
+				"@jest/test-result": "^25.2.4",
+				"@jest/types": "^25.2.3",
 				"chalk": "^3.0.0",
 				"co": "^4.6.0",
-				"expect": "^25.2.1",
+				"expect": "^25.2.4",
 				"is-generator-fn": "^2.0.0",
-				"jest-each": "^25.2.1",
-				"jest-matcher-utils": "^25.2.1",
-				"jest-message-util": "^25.2.1",
-				"jest-runtime": "^25.2.1",
-				"jest-snapshot": "^25.2.1",
-				"jest-util": "^25.2.1",
-				"pretty-format": "^25.2.1",
+				"jest-each": "^25.2.3",
+				"jest-matcher-utils": "^25.2.3",
+				"jest-message-util": "^25.2.4",
+				"jest-runtime": "^25.2.4",
+				"jest-snapshot": "^25.2.4",
+				"jest-util": "^25.2.3",
+				"pretty-format": "^25.2.3",
 				"throat": "^5.0.0"
 			}
 		},
@@ -7830,33 +7856,33 @@
 			}
 		},
 		"jest-leak-detector": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-25.2.1.tgz",
-			"integrity": "sha512-bsxjjFksjLWNqC8aLsN0KO2KQ3tiqPqmFpYt+0y4RLHc1dqaThQL68jra5y1f/yhX3dNC8ugksDvqnGxwxjo4w==",
+			"version": "25.2.3",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-25.2.3.tgz",
+			"integrity": "sha512-yblCMPE7NJKl7778Cf/73yyFWAas5St0iiEBwq7RDyaz6Xd4WPFnPz2j7yDb/Qce71A1IbDoLADlcwD8zT74Aw==",
 			"requires": {
 				"jest-get-type": "^25.2.1",
-				"pretty-format": "^25.2.1"
+				"pretty-format": "^25.2.3"
 			}
 		},
 		"jest-matcher-utils": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.2.1.tgz",
-			"integrity": "sha512-uuoYY8W6eeVxHUEOvrKIVVTl9X6RP+ohQn2Ta2W8OOLMN6oA8pZUKQEPGxLsSqB3RKfpTueurMLrxDTEZGllsA==",
+			"version": "25.2.3",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.2.3.tgz",
+			"integrity": "sha512-ZmiXiwQRVM9MoKjGMP5YsGGk2Th5ncyRxfXKz5AKsmU8m43kgNZirckVzaP61MlSa9LKmXbevdYqVp1ZKAw2Rw==",
 			"requires": {
 				"chalk": "^3.0.0",
-				"jest-diff": "^25.2.1",
+				"jest-diff": "^25.2.3",
 				"jest-get-type": "^25.2.1",
-				"pretty-format": "^25.2.1"
+				"pretty-format": "^25.2.3"
 			}
 		},
 		"jest-message-util": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-25.2.1.tgz",
-			"integrity": "sha512-pxwehr9uPEuCI9bPjBiZxpFMN0+3wny5p7/E3hbV9XjsqREhJJAMf0czvHtgNeUBo2iAiAI9yi9ICKHPOKePEw==",
+			"version": "25.2.4",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-25.2.4.tgz",
+			"integrity": "sha512-9wWMH3Bf+GVTv0GcQLmH/FRr0x0toptKw9TA8U5YFLVXx7Tq9pvcNzTyJrcTJ+wLqNbMPPJlJNft4MnlcrtF5Q==",
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@jest/test-result": "^25.2.1",
-				"@jest/types": "^25.2.1",
+				"@jest/test-result": "^25.2.4",
+				"@jest/types": "^25.2.3",
 				"@types/stack-utils": "^1.0.1",
 				"chalk": "^3.0.0",
 				"micromatch": "^4.0.2",
@@ -7910,11 +7936,11 @@
 			}
 		},
 		"jest-mock": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-25.2.1.tgz",
-			"integrity": "sha512-ZXcmqpCTG1MEm2AP2q9XiJzdbQ655Pnssj+xQMP1thrW2ptEFrd4vSkxTpxk6rnluLPRKagaHmzUpWNxShMvqQ==",
+			"version": "25.2.3",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-25.2.3.tgz",
+			"integrity": "sha512-xlf+pyY0j47zoCs8zGGOGfWyxxLximE8YFOfEK8s4FruR8DtM/UjNj61um+iDuMAFEBDe1bhCXkqiKoCmWjJzg==",
 			"requires": {
-				"@jest/types": "^25.2.1"
+				"@jest/types": "^25.2.3"
 			}
 		},
 		"jest-pnp-resolver": {
@@ -7928,11 +7954,11 @@
 			"integrity": "sha512-wroFVJw62LdqTdkL508ZLV82FrJJWVJMIuYG7q4Uunl1WAPTf4ftPKrqqfec4SvOIlvRZUdEX2TFpWR356YG/w=="
 		},
 		"jest-resolve": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-25.2.1.tgz",
-			"integrity": "sha512-5rVc6khEckNH62adcR+jlYd34/jBO/U22VHf+elmyO6UBHNWXSbfy63+spJRN4GQ/0dbu6Hi6ZVdR58bmNG2Eg==",
+			"version": "25.2.3",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-25.2.3.tgz",
+			"integrity": "sha512-1vZMsvM/DBH258PnpUNSXIgtzpYz+vCVCj9+fcy4akZl4oKbD+9hZSlfe9RIDpU0Fc28ozHQrmwX3EqFRRIHGg==",
 			"requires": {
-				"@jest/types": "^25.2.1",
+				"@jest/types": "^25.2.3",
 				"browser-resolve": "^1.11.3",
 				"chalk": "^3.0.0",
 				"jest-pnp-resolver": "^1.2.1",
@@ -7941,67 +7967,67 @@
 			}
 		},
 		"jest-resolve-dependencies": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-25.2.1.tgz",
-			"integrity": "sha512-fnct/NyrBpBAVUIMa0M876ubufHP/2Rrc038+gCpVT1s7kazV7ZPFlmGfInahCIthbMr644uzt6pnSvmQgTPGg==",
+			"version": "25.2.4",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-25.2.4.tgz",
+			"integrity": "sha512-qhUnK4PfNHzNdca7Ub1mbAqE0j5WNyMTwxBZZJjQlUrdqsiYho/QGK65FuBkZuSoYtKIIqriR9TpGrPEc3P5Gg==",
 			"requires": {
-				"@jest/types": "^25.2.1",
+				"@jest/types": "^25.2.3",
 				"jest-regex-util": "^25.2.1",
-				"jest-snapshot": "^25.2.1"
+				"jest-snapshot": "^25.2.4"
 			}
 		},
 		"jest-runner": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-25.2.1.tgz",
-			"integrity": "sha512-eONqmMQ2vvKh9BsmJmPmv22DqezFSnwX97rj0L5LvPxQNXTz+rpx7nWiKA7xlvOykLFcspw6worK3+AzhwHWhQ==",
+			"version": "25.2.4",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-25.2.4.tgz",
+			"integrity": "sha512-5xaIfqqxck9Wg2CV4b9KmJtf/sWO7zWQx7O+34GCLGPzoPcVmB3mZtdrQI1/jS3Reqjru9ycLjgLHSf6XoxRqA==",
 			"requires": {
-				"@jest/console": "^25.2.1",
-				"@jest/environment": "^25.2.1",
-				"@jest/test-result": "^25.2.1",
-				"@jest/types": "^25.2.1",
+				"@jest/console": "^25.2.3",
+				"@jest/environment": "^25.2.4",
+				"@jest/test-result": "^25.2.4",
+				"@jest/types": "^25.2.3",
 				"chalk": "^3.0.0",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.2.3",
-				"jest-config": "^25.2.1",
-				"jest-docblock": "^25.2.0",
-				"jest-haste-map": "^25.2.1",
-				"jest-jasmine2": "^25.2.1",
-				"jest-leak-detector": "^25.2.1",
-				"jest-message-util": "^25.2.1",
-				"jest-resolve": "^25.2.1",
-				"jest-runtime": "^25.2.1",
-				"jest-util": "^25.2.1",
+				"jest-config": "^25.2.4",
+				"jest-docblock": "^25.2.3",
+				"jest-haste-map": "^25.2.3",
+				"jest-jasmine2": "^25.2.4",
+				"jest-leak-detector": "^25.2.3",
+				"jest-message-util": "^25.2.4",
+				"jest-resolve": "^25.2.3",
+				"jest-runtime": "^25.2.4",
+				"jest-util": "^25.2.3",
 				"jest-worker": "^25.2.1",
 				"source-map-support": "^0.5.6",
 				"throat": "^5.0.0"
 			}
 		},
 		"jest-runtime": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-25.2.1.tgz",
-			"integrity": "sha512-eHEnMrOVeGe8mGDoTZWqCdbsM3RwxsMKVMAj1RTZ4LtRyWqQHKec3RiJiJST5LVj3Mw72clr0U21yoE4p5Mq3w==",
+			"version": "25.2.4",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-25.2.4.tgz",
+			"integrity": "sha512-6ehOUizgIghN+aV5YSrDzTZ+zJ9omgEjJbTHj3Jqes5D52XHfhzT7cSfdREwkNjRytrR7mNwZ7pRauoyNLyJ8Q==",
 			"requires": {
-				"@jest/console": "^25.2.1",
-				"@jest/environment": "^25.2.1",
+				"@jest/console": "^25.2.3",
+				"@jest/environment": "^25.2.4",
 				"@jest/source-map": "^25.2.1",
-				"@jest/test-result": "^25.2.1",
-				"@jest/transform": "^25.2.1",
-				"@jest/types": "^25.2.1",
+				"@jest/test-result": "^25.2.4",
+				"@jest/transform": "^25.2.4",
+				"@jest/types": "^25.2.3",
 				"@types/yargs": "^15.0.0",
 				"chalk": "^3.0.0",
 				"collect-v8-coverage": "^1.0.0",
 				"exit": "^0.1.2",
 				"glob": "^7.1.3",
 				"graceful-fs": "^4.2.3",
-				"jest-config": "^25.2.1",
-				"jest-haste-map": "^25.2.1",
-				"jest-message-util": "^25.2.1",
-				"jest-mock": "^25.2.1",
+				"jest-config": "^25.2.4",
+				"jest-haste-map": "^25.2.3",
+				"jest-message-util": "^25.2.4",
+				"jest-mock": "^25.2.3",
 				"jest-regex-util": "^25.2.1",
-				"jest-resolve": "^25.2.1",
-				"jest-snapshot": "^25.2.1",
-				"jest-util": "^25.2.1",
-				"jest-validate": "^25.2.1",
+				"jest-resolve": "^25.2.3",
+				"jest-snapshot": "^25.2.4",
+				"jest-util": "^25.2.3",
+				"jest-validate": "^25.2.3",
 				"realpath-native": "^2.0.0",
 				"slash": "^3.0.0",
 				"strip-bom": "^4.0.0",
@@ -8026,23 +8052,23 @@
 			"integrity": "sha512-fibDi7M5ffx6c/P66IkvR4FKkjG5ldePAK1WlbNoaU4GZmIAkS9Le/frAwRUFEX0KdnisSPWf+b1RC5jU7EYJQ=="
 		},
 		"jest-snapshot": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-25.2.1.tgz",
-			"integrity": "sha512-5Wd8SEJVTXqQvzkQpuYqQt1QTlRj2XVUV/iaEzO+AeSVg6g5pQWu0z2iLdSBlVeWRrX0MyZn6dhxYGwEq4wW0w==",
+			"version": "25.2.4",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-25.2.4.tgz",
+			"integrity": "sha512-nIwpW7FZCq5p0AE3Oyqyb6jL0ENJixXzJ5/CD/XRuOqp3gS5OM3O/k+NnTrniCXxPFV4ry6s9HNfiPQBi0wcoA==",
 			"requires": {
 				"@babel/types": "^7.0.0",
-				"@jest/types": "^25.2.1",
+				"@jest/types": "^25.2.3",
 				"@types/prettier": "^1.19.0",
 				"chalk": "^3.0.0",
-				"expect": "^25.2.1",
-				"jest-diff": "^25.2.1",
+				"expect": "^25.2.4",
+				"jest-diff": "^25.2.3",
 				"jest-get-type": "^25.2.1",
-				"jest-matcher-utils": "^25.2.1",
-				"jest-message-util": "^25.2.1",
-				"jest-resolve": "^25.2.1",
+				"jest-matcher-utils": "^25.2.3",
+				"jest-message-util": "^25.2.4",
+				"jest-resolve": "^25.2.3",
 				"make-dir": "^3.0.0",
 				"natural-compare": "^1.4.0",
-				"pretty-format": "^25.2.1",
+				"pretty-format": "^25.2.3",
 				"semver": "^6.3.0"
 			},
 			"dependencies": {
@@ -8057,11 +8083,11 @@
 			}
 		},
 		"jest-util": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.2.1.tgz",
-			"integrity": "sha512-oFVMSY/7flrSgEE/B+RApaBZOdLURXRnXCf4COV5td9uRidxudyjA64I1xk2h9Pf3jloSArm96e2FKAbFs0DYg==",
+			"version": "25.2.3",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-25.2.3.tgz",
+			"integrity": "sha512-7tWiMICVSo9lNoObFtqLt9Ezt5exdFlWs5fLe1G4XLY2lEbZc814cw9t4YHScqBkWMfzth8ASHKlYBxiX2rdCw==",
 			"requires": {
-				"@jest/types": "^25.2.1",
+				"@jest/types": "^25.2.3",
 				"chalk": "^3.0.0",
 				"is-ci": "^2.0.0",
 				"make-dir": "^3.0.0"
@@ -8078,28 +8104,28 @@
 			}
 		},
 		"jest-validate": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-25.2.1.tgz",
-			"integrity": "sha512-vGtNFPyvylFfTFFfptzqCy5S3cP/N5JJVwm8gsXeZq8jMmvUngfWtuw+Tr5Wjo+dqOle23td8BE0ruGnsONDmw==",
+			"version": "25.2.3",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-25.2.3.tgz",
+			"integrity": "sha512-GObn91jzU0B0Bv4cusAwjP6vnWy78hJUM8MOSz7keRfnac/ZhQWIsUjvk01IfeXNTemCwgR57EtdjQMzFZGREg==",
 			"requires": {
-				"@jest/types": "^25.2.1",
+				"@jest/types": "^25.2.3",
 				"camelcase": "^5.3.1",
 				"chalk": "^3.0.0",
 				"jest-get-type": "^25.2.1",
 				"leven": "^3.1.0",
-				"pretty-format": "^25.2.1"
+				"pretty-format": "^25.2.3"
 			}
 		},
 		"jest-watcher": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-25.2.1.tgz",
-			"integrity": "sha512-m35rftCYE2EEh01+IIpQMpdB9VXBAjITZvgP4drd/LI3JEJIdd0Pkf/qJZ3oiMQJdqmuwYcTqE+BL40MxVv83Q==",
+			"version": "25.2.4",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-25.2.4.tgz",
+			"integrity": "sha512-p7g7s3zqcy69slVzQYcphyzkB2FBmJwMbv6k6KjI5mqd6KnUnQPfQVKuVj2l+34EeuxnbXqnrjtUFmxhcL87rg==",
 			"requires": {
-				"@jest/test-result": "^25.2.1",
-				"@jest/types": "^25.2.1",
+				"@jest/test-result": "^25.2.4",
+				"@jest/types": "^25.2.3",
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^3.0.0",
-				"jest-util": "^25.2.1",
+				"jest-util": "^25.2.3",
 				"string-length": "^3.1.0"
 			},
 			"dependencies": {
@@ -8119,9 +8145,9 @@
 			}
 		},
 		"jest-when": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/jest-when/-/jest-when-2.7.0.tgz",
-			"integrity": "sha512-psU0pXdomBORY9TGuSut/k8vViVki9l92WggL0m5/Lk8zTrDYtcCpPIFdZQDKqXvmW5Jzoh7SCsLKITvBJ0jyQ==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/jest-when/-/jest-when-2.7.1.tgz",
+			"integrity": "sha512-4J2kNNEiu8rWmiZTn9HJB8U1HyDfvywpZ+FzgwnUv7yftvDFLo95U7sEiOeVK3j20af8lj6/7nrFf9lyCmOjKA==",
 			"requires": {
 				"bunyan": "^1.8.12",
 				"expect": "^24.8.0"
@@ -9103,8 +9129,7 @@
 		"mkdirp": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
-			"integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==",
-			"dev": true
+			"integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g=="
 		},
 		"mkdirp-promise": {
 			"version": "5.0.1",
@@ -10098,11 +10123,11 @@
 			}
 		},
 		"pretty-format": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.2.1.tgz",
-			"integrity": "sha512-YS+e9oGYIbEeAFgqTU8qeZ3DN2Pz0iaD81ox+iUjLIXVJWeB7Ro/2AnfxRnl/yJJ5R674d7E3jLPuh6bwg0+qw==",
+			"version": "25.2.3",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.2.3.tgz",
+			"integrity": "sha512-IP4+5UOAVGoyqC/DiomOeHBUKN6q00gfyT2qpAsRH64tgOKB2yF7FHJXC18OCiU0/YFierACup/zdCOWw0F/0w==",
 			"requires": {
-				"@jest/types": "^25.2.1",
+				"@jest/types": "^25.2.3",
 				"ansi-regex": "^5.0.0",
 				"ansi-styles": "^4.0.0",
 				"react-is": "^16.12.0"
@@ -10592,6 +10617,11 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+		},
+		"requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
 		},
 		"resolve": {
 			"version": "1.15.1",
@@ -11699,9 +11729,9 @@
 			"integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
 		},
 		"ts-jest": {
-			"version": "25.2.1",
-			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-25.2.1.tgz",
-			"integrity": "sha512-TnntkEEjuXq/Gxpw7xToarmHbAafgCaAzOpnajnFC6jI7oo1trMzAHA04eWpc3MhV6+yvhE8uUBAmN+teRJh0A==",
+			"version": "25.3.0",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-25.3.0.tgz",
+			"integrity": "sha512-qH/uhaC+AFDU9JfAueSr0epIFJkGMvUPog4FxSEVAtPOur1Oni5WBJMiQIkfHvc7PviVRsnlVLLY2I6221CQew==",
 			"requires": {
 				"bs-logger": "0.x",
 				"buffer-from": "1.x",
@@ -11709,34 +11739,16 @@
 				"json5": "2.x",
 				"lodash.memoize": "4.x",
 				"make-error": "1.x",
-				"mkdirp": "0.x",
+				"mkdirp": "1.x",
 				"resolve": "1.x",
-				"semver": "^5.5",
-				"yargs-parser": "^16.1.0"
+				"semver": "6.x",
+				"yargs-parser": "^18.1.1"
 			},
 			"dependencies": {
-				"minimist": {
-					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-				},
-				"mkdirp": {
-					"version": "0.5.4",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
-					"integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
-					"requires": {
-						"minimist": "^1.2.5"
-					}
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-				},
 				"yargs-parser": {
-					"version": "16.1.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
-					"integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
+					"version": "18.1.2",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
+					"integrity": "sha512-hlIPNR3IzC1YuL1c2UwwDKpXlNFBqD1Fswwh1khz5+d8Cq/8yc/Mn0i+rQXduu8hcrFKvO7Eryk+09NecTQAAQ==",
 					"requires": {
 						"camelcase": "^5.0.0",
 						"decamelize": "^1.2.0"
@@ -11745,9 +11757,9 @@
 			}
 		},
 		"ts-morph": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-7.0.0.tgz",
-			"integrity": "sha512-t4FhkXtW0hN9n3/cgalyu3piLn7DIx0DKSQ1hZWZI1/PNet21EZnhdMkKRj+N3cphXn7yz9OWG3xGQtxkCMkKA==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-7.0.1.tgz",
+			"integrity": "sha512-/HghaxCDqBKHWPI+n9/ueT4k5NKTxSsEfJMMUMLybTn7zvi9gcZ8ynnGYrQt5cfl2oapFe/X5VHjLcS1ugV4lg==",
 			"requires": {
 				"@dsherret/to-absolute-glob": "^2.0.2",
 				"@ts-morph/common": "~0.4.0",
@@ -12126,9 +12138,9 @@
 			}
 		},
 		"uuid": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.2.tgz",
-			"integrity": "sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw=="
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+			"integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
 		},
 		"v8-compile-cache": {
 			"version": "2.1.0",
@@ -12137,9 +12149,9 @@
 			"dev": true
 		},
 		"v8-to-istanbul": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-4.1.2.tgz",
-			"integrity": "sha512-G9R+Hpw0ITAmPSr47lSlc5A1uekSYzXxTMlFxso2xoffwo4jQnzbv1p9yXIinO8UMZKfAFewaCHwWvnH4Jb4Ug==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-4.1.3.tgz",
+			"integrity": "sha512-sAjOC+Kki6aJVbUOXJbcR0MnbfjvBzwKZazEJymA2IX49uoOdEdk+4fBq5cXgYgiyKtAyrrJNtBZdOeDIF+Fng==",
 			"requires": {
 				"@types/istanbul-lib-coverage": "^2.0.1",
 				"convert-source-map": "^1.6.0",
@@ -12653,9 +12665,9 @@
 					}
 				},
 				"yargs-parser": {
-					"version": "18.1.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.1.tgz",
-					"integrity": "sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==",
+					"version": "18.1.2",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
+					"integrity": "sha512-hlIPNR3IzC1YuL1c2UwwDKpXlNFBqD1Fswwh1khz5+d8Cq/8yc/Mn0i+rQXduu8hcrFKvO7Eryk+09NecTQAAQ==",
 					"requires": {
 						"camelcase": "^5.0.0",
 						"decamelize": "^1.2.0"

--- a/test-packages/integration-tests/jest.config.js
+++ b/test-packages/integration-tests/jest.config.js
@@ -9,5 +9,5 @@ module.exports = {
   coverageReporters: ['text', 'cobertura', 'html'],
   coveragePathIgnorePatterns: ['dist/', 'node_modules/', 'test/'],
   reporters: ['default', 'jest-junit'],
-  testPathIgnorePatterns: ['<rootDir>/test/proxy.spec.ts']
+  // testPathIgnorePatterns: ['<rootDir>/test/proxy-skipped.spec.ts']
 };

--- a/test-packages/integration-tests/jest.config.js
+++ b/test-packages/integration-tests/jest.config.js
@@ -9,5 +9,5 @@ module.exports = {
   coverageReporters: ['text', 'cobertura', 'html'],
   coveragePathIgnorePatterns: ['dist/', 'node_modules/', 'test/'],
   reporters: ['default', 'jest-junit'],
-  // testPathIgnorePatterns: ['<rootDir>/test/proxy-skipped.spec.ts']
+  testPathIgnorePatterns: ['<rootDir>/test/proxy-skipped.spec.ts']
 };

--- a/test-packages/integration-tests/package.json
+++ b/test-packages/integration-tests/package.json
@@ -21,6 +21,8 @@
   },
   "devDependencies": {
     "@types/jest": "^25.1.4",
+    "@types/http-proxy": "^1.17.4",
+    "http-proxy": "^1.18.0",
     "jest": "^25.1.0",
     "jest-junit": "^10.0.0",
     "mockserver-node": "5.8.1",

--- a/test-packages/integration-tests/test/proxy-skipped.spec.ts
+++ b/test-packages/integration-tests/test/proxy-skipped.spec.ts
@@ -1,0 +1,206 @@
+/* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
+import {
+  Destination,
+  executeHttpRequest,
+  HttpMethod,
+  HttpResponse,
+  Protocol
+} from '@sap-cloud-sdk/core';
+import {
+  setTestDestination,
+  unmockTestDestination
+} from '@sap-cloud-sdk/test-util';
+import { MapType } from '@sap-cloud-sdk/util';
+import axios from 'axios';
+import {
+  ODataRequest,
+  ODataRequestConfig
+} from '../../../packages/core/src/request-builder/request';
+import mockserver = require('mockserver-node');
+
+describe('proxy', () => {
+  const proxyPort = 1080;
+  const destination: Destination = {
+    name: 'exampleDotCom',
+    url: 'http://example.com',
+    proxyConfiguration: {
+      host: 'localhost',
+      protocol: Protocol.HTTP,
+      port: proxyPort,
+      headers: undefined
+    }
+  };
+
+  beforeAll(async () => {
+    await startProxyServer(proxyPort);
+  }, 10000);
+
+  afterAll(async () => {
+    await mockserver.stop_mockserver({ serverPort: proxyPort });
+    unmockTestDestination(destination.name as string);
+    delete process.env.VCAP_SERVICES;
+  });
+
+  beforeEach(async () => {
+    const response = await axios.put(
+      'http://localhost:1080/mockserver/clear?type=log'
+    );
+    expect(response.status).toBe(200);
+    unmockTestDestination(destination.name as string);
+    delete process.env.VCAP_SERVICES;
+  });
+
+  it('should use the http proxy with odata-request', async () => {
+    await checkProxyServerLogsClean();
+    const config = new DummyODataRequestConfig('get', '', 'application/json');
+    const oDataRequest = new ODataRequest(config, destination);
+    const response = await oDataRequest.execute();
+
+    checkResponse(response);
+
+    await checkProxyServerWasUsed();
+  });
+
+  it('should use the http proxy with http-execute.', async () => {
+    await checkProxyServerLogsClean();
+
+    await executeHttpRequest(destination, {
+      method: HttpMethod.GET
+    });
+
+    await checkProxyServerWasUsed();
+  }, 10000);
+
+  it('should use proxy if destination is in env variables.', async () => {
+    setTestDestination(destination);
+
+    await checkProxyServerLogsClean();
+
+    // Do the call using the proxy
+    const response = await executeHttpRequest(
+      { destinationName: destination.name as string },
+      {
+        method: HttpMethod.GET
+      }
+    );
+
+    checkResponse(response);
+
+    await checkProxyServerWasUsed();
+  }, 10000);
+
+  it('should use proxy if destination and proxy is in env variables.', async () => {
+    setTestDestination({
+      name: 'exampleDotCom',
+      url: 'http://example.com'
+    });
+
+    process.env['http_proxy'] = `http://localhost:${proxyPort}`;
+
+    await checkProxyServerLogsClean();
+
+    // Do the call using the proxy
+    const response = await executeHttpRequest(
+      { destinationName: destination.name as string },
+      {
+        method: HttpMethod.GET
+      }
+    );
+
+    checkResponse(response);
+
+    await checkProxyServerWasUsed();
+  }, 10000);
+
+  it('should use proxy if destination is in vcap and proxy is in env variables.', async () => {
+    const serviceBindings = {
+      's4-hana-cloud': [
+        {
+          binding_name: null,
+          credentials: {
+            Authentication: 'BasicAuthentication',
+            Password: 'bar',
+            URL: destination.url,
+            User: 'foo'
+          },
+          instance_name: destination.name,
+          label: 's4-hana-cloud',
+          name: destination.name,
+          plan: 'sap_com_0008',
+          provider: null,
+          syslog_drain_url: null,
+          tags: ['s4-hana-cloud'],
+          volume_mounts: []
+        }
+      ]
+    };
+
+    process.env.VCAP_SERVICES = JSON.stringify(serviceBindings);
+
+    process.env['http_proxy'] = `http://localhost:${proxyPort}`;
+
+    await checkProxyServerLogsClean();
+
+    // Do the call using the proxy
+    const response = await executeHttpRequest(
+      { destinationName: destination.name as string },
+      {
+        method: HttpMethod.GET
+      }
+    );
+
+    checkResponse(response);
+
+    await checkProxyServerWasUsed();
+  }, 10000);
+});
+
+const expectedStringsAfterRequest = [
+  'example.com',
+  'for forwarded request',
+  'This domain is for use in illustrative examples in documents.'
+];
+
+async function checkProxyServerLogsClean() {
+  const serverLogsBeforCall = await getMockServerLogs();
+  expectedStringsAfterRequest.forEach(expected =>
+    expect(serverLogsBeforCall).not.toContain(expected)
+  );
+}
+
+async function checkResponse(response: HttpResponse) {
+  expect(response.status).toBe(200);
+  expect(response.data).toContain(
+    'This domain is for use in illustrative examples in documents.'
+  );
+}
+
+async function checkProxyServerWasUsed() {
+  const serverLogsAfterCall = await getMockServerLogs();
+  expectedStringsAfterRequest.forEach(expected =>
+    expect(serverLogsAfterCall).toContain(expected)
+  );
+}
+
+async function getMockServerLogs(): Promise<string> {
+  return (
+    await axios.put('http://localhost:1080/mockserver/retrieve?type=logs')
+  ).data;
+}
+
+async function startProxyServer(port: number) {
+  return mockserver.start_mockserver({
+    serverPort: port,
+    verbose: true
+  });
+}
+
+class DummyODataRequestConfig extends ODataRequestConfig {
+  queryParameters(): MapType<any> {
+    return new Map();
+  }
+
+  resourcePath(): string {
+    return '';
+  }
+}

--- a/test-packages/integration-tests/test/proxy.spec.ts
+++ b/test-packages/integration-tests/test/proxy.spec.ts
@@ -1,206 +1,77 @@
 /* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
+
+import * as http from 'http';
+import * as https from 'https';
+import * as fs from 'fs';
+import * as path from 'path';
+import { once } from 'events';
 import {
-  Destination,
+  Protocol,
   executeHttpRequest,
   HttpMethod,
-  HttpResponse,
-  Protocol
+  Destination
 } from '@sap-cloud-sdk/core';
-import {
-  setTestDestination,
-  unmockTestDestination
-} from '@sap-cloud-sdk/test-util';
-import { MapType } from '@sap-cloud-sdk/util';
-import axios from 'axios';
-import {
-  ODataRequest,
-  ODataRequestConfig
-} from '../../../packages/core/src/request-builder/request';
-import mockserver = require('mockserver-node');
+import httpProxy from 'http-proxy';
 
+const httpServerResponse = 'http';
 describe('proxy', () => {
-  const proxyPort = 1080;
-  const destination: Destination = {
-    name: 'exampleDotCom',
-    url: 'http://example.com',
-    proxyConfiguration: {
-      host: 'localhost',
-      protocol: Protocol.HTTP,
-      port: proxyPort,
-      headers: undefined
-    }
-  };
+  it("should use the http proxy with http-execute for 'http'", async () => {
+    const httpServer = await createHttpServer();
+    const httpServerPort = getServerPort(httpServer);
 
-  beforeAll(async () => {
-    await startProxyServer(proxyPort);
-  }, 10000);
+    const proxySpy = jest.fn();
 
-  afterAll(async () => {
-    await mockserver.stop_mockserver({ serverPort: proxyPort });
-    unmockTestDestination(destination.name as string);
-    delete process.env.VCAP_SERVICES;
-  });
+    const proxyServer = await createProxyServer(proxySpy);
+    const proxyPort = getServerPort(proxyServer);
 
-  beforeEach(async () => {
-    const response = await axios.put(
-      'http://localhost:1080/mockserver/clear?type=log'
-    );
-    expect(response.status).toBe(200);
-    unmockTestDestination(destination.name as string);
-    delete process.env.VCAP_SERVICES;
-  });
-
-  it('should use the http proxy with odata-request', async () => {
-    await checkProxyServerLogsClean();
-    const config = new DummyODataRequestConfig('get', '', 'application/json');
-    const oDataRequest = new ODataRequest(config, destination);
-    const response = await oDataRequest.execute();
-
-    checkResponse(response);
-
-    await checkProxyServerWasUsed();
-  });
-
-  it('should use the http proxy with http-execute.', async () => {
-    await checkProxyServerLogsClean();
-
-    await executeHttpRequest(destination, {
-      method: HttpMethod.GET
-    });
-
-    await checkProxyServerWasUsed();
-  }, 10000);
-
-  it('should use proxy if destination is in env variables.', async () => {
-    setTestDestination(destination);
-
-    await checkProxyServerLogsClean();
-
-    // Do the call using the proxy
-    const response = await executeHttpRequest(
-      { destinationName: destination.name as string },
-      {
-        method: HttpMethod.GET
+    const destination: Destination = {
+      url: `http://localhost:${httpServerPort}`,
+      proxyConfiguration: {
+        host: 'localhost',
+        protocol: Protocol.HTTP,
+        port: proxyPort
       }
-    );
-
-    checkResponse(response);
-
-    await checkProxyServerWasUsed();
-  }, 10000);
-
-  it('should use proxy if destination and proxy is in env variables.', async () => {
-    setTestDestination({
-      name: 'exampleDotCom',
-      url: 'http://example.com'
-    });
-
-    process.env['http_proxy'] = `http://localhost:${proxyPort}`;
-
-    await checkProxyServerLogsClean();
-
-    // Do the call using the proxy
-    const response = await executeHttpRequest(
-      { destinationName: destination.name as string },
-      {
-        method: HttpMethod.GET
-      }
-    );
-
-    checkResponse(response);
-
-    await checkProxyServerWasUsed();
-  }, 10000);
-
-  it('should use proxy if destination is in vcap and proxy is in env variables.', async () => {
-    const serviceBindings = {
-      's4-hana-cloud': [
-        {
-          binding_name: null,
-          credentials: {
-            Authentication: 'BasicAuthentication',
-            Password: 'bar',
-            URL: destination.url,
-            User: 'foo'
-          },
-          instance_name: destination.name,
-          label: 's4-hana-cloud',
-          name: destination.name,
-          plan: 'sap_com_0008',
-          provider: null,
-          syslog_drain_url: null,
-          tags: ['s4-hana-cloud'],
-          volume_mounts: []
-        }
-      ]
     };
 
-    process.env.VCAP_SERVICES = JSON.stringify(serviceBindings);
+    const request = executeHttpRequest(destination, {
+      method: HttpMethod.GET
+    }).then(res => res.data);
 
-    process.env['http_proxy'] = `http://localhost:${proxyPort}`;
+    await expect(request).resolves.toEqual(httpServerResponse);
+    expect(proxySpy).toHaveBeenCalled();
 
-    await checkProxyServerLogsClean();
-
-    // Do the call using the proxy
-    const response = await executeHttpRequest(
-      { destinationName: destination.name as string },
-      {
-        method: HttpMethod.GET
-      }
-    );
-
-    checkResponse(response);
-
-    await checkProxyServerWasUsed();
-  }, 10000);
+    await closeServer(httpServer);
+    await closeServer(proxyServer);
+  });
 });
 
-const expectedStringsAfterRequest = [
-  'example.com',
-  'for forwarded request',
-  'This domain is for use in illustrative examples in documents.'
-];
-
-async function checkProxyServerLogsClean() {
-  const serverLogsBeforCall = await getMockServerLogs();
-  expectedStringsAfterRequest.forEach(expected =>
-    expect(serverLogsBeforCall).not.toContain(expected)
-  );
-}
-
-async function checkResponse(response: HttpResponse) {
-  expect(response.status).toBe(200);
-  expect(response.data).toContain(
-    'This domain is for use in illustrative examples in documents.'
-  );
-}
-
-async function checkProxyServerWasUsed() {
-  const serverLogsAfterCall = await getMockServerLogs();
-  expectedStringsAfterRequest.forEach(expected =>
-    expect(serverLogsAfterCall).toContain(expected)
-  );
-}
-
-async function getMockServerLogs(): Promise<string> {
-  return (
-    await axios.put('http://localhost:1080/mockserver/retrieve?type=logs')
-  ).data;
-}
-
-async function startProxyServer(port: number) {
-  return mockserver.start_mockserver({
-    serverPort: port,
-    verbose: true
+async function createHttpServer() {
+  const server = http.createServer((req, res) => {
+    res.end(httpServerResponse);
   });
+
+  server.listen();
+  await once(server, 'listening');
+  return server;
 }
 
-class DummyODataRequestConfig extends ODataRequestConfig {
-  queryParameters(): MapType<any> {
-    return new Map();
-  }
+async function createProxyServer(proxySpy) {
+  const proxy = httpProxy.createProxyServer({});
+  const server = http.createServer(function (req, res) {
+    proxySpy();
+    proxy.web(req, res, { target: `http://${req.headers.host!}` });
+  });
 
-  resourcePath(): string {
-    return '';
-  }
+  server.listen();
+  await once(server, 'listening');
+  return server;
+}
+
+function getServerPort(server) {
+  return (server._server || server).address().port;
+}
+
+async function closeServer(server) {
+  server.close();
+  return once(server, 'close');
 }


### PR DESCRIPTION
I added a proxy test that does not require any java runtime. Unfortunately I was not able to get this running for https, but I decided that this is already something worth merging.