### PR TITLE
chore: Skip canary release on tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       - run: npm run check:license
         name: License Check
   canary-release:
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' || !startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     needs: [tests, checks]
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       - run: npm run check:license
         name: License Check
   canary-release:
-    if: github.event_name != 'pull_request' || !startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     needs: [tests, checks]
     steps:


### PR DESCRIPTION
Fix pipeline to only create one release