### PR TITLE
fix: Downgrade moment for frontend applications

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -3913,9 +3913,9 @@
 			}
 		},
 		"moment": {
-			"version": "2.25.1",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.25.1.tgz",
-			"integrity": "sha512-nRKMf9wDS4Fkyd0C9LXh2FFXinD+iwbJ5p/lh3CHitW9kZbRbJ8hCruiadiIXZVbeAqKZzqcTvHnK3mRhFjb6w=="
+			"version": "2.24.0",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+			"integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
 		},
 		"ms": {
 			"version": "2.0.0",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -3913,9 +3913,9 @@
 			}
 		},
 		"moment": {
-			"version": "2.24.0",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-			"integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+			"version": "2.25.1",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.25.1.tgz",
+			"integrity": "sha512-nRKMf9wDS4Fkyd0C9LXh2FFXinD+iwbJ5p/lh3CHitW9kZbRbJ8hCruiadiIXZVbeAqKZzqcTvHnK3mRhFjb6w=="
 		},
 		"ms": {
 			"version": "2.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,7 @@
     "http-proxy-agent": "^4.0.1",
     "https-proxy-agent": "^5.0.0",
     "jsonwebtoken": "^8.5.1",
-    "moment": "^2.25.1",
+    "moment": "~2.24.0",
     "opossum": "^5.0.0",
     "rambda": "^5.0.0",
     "uuid": "^7.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,7 @@
     "http-proxy-agent": "^4.0.1",
     "https-proxy-agent": "^5.0.0",
     "jsonwebtoken": "^8.5.1",
-    "moment": "^2.24.0",
+    "moment": "^2.25.1",
     "opossum": "^5.0.0",
     "rambda": "^5.0.0",
     "uuid": "^7.0.3",


### PR DESCRIPTION
## Context

moment version 2.25.0 is breaks in frontends. Currently, there is no fix, therefore I restricted the version to ~2.24.0.
https://github.com/moment/moment/issues/5484
