### PR TITLE
feat: Remove notion of fractional seconds

### DIFF
--- a/packages/core/src/odata/common/time.ts
+++ b/packages/core/src/odata/common/time.ts
@@ -5,10 +5,6 @@ export interface Time {
   seconds: number;
 }
 
-export interface TimeFractionalSeconds extends Time {
-  fractionalSeconds: string | undefined;
-}
-
 /**
  * Converts the given time to seconds in positive numerical format.
  *
@@ -23,7 +19,7 @@ export function timeToSeconds(time: Time): number {
 }
 
 /**
- * Converts from seconds to time in HH:MM:SS format.
+ * Converts from seconds to time as [[Time]].
  *
  * @param n - Number of seconds to convert (should be positive).
  * @returns Time The converted time from the given number of seconds

--- a/packages/core/src/odata/v4/payload-value-converter.ts
+++ b/packages/core/src/odata/v4/payload-value-converter.ts
@@ -3,7 +3,7 @@
 
 import BigNumber from 'bignumber.js';
 import moment, { Duration, Moment } from 'moment';
-import { Time, EdmTypeShared, TimeFractionalSeconds } from '../common';
+import { Time, EdmTypeShared } from '../common';
 import {
   deserializersCommon,
   serializersCommom
@@ -77,8 +77,8 @@ function edmDurationToMoment(value: string): Duration {
   return moment.duration(value);
 }
 
-function edmTimeOfDayToTime(value: string): TimeFractionalSeconds {
-  const timeComponents = /(\d{2,2}):(\d{2,2}):(\d{2,2})\.{0,1}(\d{1,12})?/.exec(
+function edmTimeOfDayToTime(value: string): Time {
+  const timeComponents = /(\d{2,2}):(\d{2,2}):(\d{2,2}(\.\d{1,12}){0,1})?/.exec(
     value
   );
   if (!timeComponents) {
@@ -87,10 +87,9 @@ function edmTimeOfDayToTime(value: string): TimeFractionalSeconds {
     );
   }
   return {
-    hours: parseInt(timeComponents[1], 10),
-    minutes: parseInt(timeComponents[2], 10),
-    seconds: parseInt(timeComponents[3], 10),
-    fractionalSeconds: timeComponents[4] || undefined
+    hours: parseInt(timeComponents[1]),
+    minutes: parseInt(timeComponents[2]),
+    seconds: parseFloat(timeComponents[3])
   };
 }
 
@@ -106,10 +105,7 @@ function durationToEdmDuration(value: Duration): string {
   return value.toISOString();
 }
 
-function timeToEdmTimeOfDay(value: TimeFractionalSeconds): string {
-  if (value.fractionalSeconds) {
-    return `${value.hours}:${value.minutes}:${value.seconds}.${value.fractionalSeconds}`;
-  }
+function timeToEdmTimeOfDay(value: Time): string {
   return `${value.hours}:${value.minutes}:${value.seconds}`;
 }
 

--- a/packages/core/test/uri-value-converter-v4.spec.ts
+++ b/packages/core/test/uri-value-converter-v4.spec.ts
@@ -25,7 +25,7 @@ describe('convertToUriFormat', () => {
   it('should convert timeOfDay', () => {
     expect(
       convertToUriFormat(
-        { hours: 13, minutes: 21, seconds: 43, fractionalSeconds: 123 },
+        { hours: 13, minutes: 21, seconds: 43.123 },
         'Edm.TimeOfDay'
       )
     ).toBe('13:21:43.123');


### PR DESCRIPTION
## Context

Reduce number of generated types and represent fractional seconds as number instead of string. This comes with the tradeoff, that trailing zeros in fractions can get lost, but as discussed, we treat this as a corner case for now.

## Definition of Done

Please consider all items and remove only if not applicable.

- [x] Tests created/adjusted for your changes.
- [ ] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [ ] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [ ] If applicable: Properly documented (JSDoc of public API)
- [ ] If applicable: Check if `node run doc` still works.
