### PR TITLE
fix: there should not be a if-match key in the header as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ## Fixed Issues
 
-- Fix an error that `if-match:false` is used as default in the header, which is now removed.
+- Fix setting ETags, when no ETag was specified by sending no `if-match` header instead of `if-match:false`.
 
 
 # 1.24.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ## Fixed Issues
 
--
+- Fix an error that `if-match:false` is used as default in the header, which is now removed.
 
 
 # 1.24.0

--- a/packages/core/src/odata/common/request/odata-request.ts
+++ b/packages/core/src/odata/common/request/odata-request.ts
@@ -213,9 +213,11 @@ export class ODataRequest<RequestConfigT extends ODataRequestConfig> {
   }
 
   private getETagHeader(): MapType<string> {
-    const eTag =
-      isWithETag(this.config) &&
-      (this.config.versionIdentifierIgnored ? '*' : this.config.eTag);
+    const eTag = isWithETag(this.config)
+      ? this.config.versionIdentifierIgnored
+        ? '*'
+        : this.config.eTag
+      : undefined;
     return filterNullishValues({ 'if-match': eTag });
   }
 

--- a/packages/core/test/request-builder/odata-request.spec.ts
+++ b/packages/core/test/request-builder/odata-request.spec.ts
@@ -128,12 +128,6 @@ describe('OData Request', () => {
     });
 
     it('request config contains headers without etag value when there is no etag config', async () => {
-      const expectedConfigEntry = {
-        headers: {
-          accept: 'application/json',
-          'content-type': 'application/json'
-        }
-      };
       const destination: Destination = {
         url: 'http://example.com'
       };
@@ -141,7 +135,11 @@ describe('OData Request', () => {
       await createRequest(ODataGetAllRequestConfig, destination).execute();
 
       expect(axios.request).toHaveBeenCalledWith(
-        expect.objectContaining(expectedConfigEntry)
+        expect.objectContaining({
+          headers: expect.not.objectContaining({
+            'if-match': expect.anything()
+          })
+        })
       );
     });
 

--- a/packages/core/test/request-builder/odata-request.spec.ts
+++ b/packages/core/test/request-builder/odata-request.spec.ts
@@ -127,6 +127,24 @@ describe('OData Request', () => {
       requestSpy.mockRestore();
     });
 
+    it('request config contains headers without etag value when there is no etag config', async () => {
+      const expectedConfigEntry = {
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/json'
+        }
+      };
+      const destination: Destination = {
+        url: 'http://example.com'
+      };
+
+      await createRequest(ODataGetAllRequestConfig, destination).execute();
+
+      expect(axios.request).toHaveBeenCalledWith(
+        expect.objectContaining(expectedConfigEntry)
+      );
+    });
+
     it('request config contains httpAgent when destination URL uses "http" as protocol', async () => {
       const expectedConfigEntry = { httpAgent: expect.anything() };
       const httpDestination: Destination = {


### PR DESCRIPTION
## Context

Currently, there is a default etag in the header: `if-match: false`, which breaks e.g., get all request (returns 409) if the OData Service checks this key.
As default behaviour, the key should not be set in the header.

## Definition of Done

Please consider all items and remove only if not applicable.

- [x] Tests created/adjusted for your changes.
- [x] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [x] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [ ] If applicable: Properly documented (JSDoc of public API)
- [ ] If applicable: Check if `node run doc` still works.
