### PR TITLE
fix: Improve building speed by using tsc instead of tsc -b

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -23,7 +23,7 @@
   ],
   "repository": "github:SAP/cloud-sdk",
   "scripts": {
-    "compile": "yarn tsc -b",
+    "compile": "yarn tsc",
     "prepare": "yarn compile",
     "test": "yarn jest --coverage --runInBand",
     "test:local": "yarn jest --config ./jest-local.json",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,7 @@
   ],
   "repository": "github:SAP/cloud-sdk",
   "scripts": {
-    "compile": "yarn tsc -b",
+    "compile": "yarn tsc",
     "prepare": "yarn compile",
     "postinstall": "node usage-analytics.js",
     "test": "yarn jest --coverage",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -26,7 +26,7 @@
   ],
   "repository": "github:SAP/cloud-sdk",
   "scripts": {
-    "compile": "yarn tsc -b",
+    "compile": "yarn tsc",
     "prepare": "yarn compile",
     "test": "yarn jest --coverage",
     "test:local": "yarn jest --config ./jest-local.json",

--- a/packages/test-util/package.json
+++ b/packages/test-util/package.json
@@ -23,7 +23,7 @@
   ],
   "repository": "github:SAP/cloud-sdk",
   "scripts": {
-    "compile": "yarn tsc -b",
+    "compile": "yarn tsc",
     "prepare": "yarn compile",
     "test": "yarn jest --coverage --runInBand",
     "test:local": "yarn jest --config ./jest-local.json",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -23,7 +23,7 @@
   ],
   "repository": "github:SAP/cloud-sdk",
   "scripts": {
-    "compile": "yarn tsc -b",
+    "compile": "yarn tsc",
     "prepare": "yarn compile",
     "test": "yarn jest --coverage",
     "test:local": "yarn jest --config ./jest-local.json",

--- a/test-packages/type-tests/package.json
+++ b/test-packages/type-tests/package.json
@@ -8,8 +8,7 @@
   "types": "types",
   "repository": "github:SAP/cloud-sdk",
   "scripts": {
-    "compile:core": "yarn tsc -b test",
-    "test": "yarn compile:core && yarn dtslint test --expectOnly --localTs ../../node_modules/typescript/lib"
+    "test": "yarn dtslint test --expectOnly --localTs ../../node_modules/typescript/lib"
   },
   "dependencies": {
     "@sap-cloud-sdk/core": "^1.25.0",


### PR DESCRIPTION
## Context

The main branch is currently failing because of timeouts. I guess adding the -b flag was not a good idea...

## Definition of Done

Please consider all items and remove only if not applicable.

- [ ] Tests created/adjusted for your changes.
- [ ] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [ ] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [ ] If applicable: Properly documented (JSDoc of public API)
- [ ] If applicable: Check if `node run doc` still works.
