### PR TITLE
Remove documentation & gh-page branch from build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,8 @@
 name: build
 
 on:
-  pull_request: ~
+  pull_request:
+    branches-ignore: [documentation, gh-pages]
   push:
     branches: [master]
     tags: ['v*']


### PR DESCRIPTION
There should be a different pipeline for docs

## Context

Current build pipeline is not applicable for `gh-pages` and `documentation` branches
