### PR TITLE
fix: Ignore enum properties in complex types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ## Fixed Issues
 
--
+- Ignore enum properties in complex types to fix generation of OData v4 clients.
 
 
 # 1.24.0

--- a/packages/generator/src/parser/common/edmx-to-vdm.ts
+++ b/packages/generator/src/parser/common/edmx-to-vdm.ts
@@ -133,36 +133,39 @@ function properties(
   complexTypes: VdmComplexType[],
   formatter: ServiceNameFormatter
 ): VdmProperty[] {
-  return entity.entityType.Property.filter(filterUnknownEdmTypes).map(p => {
-    checkCollectionKind(p);
-    const swaggerProp = entity.swaggerDefinition
-      ? entity.swaggerDefinition.properties[p.Name]
-      : undefined;
-    const instancePropertyName = formatter.originalToInstancePropertyName(
-      entity.entitySet.Name,
-      p.Name
-    );
-    const type = parseTypeName(p.Type);
-    const isComplex = isComplexType(type);
-    return {
-      originalName: p.Name,
-      instancePropertyName,
-      staticPropertyName: formatter.originalToStaticPropertyName(
+  return entity.entityType.Property.filter(filterUnknownEdmTypes)
+    .map(p => {
+      checkCollectionKind(p);
+      const swaggerProp = entity.swaggerDefinition
+        ? entity.swaggerDefinition.properties[p.Name]
+        : undefined;
+      const instancePropertyName = formatter.originalToInstancePropertyName(
         entity.entitySet.Name,
         p.Name
-      ),
-      propertyNameAsParam: applyPrefixOnJsConfictParam(instancePropertyName),
-      edmType: type,
-      jsType: propertyJsType(type) || complexTypeForName(type, complexTypes),
-      fieldType:
-        propertyFieldType(type) || complexTypeFieldForName(type, complexTypes),
-      description: propertyDescription(p, swaggerProp),
-      nullable: isNullableProperty(p),
-      maxLength: p.MaxLength,
-      isComplex,
-      isCollection: isCollection(p.Type)
-    };
-  });
+      );
+      const type = parseTypeName(p.Type);
+      const isComplex = isComplexType(type);
+      return {
+        originalName: p.Name,
+        instancePropertyName,
+        staticPropertyName: formatter.originalToStaticPropertyName(
+          entity.entitySet.Name,
+          p.Name
+        ),
+        propertyNameAsParam: applyPrefixOnJsConfictParam(instancePropertyName),
+        edmType: type,
+        jsType: propertyJsType(type) || complexTypeForName(type, complexTypes),
+        fieldType:
+          propertyFieldType(type) ||
+          complexTypeFieldForName(type, complexTypes),
+        description: propertyDescription(p, swaggerProp),
+        nullable: isNullableProperty(p),
+        maxLength: p.MaxLength,
+        isComplex,
+        isCollection: isCollection(p.Type)
+      };
+    })
+    .filter(filterEnumProperties);
 }
 
 const propertyFieldType = (type: string): string | undefined =>
@@ -327,6 +330,11 @@ function filterUnknownEdmTypes(p: EdmxProperty): boolean {
   return !skip;
 }
 
