### PR TITLE
feat: V4 etag handling

### DIFF
--- a/packages/core/src/odata/common/entity-deserializer.ts
+++ b/packages/core/src/odata/common/entity-deserializer.ts
@@ -19,7 +19,7 @@ import { CollectionField } from '../v4/selectable/collection-field';
 /**
  * @experimental This is experimental and is subject to change. Use with caution.
  */
-export function entityDeserializer(edmToTs) {
+export function entityDeserializer(edmToTs, extractODataETag) {
   /**
    * Extracts all custom fields from the JSON payload for a single entity.
    * In this context, a custom fields is every property that is not known in the corresponding entity class.
@@ -82,10 +82,6 @@ export function entityDeserializer(edmToTs) {
 
   function extractEtagFromHeader(headers: any): string | undefined {
     return headers ? headers['Etag'] || headers['etag'] : undefined;
-  }
-
-  function extractODataETag(json: MapType<any>): string | undefined {
-    return '__metadata' in json ? json['__metadata']['etag'] : undefined;
   }
 
   function getFieldValue<EntityT extends EntityBase, JsonT>(

--- a/packages/core/src/odata/v2/entity-deserializer.ts
+++ b/packages/core/src/odata/v2/entity-deserializer.ts
@@ -2,7 +2,8 @@
 
 import { entityDeserializer } from '../common/entity-deserializer';
 import { edmToTs } from './payload-value-converter';
-const deserializer = entityDeserializer(edmToTs);
+import { extractODataETag } from './extract-odata-etag';
+const deserializer = entityDeserializer(edmToTs, extractODataETag);
 
 export const extractCustomFields = deserializer.extractCustomFields;
 export const deserializeEntity = deserializer.deserializeEntity;

--- a/packages/core/src/odata/v2/extract-odata-etag.ts
+++ b/packages/core/src/odata/v2/extract-odata-etag.ts
@@ -1,0 +1,5 @@
+import { MapType } from '@sap-cloud-sdk/util';
+
+export function extractODataETag(json: MapType<any>): string | undefined {
+  return '__metadata' in json ? json['__metadata']['etag'] : undefined;
+}

--- a/packages/core/src/odata/v2/index.ts
+++ b/packages/core/src/odata/v2/index.ts
@@ -13,4 +13,5 @@ export * from './request-builder';
 export * from './selectable/custom-field';
 export * from './uri-conversion';
 export * from './legacy-request-configs';
+export * from './extract-odata-etag';
 export * from '../common';

--- a/packages/core/src/odata/v4/entity-deserializer.ts
+++ b/packages/core/src/odata/v4/entity-deserializer.ts
@@ -2,7 +2,8 @@
 
 import { entityDeserializer } from '../common/entity-deserializer';
 import { edmToTs } from './payload-value-converter';
-const deserializer = entityDeserializer(edmToTs);
+import { extractODataETag } from './extract-odata-etag';
+const deserializer = entityDeserializer(edmToTs, extractODataETag);
 
 export const extractCustomFields = deserializer.extractCustomFields;
 export const deserializeEntity = deserializer.deserializeEntity;

--- a/packages/core/src/odata/v4/extract-odata-etag.ts
+++ b/packages/core/src/odata/v4/extract-odata-etag.ts
@@ -2,5 +2,5 @@
 import { MapType } from '@sap-cloud-sdk/util';
 
 export function extractODataETag(json: MapType<any>): string | undefined {
-  return '__metadata' in json ? json['__metadata']['etag'] : undefined;
+  return '@odata.etag' in json ? json['@odata.etag'] : undefined;
 }

--- a/packages/core/src/odata/v4/index.ts
+++ b/packages/core/src/odata/v4/index.ts
@@ -11,5 +11,6 @@ export * from './payload-value-converter';
 export * from './request-builder';
 export * from './selectable/custom-field';
 export * from './uri-conversion';
+export * from './extract-odata-etag';
 export * from '../common';
 export * from '../common/selectable/one-to-many-link';

--- a/packages/core/test/request-builder/get-by-key-request-builder-v4.spec.ts
+++ b/packages/core/test/request-builder/get-by-key-request-builder-v4.spec.ts
@@ -42,4 +42,50 @@ describe('GetByKeyRequestBuilder', () => {
       expect(actual).toEqual(expected);
     });
   });
+
+  it('etag should be pulled from @odata.etag', async () => {
+    const entityData = createOriginalTestEntityData1();
+    const versionIdentifier = 'etagInMetadata';
+    entityData['@odata.etag'] = versionIdentifier;
+    const expected = createTestEntity(entityData);
+
+    mockGetRequest({
+      path: testEntityResourcePath(
+        expected.keyPropertyGuid,
+        expected.keyPropertyString,
+        convertToUriFormat
+      ),
+      responseBody: entityData
+    });
+
+    const actual = await new GetByKeyRequestBuilder(TestEntity, {
+      KeyPropertyGuid: expected.keyPropertyGuid,
+      KeyPropertyString: expected.keyPropertyString
+    }).execute(defaultDestination);
+    expected.setVersionIdentifier(versionIdentifier);
+    expect(actual).toEqual(expected);
+  });
+
+  it('etag should be pulled from response header when json payload has no @odata.etag property', async () => {
+    const entityData = createOriginalTestEntityData1();
+    const expected = createTestEntity(entityData);
+    const versionIdentifier = 'etagInHeader';
+    expected.setVersionIdentifier(versionIdentifier);
+
+    mockGetRequest({
+      path: testEntityResourcePath(
+        expected.keyPropertyGuid,
+        expected.keyPropertyString,
+        convertToUriFormat
+      ),
+      responseBody: entityData ,
+      responseHeaders: { Etag: versionIdentifier }
+    });
+
+    const actual = await new GetByKeyRequestBuilder(TestEntity, {
+      KeyPropertyGuid: expected.keyPropertyGuid,
+      KeyPropertyString: expected.keyPropertyString
+    }).execute(defaultDestination);
+    expect(actual).toEqual(expected);
+  });
 });

--- a/packages/core/test/request-builder/get-by-key-request-builder-v4.spec.ts
+++ b/packages/core/test/request-builder/get-by-key-request-builder-v4.spec.ts
@@ -78,7 +78,7 @@ describe('GetByKeyRequestBuilder', () => {
         expected.keyPropertyString,
         convertToUriFormat
       ),
-      responseBody: entityData ,
+      responseBody: entityData,
       responseHeaders: { Etag: versionIdentifier }
     });
 


### PR DESCRIPTION
## Context

The Etag information from the payload has different format in the OData V4 (`json.@odata.etag`) compared to V2(`json.__metadata.etag`).
Since the key of the header used is the same, the write operations are not affected.

## Definition of Done

Please consider all items and remove only if not applicable.

- [x] Tests created/adjusted for your changes.
- [ ] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [x] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [ ] If applicable: Properly documented (JSDoc of public API)
- [ ] If applicable: Check if `node run doc` still works.
