### PR TITLE
Revert "Force publishing all packages when releasing a canary version"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           git update-index --assume-unchanged .npmrc
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc
-          npx lerna publish --canary --force-publish -y
+          npx lerna publish --canary -y
         env:
           NPM_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}
   draft-github-release:


### PR DESCRIPTION
Reverts SAP/cloud-sdk#104

It seems that the force publishing makes the canary release failing.