### PR TITLE
fix: Corrected spelling of 'sucessful' in messages

### DIFF
--- a/packages/core/src/scp-cf/destination-accessor.ts
+++ b/packages/core/src/scp-cf/destination-accessor.ts
@@ -181,7 +181,7 @@ export async function getDestinationFromDestinationService(
     );
     if (subscriberDestinationCache) {
       logger.info(
-        'Sucessfully retrieved destination from destination service cache for subscriber destinations.'
+        'Successfully retrieved destination from destination service cache for subscriber destinations.'
       );
       return subscriberDestinationCache;
     }
@@ -204,7 +204,7 @@ export async function getDestinationFromDestinationService(
           isIdenticalTenant(decodedUserJwt!, decodedProviderJwt)))
     ) {
       logger.info(
-        'Sucessfully retrieved destination from destination service cache for provider destinations.'
+        'Successfully retrieved destination from destination service cache for provider destinations.'
       );
       return providerDestinationCache;
     }
@@ -225,7 +225,7 @@ export async function getDestinationFromDestinationService(
     selectionStrategy !== alwaysSubscriber
   ) {
     logger.info(
-      'Sucessfully retrieved destination from destination service cache for provider destinations.'
+      'Successfully retrieved destination from destination service cache for provider destinations.'
     );
     return providerDestinationCache;
   }
@@ -301,7 +301,7 @@ export async function getDestinationFromDestinationService(
 
     if (destination) {
       logger.info(
-        'Sucessfully retrieved destination from destination service.'
+        'Successfully retrieved destination from destination service.'
       );
       if (proxyStrategy(destination) === ProxyStrategy.ON_PREMISE_PROXY) {
         destination = await addProxyConfigurationOnPrem(
@@ -332,7 +332,7 @@ function tryDestinationForServiceBinding(
   logger.info('Attempting to retrieve destination from service binding.');
   try {
     const destination = destinationForServiceBinding(name);
-    logger.info('Sucessfully retrieved destination from service binding.');
+    logger.info('Successfully retrieved destination from service binding.');
     return destination;
   } catch (error) {
     logger.info(error.message);
@@ -358,7 +358,7 @@ function tryDestinationFromEnv(name: string): Destination | undefined {
       const destination = getDestinationFromEnvByName(name);
       if (destination) {
         logger.info(
-          'Sucessfully retrieved destination from environment variable.'
+          'Successfully retrieved destination from environment variable.'
         );
         return destination;
       }


### PR DESCRIPTION
Spelling correction: 'Sucessful' -> 'Successful'

## Context

Correction of spelling of 'sucessful'.

## Definition of Done
'Successful' appears with the correct spelling in messages.

Please consider all items and remove only if not applicable.

- [ ] Tests created/adjusted for your changes.
- [ ] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [x] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [ ] If applicable: Properly documented (JSDoc of public API)
- [ ] If applicable: Check if `node run doc` still works.

## Labels
`please review`