### PR TITLE
chore: use new api doc link for the npm readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $ npm install -D @sap-cloud-sdk/test-util
 ```
 
 ## API documentations
-We use GitHub Pages for our API documentations, the link can be found [here](https://sap.github.io/cloud-sdk/api/).
+We use GitHub Pages for our API documentations, the link can be found [here](https://sap.github.io/cloud-sdk/docs/js/api-reference-js-ts).
 
 ## How to switch to the Open Source version of the SAP Cloud SDK
 Please ignore this section, if you have never used the SAP Cloud SDK with a version `< 1.18.0`.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -29,7 +29,7 @@ BusinessPartner.requestBuilder()
 ```
 
 ### Api documentation
-https://sap.github.io/cloud-sdk/api/
+https://sap.github.io/cloud-sdk/docs/js/api-reference-js-ts
 
 ### Helpful Links
 

--- a/packages/generator/README.md
+++ b/packages/generator/README.md
@@ -40,7 +40,7 @@ project.save();
 ```
 
 ### Api documentation
-https://sap.github.io/cloud-sdk/api/
+https://sap.github.io/cloud-sdk/docs/js/api-reference-js-ts
 
 ### Helpful Links
 

--- a/packages/test-util/README.md
+++ b/packages/test-util/README.md
@@ -43,7 +43,7 @@ and `credentials.json`:
 ```
 
 ### Api documentation
-https://sap.github.io/cloud-sdk/api/
+https://sap.github.io/cloud-sdk/docs/js/api-reference-js-ts
 
 ### Helpful Links
 

--- a/packages/util/README.md
+++ b/packages/util/README.md
@@ -19,7 +19,7 @@ setLogLevel('debug', 'destination-accessor');
 ```
 
 ### Api documentation
-https://sap.github.io/cloud-sdk/api/
+https://sap.github.io/cloud-sdk/docs/js/api-reference-js-ts
 
 ### Helpful Links
 


### PR DESCRIPTION
## Context

The api doc link in this page:https://www.npmjs.com/package/@sap-cloud-sdk/core is broken after switching to new doc portal.
We have to fix it.

## Definition of Done

Please consider all items and remove only if not applicable.

- [ ] Tests created/adjusted for your changes.
- [ ] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [x] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [ ] If applicable: Properly documented (JSDoc of public API)
- [ ] If applicable: Check if `node run doc` still works.

## Labels
We use labels to indicate the status of PRs. 
Please select `please review`, `please merge` or `don't merge` for your PR.
