### PR TITLE
add comments to the pipeline

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,7 @@ jobs:
           # clone current version of documentation
           git clone --depth 1 -b documentation git@github.com:SAP/cloud-sdk.git documentation
           # copy latest changes from the API docs to the SDK documentation
-          rsync -avz cloud-sdk/docs/api documentation/static/api
+          rsync -avz cloud-sdk/docs/api/ documentation/static/api/
           # change to documentation folder
           cd documentation
           # run git add -> commit -> push the new version of the docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches: [master]
     tags: ['v*']
+    # run only for update inside the docs folder 
     paths:
       - 'docs/**'
 
@@ -35,9 +36,13 @@ jobs:
           git config --global user.email "irrelevant@completely.irrelevant"
           git config --global user.name "irrelevant"
           cd ..
+          # clone current version of documentation
           git clone --depth 1 -b documentation git@github.com:SAP/cloud-sdk.git documentation
+          # copy latest changes from the API docs to the SDK documentation
           rsync -avz cloud-sdk/docs/api documentation/static/api
+          # change to documentation folder
           cd documentation
+          # run git add -> commit -> push the new version of the docs
           git add -A
           git commit -a -m "JS API documentation update via pipeline"
           git push


### PR DESCRIPTION
The pipeline already works. With this PR I only add comments to it for easier review.

I manually tested it end to end
![image](https://user-images.githubusercontent.com/10460752/81861819-1f73aa00-9569-11ea-8463-a58458d2576a.png)
![image](https://user-images.githubusercontent.com/10460752/81862939-c147c680-956a-11ea-94ed-d30b64b7d6dc.png)
![image](https://user-images.githubusercontent.com/10460752/81862950-c4db4d80-956a-11ea-967d-1866a19eb76b.png)

I also added the snippet below to `build.yml` to avoid running full builds on every docs change. I forced pushed it so that testing is not super slow because of multitude of builds.
```
paths-ignore:
- 'docs/**'
```
API docs should be now fully automated whenever anything new is added there but now with every build of the SDK, which is desired.

