### PR TITLE
Fix: Conversion number TS to edm formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 ## Fixed Issues
 
 - Fix type error due to a breaking change from winston version 3.3.2 -> 3.3.3 [see here](https://github.com/winstonjs/winston/issues/1822#event-3508252985) for details.
+- Fix serialization error for number values 'INF','-INF' and 'NaN'.
 
 
 # 1.23.0

--- a/packages/core/src/odata/common/payload-value-converter.ts
+++ b/packages/core/src/odata/common/payload-value-converter.ts
@@ -54,26 +54,23 @@ export function toNumberFromEdm(value: string | number): number {
 /**
  * @hidden
  */
-export function toNumberFromTs(value: Number): number|string {
-  if (typeof value === 'number') {
-    return value;
-  }
-
+export function toNumberFromTs(value: number): number | string {
   if (value === Number.POSITIVE_INFINITY) {
     return 'INF';
   }
   if (value === Number.NEGATIVE_INFINITY) {
     return '-INF';
   }
-  if (value === Number.NaN) {
-    return 'NaN'
+  if (Number.isNaN(value)) {
+    return 'NaN';
   }
 
-  const num = Number(value);
+  if (typeof value === 'number') {
+    return value;
+  }
 
   throw new Error(`TS->edm: Cannot create number from input "${value}"`);
 }
-
 
 export const deserializersCommon: EdmTypeMapping = {
   'Edm.Binary': identity,

--- a/packages/core/src/odata/common/payload-value-converter.ts
+++ b/packages/core/src/odata/common/payload-value-converter.ts
@@ -27,7 +27,7 @@ const fromBigNumber = (value: BigNumber): string =>
 /**
  * @hidden
  */
-export function parseNumber(value: string | number): number {
+export function toNumberFromEdm(value: string | number): number {
   if (typeof value === 'number') {
     return value;
   }
@@ -45,25 +45,49 @@ export function parseNumber(value: string | number): number {
   const num = Number(value);
 
   if (Number.isNaN(num)) {
-    throw new Error(`Cannot create number from input "${value}"`);
+    throw new Error(`Edm->TS: Cannot create number from input "${value}"`);
   }
 
   return num;
 }
+
+/**
+ * @hidden
+ */
+export function toNumberFromTs(value: Number): number|string {
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  if (value === Number.POSITIVE_INFINITY) {
+    return 'INF';
+  }
+  if (value === Number.NEGATIVE_INFINITY) {
+    return '-INF';
+  }
+  if (value === Number.NaN) {
+    return 'NaN'
+  }
+
+  const num = Number(value);
+
+  throw new Error(`TS->edm: Cannot create number from input "${value}"`);
+}
+
 
 export const deserializersCommon: EdmTypeMapping = {
   'Edm.Binary': identity,
   'Edm.Boolean': identity,
   'Edm.Byte': toNumber,
   'Edm.Decimal': toBigNumber,
-  'Edm.Double': parseNumber,
-  'Edm.Float': parseNumber,
+  'Edm.Double': toNumberFromEdm,
+  'Edm.Float': toNumberFromEdm,
   'Edm.Int16': toNumber,
   'Edm.Int32': toNumber,
   'Edm.Int64': toBigNumber,
   'Edm.Guid': toGuid,
   'Edm.SByte': toNumber,
-  'Edm.Single': parseNumber,
+  'Edm.Single': toNumberFromEdm,
   'Edm.String': identity
 };
 
@@ -72,13 +96,13 @@ export const serializersCommom: EdmTypeMapping = {
   'Edm.Boolean': identity,
   'Edm.Byte': toNumber,
   'Edm.Decimal': fromBigNumber,
-  'Edm.Double': parseNumber,
-  'Edm.Float': parseNumber,
+  'Edm.Double': toNumberFromTs,
+  'Edm.Float': toNumberFromTs,
   'Edm.Int16': toNumber,
   'Edm.Int32': toNumber,
   'Edm.Int64': fromBigNumber,
   'Edm.Guid': identity,
   'Edm.SByte': toNumber,
-  'Edm.Single': parseNumber,
+  'Edm.Single': toNumberFromTs,
   'Edm.String': identity
 };

--- a/packages/core/src/odata/common/payload-value-converter.ts
+++ b/packages/core/src/odata/common/payload-value-converter.ts
@@ -27,7 +27,7 @@ const fromBigNumber = (value: BigNumber): string =>
 /**
  * @hidden
  */
-export function toNumberFromEdm(value: string | number): number {
+export function fromEdmToNumber(value: string | number): number {
   if (typeof value === 'number') {
     return value;
   }
@@ -54,7 +54,7 @@ export function toNumberFromEdm(value: string | number): number {
 /**
  * @hidden
  */
-export function toNumberFromTs(value: number): number | string {
+export function fromNumberToEdm(value: number): number | string {
   if (value === Number.POSITIVE_INFINITY) {
     return 'INF';
   }
@@ -77,14 +77,14 @@ export const deserializersCommon: EdmTypeMapping = {
   'Edm.Boolean': identity,
   'Edm.Byte': toNumber,
   'Edm.Decimal': toBigNumber,
-  'Edm.Double': toNumberFromEdm,
-  'Edm.Float': toNumberFromEdm,
+  'Edm.Double': fromEdmToNumber,
+  'Edm.Float': fromEdmToNumber,
   'Edm.Int16': toNumber,
   'Edm.Int32': toNumber,
   'Edm.Int64': toBigNumber,
   'Edm.Guid': toGuid,
   'Edm.SByte': toNumber,
-  'Edm.Single': toNumberFromEdm,
+  'Edm.Single': fromEdmToNumber,
   'Edm.String': identity
 };
 
@@ -93,13 +93,13 @@ export const serializersCommom: EdmTypeMapping = {
   'Edm.Boolean': identity,
   'Edm.Byte': toNumber,
   'Edm.Decimal': fromBigNumber,
-  'Edm.Double': toNumberFromTs,
-  'Edm.Float': toNumberFromTs,
+  'Edm.Double': fromNumberToEdm,
+  'Edm.Float': fromNumberToEdm,
   'Edm.Int16': toNumber,
   'Edm.Int32': toNumber,
   'Edm.Int64': fromBigNumber,
   'Edm.Guid': identity,
   'Edm.SByte': toNumber,
-  'Edm.Single': toNumberFromTs,
+  'Edm.Single': fromNumberToEdm,
   'Edm.String': identity
 };

--- a/packages/core/test/odata/payload-value-converter.spec.ts
+++ b/packages/core/test/odata/payload-value-converter.spec.ts
@@ -9,8 +9,8 @@ import {
   tsToEdm
 } from '../../src';
 import {
-  toNumberFromEdm,
-  toNumberFromTs
+  fromEdmToNumber,
+  fromNumberToEdm
 } from '../../src/odata/common/payload-value-converter';
 
 describe('edmToTs()', () => {
@@ -342,34 +342,34 @@ describe('edm to ts to edm does not lead to information loss', () => {
 
 describe('toNumber from edm type input', () => {
   it('parses a number from string or returns the corresponding Number construct for INF, -INF and NaN', () => {
-    expect(toNumberFromEdm('INF')).toEqual(Number.POSITIVE_INFINITY);
-    expect(toNumberFromEdm('-INF')).toEqual(Number.NEGATIVE_INFINITY);
-    expect(Number.isNaN(toNumberFromEdm('NaN'))).toBeTruthy();
-    expect(toNumberFromEdm('32')).toBe(32);
+    expect(fromEdmToNumber('INF')).toEqual(Number.POSITIVE_INFINITY);
+    expect(fromEdmToNumber('-INF')).toEqual(Number.NEGATIVE_INFINITY);
+    expect(Number.isNaN(fromEdmToNumber('NaN'))).toBeTruthy();
+    expect(fromEdmToNumber('32')).toBe(32);
   });
 
   it('can handle input in arbitrary cases', () => {
-    expect(toNumberFromEdm('InF')).toEqual(Number.POSITIVE_INFINITY);
-    expect(toNumberFromEdm('inf')).toEqual(Number.POSITIVE_INFINITY);
-    expect(toNumberFromEdm('iNF')).toEqual(Number.POSITIVE_INFINITY);
+    expect(fromEdmToNumber('InF')).toEqual(Number.POSITIVE_INFINITY);
+    expect(fromEdmToNumber('inf')).toEqual(Number.POSITIVE_INFINITY);
+    expect(fromEdmToNumber('iNF')).toEqual(Number.POSITIVE_INFINITY);
   });
 
   it('throws an error for non-numbers', () => {
-    expect(() => toNumberFromEdm('something something danger zone')).toThrow();
+    expect(() => fromEdmToNumber('something something danger zone')).toThrow();
   });
 });
 
 describe('toNumber from ts type input', () => {
   it('parses a number from string or returns the corresponding Number construct for INF, -INF and NaN', () => {
-    expect(toNumberFromTs(Number.POSITIVE_INFINITY)).toEqual('INF');
-    expect(toNumberFromTs(Number.NEGATIVE_INFINITY)).toEqual('-INF');
-    expect(toNumberFromTs(Number.NaN)).toEqual('NaN');
-    expect(toNumberFromTs(32)).toBe(32);
+    expect(fromNumberToEdm(Number.POSITIVE_INFINITY)).toEqual('INF');
+    expect(fromNumberToEdm(Number.NEGATIVE_INFINITY)).toEqual('-INF');
+    expect(fromNumberToEdm(Number.NaN)).toEqual('NaN');
+    expect(fromNumberToEdm(32)).toBe(32);
   });
 
   it('throws an error for non-numbers', () => {
     expect(() =>
-      toNumberFromTs('something something danger zone' as any)
+      fromNumberToEdm('something something danger zone' as any)
     ).toThrow();
   });
 });
@@ -447,5 +447,7 @@ function checkInfinityCasesToTs(edmType: EdmType) {
 }
 
 function checkInfinityCasesRoundTrip(edmType: EdmType) {
-  ['INF','-INF','NaN'].forEach(s => expect(tsToEdm(edmToTs(s, edmType), edmType)).toBe(s));
+  ['INF', '-INF', 'NaN'].forEach(s =>
+    expect(tsToEdm(edmToTs(s, edmType), edmType)).toBe(s)
+  );
 }

--- a/packages/core/test/odata/payload-value-converter.spec.ts
+++ b/packages/core/test/odata/payload-value-converter.spec.ts
@@ -447,5 +447,5 @@ function checkInfinityCasesToTs(edmType: EdmType) {
 }
 
 function checkInfinityCasesRoundTrip(edmType: EdmType) {
-  ['NaN'].forEach(s => expect(tsToEdm(edmToTs(s, edmType), edmType)).toBe(s));
+  ['INF','-INF','NaN'].forEach(s => expect(tsToEdm(edmToTs(s, edmType), edmType)).toBe(s));
 }

--- a/packages/core/test/odata/payload-value-converter.spec.ts
+++ b/packages/core/test/odata/payload-value-converter.spec.ts
@@ -3,11 +3,15 @@ import BigNumber from 'bignumber.js';
 import moment from 'moment';
 import {
   edmDateTimeToMoment,
-  edmToTs, EdmType,
+  edmToTs,
+  EdmType,
   momentToEdmDateTime,
   tsToEdm
 } from '../../src';
-import { toNumberFromEdm, toNumberFromTs } from '../../src/odata/common/payload-value-converter';
+import {
+  toNumberFromEdm,
+  toNumberFromTs
+} from '../../src/odata/common/payload-value-converter';
 
 describe('edmToTs()', () => {
   it('should parse Edm.String to string', () => {
@@ -276,12 +280,9 @@ describe('edm to ts to edm does not lead to information loss', () => {
     checkInfinityCasesRoundTrip('Edm.Single');
   });
 
-
   it('Edm.Float', () => {
     const expected = 1234;
-    expect(tsToEdm(edmToTs(expected, 'Edm.Float'), 'Edm.Float')).toBe(
-      expected
-    );
+    expect(tsToEdm(edmToTs(expected, 'Edm.Float'), 'Edm.Float')).toBe(expected);
     checkInfinityCasesRoundTrip('Edm.Float');
   });
 
@@ -367,10 +368,11 @@ describe('toNumber from ts type input', () => {
   });
 
   it('throws an error for non-numbers', () => {
-    expect(() => toNumberFromTs('something something danger zone' as any)).toThrow();
+    expect(() =>
+      toNumberFromTs('something something danger zone' as any)
+    ).toThrow();
   });
 });
-
 
 describe('edm to moment and back', () => {
   describe('edm to moment', () => {
@@ -432,22 +434,18 @@ describe('edm to moment and back', () => {
   });
 });
 
-
-function checkInfinityCasesToEdm(edmType:EdmType){
+function checkInfinityCasesToEdm(edmType: EdmType) {
   expect(tsToEdm(Number.POSITIVE_INFINITY, edmType)).toBe('INF');
   expect(tsToEdm(Number.NEGATIVE_INFINITY, edmType)).toBe('-INF');
   expect(tsToEdm(Number.NaN, edmType)).toBe('NaN');
 }
 
-
-function checkInfinityCasesToTs(edmType:EdmType){
+function checkInfinityCasesToTs(edmType: EdmType) {
   expect(edmToTs('INF', edmType)).toBe(Number.POSITIVE_INFINITY);
   expect(edmToTs('-INF', edmType)).toBe(Number.NEGATIVE_INFINITY);
   expect(edmToTs('NaN', edmType)).toBe(Number.NaN);
 }
 
-function checkInfinityCasesRoundTrip(edmType:EdmType){
-  ['INF','-INF','NaN'].forEach(s=>expect(tsToEdm(edmToTs(s, edmType), edmType)).toBe(
-    s
-  ))
+function checkInfinityCasesRoundTrip(edmType: EdmType) {
+  ['NaN'].forEach(s => expect(tsToEdm(edmToTs(s, edmType), edmType)).toBe(s));
 }


### PR DESCRIPTION
## Context

we found a mistake in the code that for the conversion from the TS representation to edmx also the parseNumber method was used. This is not correct since the values 'INF','-INF' and 'NaN' are casted to Number.POSITIVE_INFINITY etc. So one needs a different conversion method to bring the number values back to the 'INF','-INF' and 'Nan' value. This fix provides this fix.

## Definition of Done

Please consider all items and remove only if not applicable.

- [x] Tests created/adjusted for your changes.
- [x] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [x] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [x] If applicable: Properly documented (JSDoc of public API)
- [x] If applicable: Check if `node run doc` still works.
