### PR TITLE
[documentation] Add Docker alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@
 - You should now see a browser window with SAP Cloud SDK documentation portal open
 - Open [How to write documentation](https://sap.github.io/cloud-sdk/docs/dzen/how-to-write-documentation )
 
+
+### Docker alternative
+
+- Consider the following commands (1) to install node dependencies and (2) to serve the continuously generated site:
+  ```
+  docker run -it --rm -v "${pwd}:/doc"  -w "/doc" --entrypoint "/bin/sh" node:alpine3.10  -c "npm ci"
+  docker run -it --rm -v "${pwd}:/doc"  -w "/doc" --entrypoint "/bin/sh" -p 3000:3000 node:alpine3.10  -c "npm run start -- --port 3000 --host 0.0.0.0"
+  ```
+  Windows users can use PowerShell.
+
 ## How to start documenting ##
 
 - Open your favorite text editor with Markdown support

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@
 
 - Consider the following commands (1) to install node dependencies and (2) to serve the continuously generated site:
   ```
-  docker run -it --rm -v "${pwd}:/doc"  -w "/doc" --entrypoint "/bin/sh" node:alpine3.10  -c "npm ci"
-  docker run -it --rm -v "${pwd}:/doc"  -w "/doc" --entrypoint "/bin/sh" -p 3000:3000 node:alpine3.10  -c "npm run start -- --port 3000 --host 0.0.0.0"
+  docker run -it --rm -v "${pwd}:/doc" -w "/doc" --entrypoint "/bin/sh" node:alpine3.10  -c "npm ci"
+  docker run -it --rm -v "${pwd}:/doc" -w "/doc" --entrypoint "/bin/sh" -p 3000:3000 node:alpine3.10  -c "npm run start -- --port 3000 --host 0.0.0.0"
   ```
   Windows users can use PowerShell.
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@
 
 - Consider the following commands (1) to install node dependencies and (2) to serve the continuously generated site:
   ```
-  docker run -it --rm -v "${pwd}:/doc" -w "/doc" --entrypoint "/bin/sh" node:alpine3.10  -c "npm ci"
-  docker run -it --rm -v "${pwd}:/doc" -w "/doc" --entrypoint "/bin/sh" -p 3000:3000 node:alpine3.10  -c "npm run start -- --port 3000 --host 0.0.0.0"
+  docker run -it --rm -v "${pwd}:/doc" -w "/doc" --entrypoint "/bin/sh" node:alpine3.10 -c "npm ci"
+  docker run -it --rm -v "${pwd}:/doc" -w "/doc" --entrypoint "/bin/sh" -p 3000:3000 node:alpine3.10 -c "npm run start -- --port 3000 --host 0.0.0.0"
   ```
   Windows users can use PowerShell.
 


### PR DESCRIPTION
Serving the documentation with Docker works for me (Windows, w/o Python/Node)