+// TODO: this should be removed once Enum types are implemented
+function filterEnumProperties(p: VdmProperty): boolean {
+  return !(p.isComplex && typeof p.jsType === 'undefined');
+}
+
 export function transformComplexTypes(
   complexTypes: EdmxComplexTypeBase[],
   formatter: ServiceNameFormatter,
@@ -346,37 +354,39 @@ export function transformComplexTypes(
       originalName: c.Name,
       factoryName: formatter.typeNameToFactoryName(typeName, reservedNames),
       fieldType: complexTypeFieldType(typeName),
-      properties: c.Property.filter(filterUnknownEdmTypes).map(p => {
-        checkCollectionKind(p);
-        const instancePropertyName = formatter.originalToInstancePropertyName(
-          c.Name,
-          p.Name
-        );
-        const type = parseTypeName(p.Type);
-        const isComplex = isComplexType(type);
-        const parsedType = parseType(type);
-        return {
-          originalName: p.Name,
-          instancePropertyName,
-          staticPropertyName: formatter.originalToStaticPropertyName(
+      properties: c.Property.filter(filterUnknownEdmTypes)
+        .map(p => {
+          checkCollectionKind(p);
+          const instancePropertyName = formatter.originalToInstancePropertyName(
             c.Name,
             p.Name
-          ),
-          propertyNameAsParam: applyPrefixOnJsConfictParam(
-            instancePropertyName
-          ),
-          description: propertyDescription(p),
-          technicalName: p.Name,
-          nullable: isNullableProperty(p),
-          edmType: isComplex ? type : parsedType,
-          jsType: isComplex ? formattedTypes[parsedType] : edmToTsType(type),
-          fieldType: isComplex
-            ? formattedTypes[parsedType] + 'Field'
-            : edmToComplexPropertyType(type),
-          isComplex,
-          isCollection: isCollection(p.Type)
-        };
-      })
+          );
+          const type = parseTypeName(p.Type);
+          const isComplex = isComplexType(type);
+          const parsedType = parseType(type);
+          return {
+            originalName: p.Name,
+            instancePropertyName,
+            staticPropertyName: formatter.originalToStaticPropertyName(
+              c.Name,
+              p.Name
+            ),
+            propertyNameAsParam: applyPrefixOnJsConfictParam(
+              instancePropertyName
+            ),
+            description: propertyDescription(p),
+            technicalName: p.Name,
+            nullable: isNullableProperty(p),
+            edmType: isComplex ? type : parsedType,
+            jsType: isComplex ? formattedTypes[parsedType] : edmToTsType(type),
+            fieldType: isComplex
+              ? formattedTypes[parsedType] + 'Field'
+              : edmToComplexPropertyType(type),
+            isComplex,
+            isCollection: isCollection(p.Type)
+          };
+        })
+        .filter(filterEnumProperties)
     };
   });
 }

--- a/packages/generator/src/parser/common/edmx-to-vdm.ts
+++ b/packages/generator/src/parser/common/edmx-to-vdm.ts
@@ -165,7 +165,7 @@ function properties(
         isCollection: isCollection(p.Type)
       };
     })
-    .filter(filterEnumProperties);
+    .filter(filterUnknownPropertyTypes);
 }
 
 const propertyFieldType = (type: string): string | undefined =>
@@ -331,7 +331,7 @@ function filterUnknownEdmTypes(p: EdmxProperty): boolean {
 }
 
 // TODO: this should be removed once Enum types are implemented
-function filterEnumProperties(p: VdmProperty): boolean {
+function filterUnknownPropertyTypes(p: VdmProperty): boolean {
   return !(p.isComplex && typeof p.jsType === 'undefined');
 }
 
@@ -386,7 +386,7 @@ export function transformComplexTypes(
             isCollection: isCollection(p.Type)
           };
         })
-        .filter(filterEnumProperties)
+        .filter(filterUnknownPropertyTypes)
     };
   });
 }

--- a/test-resources/service-specs/v4/API_TEST_SRV/API_TEST_SRV.edmx
+++ b/test-resources/service-specs/v4/API_TEST_SRV/API_TEST_SRV.edmx
@@ -125,6 +125,7 @@
         <Property Name="ByteProperty" Type="Edm.Byte"/>
         <Property Name="SByteProperty" Type="Edm.SByte"/>
         <Property Name="GeographyPointProperty" Type="Edm.GeographyPoint"/>
+        <Property Name="EnumProperty" Type="API_TEST_SRV.A_TestEnumType"/>
         <Property CollectionKind="List" Name="ComplexTypeProperty" Nullable="true" Type="API_TEST_SRV.A_TestNestedComplexType"/>
       </ComplexType>
 


### PR DESCRIPTION
## Context

Currently we do not yet support enums which breaks the generation of v4 services. This is a hotfix that avoids generating properties that are enum types. Closes #222.

## Definition of Done

Please consider all items and remove only if not applicable.

- [x] Tests created/adjusted for your changes.
- [x] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [x] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [ ] If applicable: Properly documented (JSDoc of public API)
- [ ] If applicable: Check if `node run doc` still works.
