### PR TITLE
fix: Make swagger parsing compatible with openapi definitions

### DIFF
--- a/packages/generator/src/parser/service-parser.ts
+++ b/packages/generator/src/parser/service-parser.ts
@@ -189,7 +189,7 @@ function transformServiceMetadata(
 function apiBusinessHubMetadata(
   swagger?: SwaggerMetadata
 ): ApiBusinessHubMetadata | undefined {
-  if (!swagger) {
+  if (!swagger || !swagger?.basePath) {
     return undefined;
   }
 

--- a/packages/generator/src/parser/swagger-parser.ts
+++ b/packages/generator/src/parser/swagger-parser.ts
@@ -13,6 +13,7 @@ export function parseSwaggerFromPath(swaggerPath: PathLike): SwaggerMetadata {
 
 function parseSwaggerFile(swaggerFile: string): SwaggerMetadata {
   const swaggerMetaData = JSON.parse(swaggerFile);
+  // If the file is not swagger but openapi
   if (swaggerMetaData.openapi) {
     swaggerMetaData.definitions = swaggerMetaData?.components?.schemas;
   }

--- a/packages/generator/src/parser/swagger-parser.ts
+++ b/packages/generator/src/parser/swagger-parser.ts
@@ -12,5 +12,9 @@ export function parseSwaggerFromPath(swaggerPath: PathLike): SwaggerMetadata {
 }
 
 function parseSwaggerFile(swaggerFile: string): SwaggerMetadata {
-  return JSON.parse(swaggerFile);
+  const swaggerMetaData = JSON.parse(swaggerFile);
+  if (swaggerMetaData.openapi) {
+    swaggerMetaData.definitions = swaggerMetaData?.components?.schemas;
+  }
+  return swaggerMetaData;
 }


### PR DESCRIPTION
Currently the S4 VDM cannot be built, because some of the swagger files were replaced with openapi files. This change should hot fix our generator to be still compatible for both cases.