### PR TITLE
Create versions.json together with versions.js

### DIFF
--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -1,3 +1,4 @@
+
 /* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
 const { execSync } = require('child_process');
 const fs = require('fs');
@@ -114,6 +115,11 @@ function writeVersions() {
   fs.writeFileSync(
     path.resolve('docs', 'api', 'versions.js'),
     `export default ${jsonStringify(apiVersions)}`,
+    'utf8'
+  );
+  fs.writeFileSync(
+    path.resolve('docs', 'api', 'versions.json'),
+    `${jsonStringify(apiVersions)}`,
     'utf8'
   );
 }


### PR DESCRIPTION
## Context

@marikaner, for some reason you required to keep versions.json for the release purposes. This update to the docs generation script will full fill this requirement.

Don't see anything bad in having them both.
