### PR TITLE
chore: Update dev dependency versions of generated odata clients

### DIFF
--- a/packages/generator/src/service/package-json.ts
+++ b/packages/generator/src/service/package-json.ts
@@ -44,8 +44,8 @@ export function packageJson(
           '@sap-cloud-sdk/core': `^${generatorVersion}`
         },
         devDependencies: {
-          typedoc: '^0.15.0',
-          typescript: '3.7.4'
+          typedoc: '^0.17.0',
+          typescript: '~3.8.3'
         }
       },
       null,


### PR DESCRIPTION
Currently the versions the generated packages diverge from the versions of core. This can cause problems in the VDM.