### PR TITLE
Fix: Validate that domains match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ## Fixed Issues
 
--
+- Fix missing validation of URL used for obtaining the JWT verification key.
 
 
 # 1.21.1

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -4281,6 +4281,11 @@
 			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
 			"dev": true
 		},
+		"querystring": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+		},
 		"rambda": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/rambda/-/rambda-5.0.0.tgz",
@@ -5273,6 +5278,22 @@
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
 			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
 			"dev": true
+		},
+		"url": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+			"integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+			"requires": {
+				"punycode": "1.3.2",
+				"querystring": "0.2.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+				}
+			}
 		},
 		"use": {
 			"version": "3.1.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,6 +46,7 @@
     "opossum": "^5.0.0",
     "rambda": "^5.0.0",
     "uuid": "^7.0.3",
+    "url" : "^0.11.0",
     "voca": "^1.4.0"
   },
   "devDependencies": {

--- a/packages/core/src/util/jwt.ts
+++ b/packages/core/src/util/jwt.ts
@@ -1,10 +1,10 @@
 /* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
 
 import { IncomingMessage } from 'http';
+import * as url from 'url';
 import { createLogger, errorWithCause } from '@sap-cloud-sdk/util';
 import { AxiosRequestConfig } from 'axios';
 import jwt from 'jsonwebtoken';
-import * as url from "url";
 import {
   Cache,
   fetchVerificationKeys,
@@ -101,21 +101,23 @@ function validateAuthHeader(header: string | undefined): boolean {
   return true;
 }
 
-
 /**
  * The URL for fetching the verfication certificate should have the same domain as the XSUAA. So if the UUA domain is "authentication.sap.hana.ondemand.com" the URL should be like
  * http://something.authentication.sap.hana.ondemand.com/somePath so the host should end with the domain.
- * @param verificationKeyURL
- * @param xsuaaUriOrCredentials
+ * @param verificationKeyURL URL used for obtaining the verification key
+ * @param uaaDomain domain given in the XSUAA credentials
  */
-function checkDomainVerificationKeyURL(verificationKeyURL:string,xsuaaUriOrCredentials: XsuaaServiceCredentials):void{
-  const jkuDomain = url.parse(verificationKeyURL).hostname
-  const uuaDomain =xsuaaUriOrCredentials.uaadomain;
-  if(!jkuDomain || !jkuDomain.endsWith(uuaDomain)){
-    throw new Error(`The domains of the XSUAA and verification URL do not match - XSUUA domain is ${uuaDomain} and the URL provided in JWT (field jku) to receive validation certificate is ${jkuDomain}.`)
+function checkDomainVerificationKeyURL(
+  verificationKeyURL: string,
+  uaaDomain: string
+): void {
+  const jkuDomain = url.parse(verificationKeyURL).hostname;
+  if (!uaaDomain || !jkuDomain || !jkuDomain.endsWith(uaaDomain)) {
+    throw new Error(
+      `The domains of the XSUAA and verification URL do not match - XSUUA domain is ${uaaDomain} and the URL provided in JWT (field jku) to receive validation certificate is ${jkuDomain}.`
+    );
   }
 }
-
 
 /**
  * Verifies the given JWT and returns the decoded payload.
@@ -132,8 +134,8 @@ export async function verifyJwt(
 
   const creds = getXsuaaServiceCredentials(token);
   const verificationKeyURL = getVerificationKeyURL(token);
-  if(verificationKeyURL) {
-    checkDomainVerificationKeyURL(verificationKeyURL,creds)
+  if (verificationKeyURL) {
+    checkDomainVerificationKeyURL(verificationKeyURL, creds.uaadomain);
   }
 
   if (

--- a/packages/core/test/test-util/environment-mocks.ts
+++ b/packages/core/test/test-util/environment-mocks.ts
@@ -20,7 +20,8 @@ export const mockXsuaaBinding: Service = {
     url: providerXsuaaUrl,
     clientid: 'clientid',
     clientsecret: 'clientsecret',
-    verificationkey: publicKey()
+    verificationkey: publicKey(),
+    uaadomain : "authentication.sap.hana.ondemand.com"
   }
 };
 

--- a/packages/core/test/test-util/environment-mocks.ts
+++ b/packages/core/test/test-util/environment-mocks.ts
@@ -21,7 +21,7 @@ export const mockXsuaaBinding: Service = {
     clientid: 'clientid',
     clientsecret: 'clientsecret',
     verificationkey: publicKey(),
-    uaadomain : "authentication.sap.hana.ondemand.com"
+    uaadomain: 'authentication.sap.hana.ondemand.com'
   }
 };
 

--- a/packages/core/test/test-util/mocked-access-tokens.ts
+++ b/packages/core/test/test-util/mocked-access-tokens.ts
@@ -28,7 +28,7 @@ export const subscriberServiceToken = signedJwt(subscriberServiceTokenPayload);
 
 export const subscriberServiceTokenWithVerificationURL = signedJwtForVerification(
   subscriberServiceTokenPayload,
-  'https://some-jku-url.com'
+  'https://my-jku-url.authentication.sap.hana.ondemand.com'
 );
 
 const userApprovedProviderTokenPayload = {

--- a/packages/core/test/util/jwt.spec.ts
+++ b/packages/core/test/util/jwt.spec.ts
@@ -97,7 +97,7 @@ describe('jwt', () => {
     };
 
     const xsuaaUrl = 'https://example.com';
-    const jku = 'https://my-verification-url.com';
+    const jku =  'https://my-jku-url.authentication.sap.hana.ondemand.com';
 
     beforeEach(() => {
       process.env.VCAP_SERVICES = JSON.stringify({
@@ -106,7 +106,8 @@ describe('jwt', () => {
             credentials: {
               clientid: 'clientid',
               clientsecret: 'clientsecret',
-              url: xsuaaUrl
+              url: xsuaaUrl,
+              uaadomain: 'authentication.sap.hana.ondemand.com'
             },
             name: 'my-xsuaa',
             plan: 'application',
@@ -135,6 +136,17 @@ describe('jwt', () => {
           );
           expect(error.stack).toContain(
             'No verification keys have been returned by the XSUAA service!'
+          );
+          done();
+        });
+    });
+
+    it('fails for jku URL and xsuaa different domain', done => {
+      verifyJwt(signedJwtForVerification(jwtPayload, 'https://my-jku-url.some.wrong.domain.com'))
+        .then(() => done('Should have failed.'))
+        .catch(error => {
+          expect(error.message).toContain(
+            'The domains of the XSUAA and verification URL do not match'
           );
           done();
         });

--- a/packages/core/test/util/jwt.spec.ts
+++ b/packages/core/test/util/jwt.spec.ts
@@ -97,7 +97,7 @@ describe('jwt', () => {
     };
 
     const xsuaaUrl = 'https://example.com';
-    const jku =  'https://my-jku-url.authentication.sap.hana.ondemand.com';
+    const jku = 'https://my-jku-url.authentication.sap.hana.ondemand.com';
 
     beforeEach(() => {
       process.env.VCAP_SERVICES = JSON.stringify({
@@ -142,7 +142,12 @@ describe('jwt', () => {
     });
 
     it('fails for jku URL and xsuaa different domain', done => {
-      verifyJwt(signedJwtForVerification(jwtPayload, 'https://my-jku-url.some.wrong.domain.com'))
+      verifyJwt(
+        signedJwtForVerification(
+          jwtPayload,
+          'https://my-jku-url.some.wrong.domain.com'
+        )
+      )
         .then(() => done('Should have failed.'))
         .catch(error => {
           expect(error.message).toContain(


### PR DESCRIPTION
## Context

In the JWT verification method provided by the SDK we used the value `jku` of the JWT header without additional checks. This is not correct. To avoid manipulations the domains of the provided value and the `uaadomain` of the XSUAA credentials need to match.

This PR fixes this vulnerability. The PR where the problem came in was:

https://github.com/SAP/cloud-sdk/pull/100 merged 29th of March.
So if I see it correctly the versions:
- v1.21.1
- v1.21.0
- v1.20.1
- v1.20.0
- v1.19.0

are effected and should be marked as vulnerable so that npm audit give a error.

## Definition of Done

Please consider all items and remove only if not applicable.

- [x] Tests created/adjusted for your changes.
- [x] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [x] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [x] If applicable: Properly documented (JSDoc of public API)
- [x] If applicable: Check if `node run doc` still works.
