### PR TITLE
fix: complex type import should contain FieldType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ## Fixed Issues
 
--
+- Fix the OData client generator to avoid a compilation error when a complex type only contain complex types.
 
 
 # 1.20.1

--- a/packages/generator/src/complex-type/imports.ts
+++ b/packages/generator/src/complex-type/imports.ts
@@ -24,12 +24,13 @@ export function importDeclarations(
         ...edmTypeImportNames(complexType.properties),
         'ComplexTypeField',
         'createComplexType',
-        'Entity'
+        'Entity',
+        'FieldType'
       ].sort()
     )
   ];
 }
 
 function edmTypeImportNames(properties: VdmProperty[]): string[] {
-  return hasEdmTypeProperty(properties) ? ['edmToTs', 'FieldType'] : [];
+  return hasEdmTypeProperty(properties) ? ['edmToTs'] : [];
 }

--- a/packages/generator/test/complex-type/imports.spec.ts
+++ b/packages/generator/test/complex-type/imports.spec.ts
@@ -64,7 +64,12 @@ describe('complex type imports', () => {
       {
         kind: StructureKind.ImportDeclaration,
         moduleSpecifier: '@sap-cloud-sdk/core',
-        namedImports: ['ComplexTypeField', 'Entity', 'FieldType', 'createComplexType']
+        namedImports: [
+          'ComplexTypeField',
+          'Entity',
+          'FieldType',
+          'createComplexType'
+        ]
       }
     ]);
   });

--- a/packages/generator/test/complex-type/imports.spec.ts
+++ b/packages/generator/test/complex-type/imports.spec.ts
@@ -64,7 +64,7 @@ describe('complex type imports', () => {
       {
         kind: StructureKind.ImportDeclaration,
         moduleSpecifier: '@sap-cloud-sdk/core',
-        namedImports: ['ComplexTypeField', 'Entity', 'createComplexType']
+        namedImports: ['ComplexTypeField', 'Entity', 'FieldType', 'createComplexType']
       }
     ]);
   });

--- a/test-resources/service-specs/API_TEST_SRV/API_TEST_SRV.edmx
+++ b/test-resources/service-specs/API_TEST_SRV/API_TEST_SRV.edmx
@@ -26,7 +26,6 @@
         <Property Name="SByteProperty" Type="Edm.SByte"/>
 
         <Property Name="ComplexTypeProperty" Type="API_TEST_SRV.A_TestComplexType"/>
-        <Property Name="ComplexTypeContainingOnlyComplexProperty" Type="API_TEST_SRV.A_TestComplexTypeContainingOnlyComplex"/>
 
         <NavigationProperty Name="to_MultiLink" Relationship="API_TEST_SRV.assoc_TestEntityToMultiLink" FromRole="FromRole_assoc_TestEntityToMultiLink" ToRole="ToRole_assoc_TestEntityToMultiLink"/>
         <NavigationProperty Name="to_OtherMultiLink" Relationship="API_TEST_SRV.assoc_TestEntityToOtherMultiLink" FromRole="FromRole_assoc_TestEntityToOtherMultiLink" ToRole="ToRole_assoc_TestEntityToOtherMultiLink"/>
@@ -149,10 +148,6 @@
 
       <ComplexType Name="A_TestNestedComplexType">
         <Property Name="StringProperty" Type="Edm.String" MaxLength="10" sap:display-format="UpperCase"/>
-      </ComplexType>
-
-      <ComplexType Name="A_TestComplexTypeContainingOnlyComplex">
-         <Property Name="ComplexTypeProperty" Nullable="true" Type="API_TEST_SRV.A_TestNestedComplexType"/>
       </ComplexType>
 
       <Association Name="assoc_TestEntityToMultiLink" sap:content-version="1">

--- a/test-resources/service-specs/API_TEST_SRV/API_TEST_SRV.edmx
+++ b/test-resources/service-specs/API_TEST_SRV/API_TEST_SRV.edmx
@@ -26,6 +26,7 @@
         <Property Name="SByteProperty" Type="Edm.SByte"/>
 
         <Property Name="ComplexTypeProperty" Type="API_TEST_SRV.A_TestComplexType"/>
+        <Property Name="ComplexTypeContainingOnlyComplexProperty" Type="API_TEST_SRV.A_TestComplexTypeContainingOnlyComplex"/>
 
         <NavigationProperty Name="to_MultiLink" Relationship="API_TEST_SRV.assoc_TestEntityToMultiLink" FromRole="FromRole_assoc_TestEntityToMultiLink" ToRole="ToRole_assoc_TestEntityToMultiLink"/>
         <NavigationProperty Name="to_OtherMultiLink" Relationship="API_TEST_SRV.assoc_TestEntityToOtherMultiLink" FromRole="FromRole_assoc_TestEntityToOtherMultiLink" ToRole="ToRole_assoc_TestEntityToOtherMultiLink"/>
@@ -148,6 +149,10 @@
 
       <ComplexType Name="A_TestNestedComplexType">
         <Property Name="StringProperty" Type="Edm.String" MaxLength="10" sap:display-format="UpperCase"/>
+      </ComplexType>
+
+      <ComplexType Name="A_TestComplexTypeContainingOnlyComplex">
+         <Property Name="ComplexTypeProperty" Nullable="true" Type="API_TEST_SRV.A_TestNestedComplexType"/>
       </ComplexType>
 
       <Association Name="assoc_TestEntityToMultiLink" sap:content-version="1">


### PR DESCRIPTION
## Context
When a complex type is generated, the import statement should contain `FieldType` without any dependencies, because the `build()` function as shown below contains it.

```
export namespace RuleFieldMappingBeanList {
  export function build(json: { [keys: string]: FieldType }): RuleFieldMappingBeanList {
    return createComplexType(json, {
      ruleFieldMappings: (ruleFieldMappings: RuleFieldMappingBean) => ({ ruleFieldMappings: RuleFieldMappingBean.build(ruleFieldMappings) })
    });
  }
}
```

## Definition of Done

Please consider all items and remove only if not applicable.

- [x] Tests created/adjusted for your changes.
- [x] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [x] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [ ] If applicable: Properly documented (JSDoc of public API)
- [ ] If applicable: Check if `node run doc` still works.

## Labels
We use labels to indicate the status of PRs. 
Please select `please review`, `please merge` or `don't merge` for your PR.
