### PR TITLE
Pipeline to handle API reference update to documentation branch

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -1,0 +1,42 @@
+name: update-api-documentation
+
+on:
+  push:
+    branches: [master]
+    tags: ['v*']
+    paths:
+    - 'docs/**'
+
+jobs:
+  push-to-documentation-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Add key
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          echo "${{ secrets.SERVER_DEPLOY_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          cat <<EOT >> ~/.ssh/config
+          Host github.com
+          HostName github.com
+          IdentityFile ~/.ssh/id_rsa
+          EOT
+      - name: Push generated API documentation to documentation branch
+        env:
+          USE_SSH: true
+          GIT_USER: irrelevant
+        run: |
+          git config --global user.email "irrelevant@completely.irrelevant"
+          git config --global user.name "irrelevant"
+          set -x
+          cd ..
+          git clone --depth 1 -b documentation git@github.com:SAP/cloud-sdk.git documentation
+          rsync -avz cloud-sdk/docs/api/ documentation/static/api/
+          cd documentation
+          git add -A
+          git commit -a -m "JS API documentation update via pipeline" || exit 0
+          git push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches: [master]
     tags: ['v*']
+    paths-ignore:
+    - 'docs/**'
 
 jobs:
   tests:


### PR DESCRIPTION
The pipeline was tested manually. What it does:
- triggered only on changes in the `docs` folder
- checks out master
- clones `documentation` branch into a separate folder
- syncs API docs inside of the container
- pushes to `documentation` branch which in turn triggers the release pipeline on it.

I manually tested it end to end

![image](https://user-images.githubusercontent.com/10460752/81861819-1f73aa00-9569-11ea-8463-a58458d2576a.png)
![image](https://user-images.githubusercontent.com/10460752/81862939-c147c680-956a-11ea-94ed-d30b64b7d6dc.png)
![image](https://user-images.githubusercontent.com/10460752/81862950-c4db4d80-956a-11ea-967d-1866a19eb76b.png)

I also added the snippet below to `build.yml` to avoid running full builds on every docs change. 

```
paths-ignore:
- 'docs/**'
```
API docs should be now fully automated whenever anything new is added there which should make releasing less of a burden.
