### PR TITLE
chore: Remove duplicate doc update

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -3,7 +3,6 @@ name: update-api-documentation
 on:
   push:
     branches: [master]
-    tags: ['v*']
     paths:
     - 'docs/**'
 


### PR DESCRIPTION
When creating a tag, a new release process is started by calling the script: `npx lerna version minor(or patch) --force-publish -y`.
This command actually also commit to master for some version updates.
As a result, both of the actions below trigger the GitHub action with the same git commit id:
- pushing a tag
- commit to master

One of them is duplicate so I would like to disable it.