### PR TITLE
Fix: use npm repo with yarn

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@sap:registry=https://npm.sap.com

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,2 @@
+"@sap:registry" "https://npm.sap.com"
+"registry" "https://registry.npmjs.org/"


### PR DESCRIPTION
## Context

The https://registry.yarnpkg.com seems to be flaky: https://github.com/sourcegraph/sourcegraph/pull/926/.
Hence we use the npm repo with yarn.
