### PR TITLE
chore: Use cache for dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,7 @@ jobs:
       - if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
       - run: find . -name "node_modules"
+      - run: ls node_modules
       - run: npm run lint
         name: Static Code Check
       - run: npm run check:vulnerability

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,7 @@ jobs:
       - uses: actions/cache@v2
         id: cache
         with:
-          path: |
-            */*/node_modules
+          path: ~/.npm
           key: ${{ matrix.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
       - if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
@@ -43,8 +42,7 @@ jobs:
       - uses: actions/cache@v2
         id: cache
         with:
-          path: |
-            ~/.npm
+          path: ~/.npm
           key: ${{ runner.os }}-12.x-${{ hashFiles('**/package-lock.json') }}
       - run: npm ci
       - run: find . -name "node_modules"
@@ -65,8 +63,7 @@ jobs:
       - uses: actions/cache@v2
         id: cache
         with:
-          path: |
-            */*/node_modules
+          path: ~/.npm
           key: ${{ runner.os }}-12.x-${{ hashFiles('**/package-lock.json') }}
       - if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,7 @@ jobs:
           key: ${{ runner.os }}-12.x-${{ hashFiles('**/package-lock.json') }}
       - if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
+      - run: find . -name "node_modules"
       - run: npm run lint
         name: Static Code Check
       - run: npm run check:vulnerability

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         id: cache
         with:
           path: ~/.npm
-          key: ${{ matrix.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ matrix.os }}-${{ hashFiles('**/package-lock.json') }}
       - run: npm ci
       - run: npm run test:unit
       - run: npm run test:integration
@@ -42,7 +42,7 @@ jobs:
         id: cache
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-12.x-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
       - run: npm ci
       - run: npm run lint
         name: Static Code Check
@@ -61,7 +61,7 @@ jobs:
         id: cache
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-12.x-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
       - run: npm ci
       - name: Build odata v4 service
         run: npm run e2e-test:build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,10 +44,9 @@ jobs:
         id: cache
         with:
           path: |
-            */*/node_modules
+            ~/.npm
           key: ${{ runner.os }}-12.x-${{ hashFiles('**/package-lock.json') }}
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: npm ci
+      - run: npm ci
       - run: find . -name "node_modules"
       - run: ls node_modules
       - run: npm run lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,7 @@ jobs:
         with:
           path: ~/.npm
           key: ${{ matrix.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: npm ci
+      - run: npm ci
       - run: npm run test:unit
       - run: npm run test:integration
       - run: npm run test:type
@@ -45,8 +44,6 @@ jobs:
           path: ~/.npm
           key: ${{ runner.os }}-12.x-${{ hashFiles('**/package-lock.json') }}
       - run: npm ci
-      - run: find . -name "node_modules"
-      - run: ls node_modules
       - run: npm run lint
         name: Static Code Check
       - run: npm run check:vulnerability
@@ -65,8 +62,7 @@ jobs:
         with:
           path: ~/.npm
           key: ${{ runner.os }}-12.x-${{ hashFiles('**/package-lock.json') }}
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: npm ci
+      - run: npm ci
       - name: Build odata v4 service
         run: npm run e2e-test:build
       - name: Start odata v4 service

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,13 +40,12 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - run: echo ${{ node-version }}
       - uses: actions/cache@v2
         id: cache
         with:
           path: |
             */*/node_modules
-          key: ${{ runner.os }}-${{ node-version }}-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-12.x-${{ hashFiles('**/package-lock.json') }}
       - if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
       - run: npm run lint
@@ -67,7 +66,7 @@ jobs:
         with:
           path: |
             */*/node_modules
-          key: ${{ runner.os }}-${{ node-version }}-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-12.x-${{ hashFiles('**/package-lock.json') }}
       - if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
       - name: Build odata v4 service

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,14 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm ci
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: |
+            */*/node_modules
+          key: ${{ matrix.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
       - run: npm run test:unit
       - run: npm run test:integration
       - run: npm run test:type
@@ -33,7 +40,15 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - run: npm ci
+      - run: echo ${{ node-version }}
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: |
+            */*/node_modules
+          key: ${{ runner.os }}-${{ node-version }}-${{ hashFiles('**/package-lock.json') }}
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
       - run: npm run lint
         name: Static Code Check
       - run: npm run check:vulnerability
@@ -47,7 +62,14 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - run: npm ci
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: |
+            */*/node_modules
+          key: ${{ runner.os }}-${{ node-version }}-${{ hashFiles('**/package-lock.json') }}
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
       - name: Build odata v4 service
         run: npm run e2e-test:build
       - name: Start odata v4 service


### PR DESCRIPTION
## Context
This PR introduces cache for npm ci to avoid unnecessary downloading.

### which files are chached?
All files under the folder `~/.npm`.

### which parameters are used for computing the cache key?
- `package-lock`s
- os (macos/ubuntu)
- node version

### what's the difference (step level):
- without cache: check `npm ci` step on macos + node 12 [here](https://github.com/SAP/cloud-sdk/runs/872851856?check_suite_focus=true), which took 8+ min
- with cache: check `npm ci` steps [here](https://github.com/SAP/cloud-sdk/runs/872905490?check_suite_focus=true), which never consume 2+ min.

### what's the difference (pipeline level):
If you randomly check a [pipeline](https://github.com/SAP/cloud-sdk/runs/849821360?check_suite_focus=true) that takes 10 min, usually there is an `npm ci` that takes 3 or 4 min or even more like 8 min. This is the bottle neck, since they are running in parallel, only the slowest job is considered. The cache improves the bottle neck, because `npm ci` becomes stable and only 1.x min is needed.

## Definition of Done

Please consider all items and remove only if not applicable.

- [ ] Tests created/adjusted for your changes.
- [ ] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [x] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [ ] If applicable: Properly documented (JSDoc of public API)
- [ ] If applicable: Check if `node run doc` still works.
