### PR TITLE
chore: disable compile in test-services package

### DIFF
--- a/test-packages/test-services/package.json
+++ b/test-packages/test-services/package.json
@@ -14,10 +14,6 @@
     "access": "restricted",
     "directory": "srv"
   },
-  "scripts": {
-    "compile": "npx tsc",
-    "prepare": "npm run compile"
-  },
   "license": "Apache-2.0",
   "dependencies": {
     "@sap-cloud-sdk/core": "^1.21.2",

--- a/test-packages/test-services/tsconfig.json
+++ b/test-packages/test-services/tsconfig.json
@@ -1,9 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "include": [
-    "**/*.ts"
-  ],
-  "exclude": [
-    "node_modules/**/*"
-  ]
-}


### PR DESCRIPTION
## Context

The ts files are compiled for verifying whether they have compilation errors.
We have to disable them, since pipeline detects some changes after that then results in a canary release error.

## Definition of Done

Please consider all items and remove only if not applicable.

- [ ] Tests created/adjusted for your changes.
- [ ] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [x] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [ ] If applicable: Properly documented (JSDoc of public API)
- [ ] If applicable: Check if `node run doc` still works.
