### PR TITLE
Fix: Improve logging on edmx generation and file creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ## Improvements
 
--
+- Increase the information shown on VDM generation and parallelized the file creation process.
 
 ## Fixed Issues
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ## Improvements
 
-- Increase the information shown on VDM generation and parallelized the file creation process.
+- Increase the information shown on VDM generation and parallelize the file creation process.
 
 ## Fixed Issues
 

--- a/packages/generator/src/generator-cli.ts
+++ b/packages/generator/src/generator-cli.ts
@@ -12,7 +12,9 @@ const logger = createLogger({
 
 logger.info('Parsing args...');
 
-generate(parseCmdArgs());
+generate(parseCmdArgs()).then(() =>
+  logger.info('Generation of services successfully finished.')
+);
 
 export function parseCmdArgs(): GeneratorOptions {
   const command = yargs.command(

--- a/packages/generator/src/generator-cli.ts
+++ b/packages/generator/src/generator-cli.ts
@@ -13,7 +13,7 @@ const logger = createLogger({
 logger.info('Parsing args...');
 
 generate(parseCmdArgs()).then(() =>
-  logger.info('Generation of services successfully finished.')
+  logger.info('Generation of services finished successfully.')
 );
 
 export function parseCmdArgs(): GeneratorOptions {


### PR DESCRIPTION
## Context

Currently the VDM generation can take very long and the user does not see what is happening.

I added more log statements and also emitted each file separately compared to the whole project directory which seems to be also more performant. 

In order to improve the value we should also fix this issue in the CLI so that our logs are also shown when executed via the CLI: SAP/cloud-sdk-cli#55.

## Definition of Done

Please consider all items and remove only if not applicable.

- [x] Release notes updated.
- [x] PR title adheres to [conventional commit guidelines]
