### PR TITLE
Fix: Use correct response accessors

### DIFF
--- a/packages/core/src/odata/common/batch-response.ts
+++ b/packages/core/src/odata/common/batch-response.ts
@@ -19,7 +19,7 @@ export interface ReadResponse {
   httpCode: number;
   body: Record<string, any>;
   type: Constructable<EntityBase>;
-  as: <T extends EntityBase>(constructor: Constructable<T>) => T[];
+  as: <T extends EntityBase>(constructor: Constructable<T>) => Error | T[];
   isSuccess: () => boolean;
 }
 

--- a/packages/core/src/odata/v2/request-builder/create-request-builder.ts
+++ b/packages/core/src/odata/v2/request-builder/create-request-builder.ts
@@ -13,6 +13,7 @@ import {
   DestinationNameAndJwt
 } from '../../../scp-cf/destination-service-types';
 import { oDataUri } from '../uri-conversion';
+import { getSingleResult } from './response-data-accessor';
 /**
  * Create OData request to create an entity.
  *
@@ -86,7 +87,7 @@ export class CreateRequestBuilder<EntityT extends Entity>
       .then(request => request.execute())
       .then(response =>
         deserializeEntity(
-          response.data.d,
+          getSingleResult(response.data),
           this._entityConstructor,
           response.headers
         )

--- a/packages/core/src/odata/v2/request-builder/get-all-request-builder.ts
+++ b/packages/core/src/odata/v2/request-builder/get-all-request-builder.ts
@@ -18,6 +18,7 @@ import {
   DestinationNameAndJwt
 } from '../../../scp-cf/destination-service-types';
 import { oDataUri } from '../uri-conversion';
+import { getCollectionResult } from './response-data-accessor';
 
 /**
  * Create OData request to get multiple entities based on the configuration of the request. A `GetAllRequestBuilder` allows to restrict the response in multiple dimensions.
@@ -110,7 +111,7 @@ export class GetAllRequestBuilder<EntityT extends Entity>
     return this.build(destination, options)
       .then(request => request.execute())
       .then(response =>
-        response.data.d.results.map(json =>
+        getCollectionResult(response.data).map(json =>
           deserializeEntity(json, this._entityConstructor, response.headers)
         )
       );

--- a/packages/core/src/odata/v2/request-builder/get-by-key-request-builder.ts
+++ b/packages/core/src/odata/v2/request-builder/get-by-key-request-builder.ts
@@ -16,8 +16,8 @@ import {
 } from '../../../scp-cf/destination-service-types';
 import { MethodRequestBuilderBase } from '../../common/request-builder/request-builder-base';
 import { ODataGetByKeyRequestConfig } from '../../common/request/odata-get-by-key-request-config';
-import { HttpReponse } from '../../../http-client';
 import { oDataUri } from '../uri-conversion';
+import { getSingleResult } from './response-data-accessor';
 /**
  * Create OData request to get a single entity based on its key properties. A `GetByKeyRequestBuilder` allows to restrict the response to a selection of fields,
  * where no selection is equal to selecting all fields.
@@ -69,7 +69,7 @@ export class GetByKeyRequestBuilder<EntityT extends Entity>
       .then(request => request.execute())
       .then(response =>
         deserializeEntity(
-          extractData(response),
+          getSingleResult(response.data),
           this._entityConstructor,
           response.headers
         )
@@ -80,12 +80,4 @@ export class GetByKeyRequestBuilder<EntityT extends Entity>
         )
       );
   }
-}
-
-/*
-C4C response to getByKey requests with the collection response format instead of the single element one
-To account for this, we test for this and use the normal format if `.result` return undefined.
-*/
-function extractData(response: HttpReponse): MapType<any> {
-  return response.data.d.results || response.data.d;
 }

--- a/packages/core/src/odata/v2/request-builder/response-data-accessor.ts
+++ b/packages/core/src/odata/v2/request-builder/response-data-accessor.ts
@@ -1,6 +1,6 @@
 /* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
 
-export function getCollectionResult(data): any[] | any {
+export function getCollectionResult(data): any[]s {
   return data.d.results;
 }
 
@@ -10,7 +10,7 @@ export function isCollectionResult(data): boolean {
 
 export function getSingleResult(data): Record<string, any> {
   return isSingleResultAsCollection(data)
-    ? getCollectionResult(data)
+    ? data.d.results
     : data?.d || {};
 }
 

--- a/packages/core/src/odata/v2/request-builder/response-data-accessor.ts
+++ b/packages/core/src/odata/v2/request-builder/response-data-accessor.ts
@@ -4,11 +4,15 @@ export function getCollectionResult(data): any[] {
   return data.d.results;
 }
 
+export function isCollectionResult(data): boolean {
+  return Array.isArray(data.d.results);
+}
+
 export function getSingleResult(data): Record<string, any> {
-  return isCollectionResponse(data) ? getCollectionResult(data) : data.d;
+  return isSingleResultAsCollection(data) ? getCollectionResult(data) : data.d;
 }
 
 // Workaround to be compatible with services that wrongly implement the OData v2 protocol and serve single responses in the same format as collections
-function isCollectionResponse(data): boolean {
+function isSingleResultAsCollection(data): boolean {
   return data.d.results && Object.keys(data.d).length > 1;
 }

--- a/packages/core/src/odata/v2/request-builder/response-data-accessor.ts
+++ b/packages/core/src/odata/v2/request-builder/response-data-accessor.ts
@@ -1,18 +1,48 @@
 /* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
 
+import { createLogger } from '@sap-cloud-sdk/util';
+
+const logger = createLogger({
+  package: 'core',
+  messageContext: 'response-data-accessor'
+});
+
 export function getCollectionResult(data): any[] {
-  return data.d.results;
+  validateCollectionResult(data);
+  return data.d.results || [];
 }
 
 export function isCollectionResult(data): boolean {
   return Array.isArray(data.d.results);
 }
 
+function validateCollectionResult(data): void {
+  if (!isCollectionResult(data)) {
+    logger.warn(
+      'The given reponse data does not have the standard OData v2 format for collections.'
+    );
+  }
+}
+
 export function getSingleResult(data): Record<string, any> {
+  validateSingleResult(data);
   return isSingleResultAsCollection(data) ? data.d.results : data?.d || {};
 }
 
 // Workaround to be compatible with services that wrongly implement the OData v2 protocol and serve single responses in the same format as collections
 function isSingleResultAsCollection(data): boolean {
   return !!data.d?.results && !isCollectionResult(data);
+}
+
+function validateSingleResult(data): void {
+  if (isSingleResultAsCollection(data)) {
+    logger.warn(
+      'The given reponse data has the format for collections instead of the standard OData v2 format for single results.'
+    );
+  }
+  if (!data?.d) {
+    logger.warn(
+      'The given reponse data does not have the standard OData v2 format for single results.'
+    );
+  }
 }

--- a/packages/core/src/odata/v2/request-builder/response-data-accessor.ts
+++ b/packages/core/src/odata/v2/request-builder/response-data-accessor.ts
@@ -1,6 +1,6 @@
 /* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
 
-export function getCollectionResult(data): any[]s {
+export function getCollectionResult(data): any[] {
   return data.d.results;
 }
 
@@ -9,9 +9,7 @@ export function isCollectionResult(data): boolean {
 }
 
 export function getSingleResult(data): Record<string, any> {
-  return isSingleResultAsCollection(data)
-    ? data.d.results
-    : data?.d || {};
+  return isSingleResultAsCollection(data) ? data.d.results : data?.d || {};
 }
 
 // Workaround to be compatible with services that wrongly implement the OData v2 protocol and serve single responses in the same format as collections

--- a/packages/core/src/odata/v2/request-builder/response-data-accessor.ts
+++ b/packages/core/src/odata/v2/request-builder/response-data-accessor.ts
@@ -9,11 +9,11 @@ const logger = createLogger({
 
 export function getCollectionResult(data): any[] {
   validateCollectionResult(data);
-  return data.d.results || [];
+  return isCollectionResult(data) ? data?.d?.results : [];
 }
 
 export function isCollectionResult(data): boolean {
-  return Array.isArray(data.d.results);
+  return Array.isArray(data?.d?.results);
 }
 
 function validateCollectionResult(data): void {
@@ -26,12 +26,12 @@ function validateCollectionResult(data): void {
 
 export function getSingleResult(data): Record<string, any> {
   validateSingleResult(data);
-  return isSingleResultAsCollection(data) ? data.d.results : data?.d || {};
+  return isSingleResultAsCollection(data) ? data?.d?.results : data?.d || {};
 }
 
 // Workaround to be compatible with services that wrongly implement the OData v2 protocol and serve single responses in the same format as collections
 function isSingleResultAsCollection(data): boolean {
-  return !!data.d?.results && !isCollectionResult(data);
+  return !!data?.d?.results && !isCollectionResult(data);
 }
 
 function validateSingleResult(data): void {

--- a/packages/core/src/odata/v2/request-builder/response-data-accessor.ts
+++ b/packages/core/src/odata/v2/request-builder/response-data-accessor.ts
@@ -1,0 +1,14 @@
+/* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
+
+export function getCollectionResult(data): any[] {
+  return data.d.results;
+}
+
+export function getSingleResult(data): Record<string, any> {
+  return isCollectionResponse(data) ? getCollectionResult(data) : data.d;
+}
+
+// Workaround to be compatible with services that wrongly implement the OData v2 protocol and serve single responses in the same format as collections
+function isCollectionResponse(data): boolean {
+  return data.d.results && Object.keys(data.d).length > 1;
+}

--- a/packages/core/src/odata/v2/request-builder/response-data-accessor.ts
+++ b/packages/core/src/odata/v2/request-builder/response-data-accessor.ts
@@ -1,6 +1,6 @@
 /* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
 
-export function getCollectionResult(data): any[] {
+export function getCollectionResult(data): any[] | any {
   return data.d.results;
 }
 
@@ -9,10 +9,12 @@ export function isCollectionResult(data): boolean {
 }
 
 export function getSingleResult(data): Record<string, any> {
-  return isSingleResultAsCollection(data) ? getCollectionResult(data) : data.d;
+  return isSingleResultAsCollection(data)
+    ? getCollectionResult(data)
+    : data?.d || {};
 }
 
 // Workaround to be compatible with services that wrongly implement the OData v2 protocol and serve single responses in the same format as collections
 function isSingleResultAsCollection(data): boolean {
-  return data.d.results && Object.keys(data.d).length > 1;
+  return !!data.d?.results && !isCollectionResult(data);
 }

--- a/packages/core/src/odata/v2/request-builder/response-transformers.ts
+++ b/packages/core/src/odata/v2/request-builder/response-transformers.ts
@@ -3,6 +3,7 @@
 import { Entity } from '../entity';
 import { deserializeEntity } from '../entity-deserializer';
 import { Constructable } from '../../common';
+import { getSingleResult, getCollectionResult } from './response-data-accessor';
 
 export function transformReturnValueForUndefined<ReturnT>(
   data: any,
@@ -16,7 +17,7 @@ export function transformReturnValueForEntity<ReturnT extends Entity>(
   entityConstructor: Constructable<ReturnT>
 ): ReturnT {
   return deserializeEntity(
-    data.d,
+    getSingleResult(data),
     entityConstructor
   ).setOrInitializeRemoteState() as ReturnT;
 }
@@ -25,7 +26,7 @@ export function transformReturnValueForEntityList<ReturnT extends Entity>(
   data: any,
   entityConstructor: Constructable<ReturnT>
 ): ReturnT[] {
-  return data.d.results.map(
+  return getCollectionResult(data).map(
     entityJson =>
       deserializeEntity(
         entityJson,
@@ -38,26 +39,26 @@ export function transformReturnValueForComplexType<ReturnT>(
   data: any,
   builderFn: (data: any) => ReturnT
 ): ReturnT {
-  return builderFn(data.d) as ReturnT;
+  return builderFn(getSingleResult(data)) as ReturnT;
 }
 
 export function transformReturnValueForComplexTypeList<ReturnT>(
   data: any,
   builderFn: (data: any) => ReturnT
 ): ReturnT[] {
-  return data.d.results.map(json => builderFn(json));
+  return getCollectionResult(data).map(json => builderFn(json));
 }
 
 export function transformReturnValueForEdmType<ReturnT>(
   data: any,
   builderFn: (data: any) => ReturnT
 ): ReturnT {
-  return builderFn(data.d);
+  return builderFn(getSingleResult(data));
 }
 
 export function transformReturnValueForEdmTypeList<ReturnT>(
   data: any,
   builderFn: (data: any) => ReturnT
 ): ReturnT[] {
-  return data.d.results.map(builderFn);
+  return getCollectionResult(data).map(builderFn);
 }

--- a/packages/core/src/odata/v4/odata-batch-request-builder.ts
+++ b/packages/core/src/odata/v4/odata-batch-request-builder.ts
@@ -22,8 +22,8 @@ import { ODataBatchRequestConfig } from '../common/request/odata-batch-request-c
 import { Entity } from './entity';
 import { deserializeEntity } from './entity-deserializer';
 import {
-  ODataBatchChangeSet,
-  toBatchChangeSet
+  toBatchChangeSet,
+  ODataBatchChangeSet
 } from './odata-batch-change-set';
 import { toBatchRetrieveBody } from './odata-batch-retrieve-request';
 import {
@@ -33,6 +33,11 @@ import {
   GetByKeyRequestBuilder,
   UpdateRequestBuilder
 } from './request-builder';
+import {
+  isCollectionResult,
+  getCollectionResult,
+  getSingleResult
+} from './request-builder/response-data-accessor';
 
 const changesetIdPrefix = 'Content-Type: multipart/mixed; boundary=';
 
@@ -209,24 +214,27 @@ function buildResponse(
 
 const asReadResponse = body => <T extends Entity>(
   constructor: Constructable<T>
-) => {
+): Error | T[] => {
   if (body.error) {
     return new Error(body.error);
   }
-  if (body.d.__metadata) {
-    return [deserializeEntity(body.d, constructor)];
+  if (isCollectionResult(body)) {
+    return getCollectionResult(body).map(r =>
+      deserializeEntity(r, constructor)
+    );
   }
-  return body.d.results.map(r => deserializeEntity(r, constructor));
+  return [deserializeEntity(getSingleResult(body), constructor)];
 };
 
 const asWriteResponse = body => <T extends Entity>(
   constructor: Constructable<T>
 ) => {
-  if (!body.d.__metadata) {
+  const resultData = getSingleResult(body);
+  if (!resultData.__metadata) {
     throw Error('The metadata of the response body is undefined.');
   }
 
-  return deserializeEntity(body.d, constructor);
+  return deserializeEntity(resultData, constructor);
 };
 
 /*
@@ -311,7 +319,7 @@ function toConstructableFromChangeSetResponse(
   entityToConstructorMap: MapType<Constructable<Entity>>
 ): Constructable<Entity> | undefined {
   return entityToConstructorMap[
-    getEntityNameFromMetadata(responseBody.d.__metadata)
+    getEntityNameFromMetadata(getSingleResult(responseBody).__metadata)
   ];
 }
 
@@ -319,19 +327,9 @@ function toConstructableFromRetrieveResponse(
   responseBody: any,
   entityToConstructorMap: MapType<Constructable<Entity>>
 ): Constructable<Entity> {
-  let entityJson;
-  const data = responseBody.d;
-
-  if (data.results && data.results.length) {
-    // GetAll
-    entityJson = data.results[0];
-  } else if (data.results && !data.results.length) {
-    // GetByKey C4C (!)
-    entityJson = data.results;
-  } else {
-    // GetByKey
-    entityJson = data;
-  }
+  const entityJson = isCollectionResult(responseBody)
+    ? getCollectionResult(responseBody)[0]
+    : getSingleResult(responseBody);
 
   return entityToConstructorMap[
     getEntityNameFromMetadata(entityJson.__metadata)
@@ -442,7 +440,7 @@ function buildRetrieveOrErrorResponse(
   const httpCode = toHttpCode(response);
   if (httpCode === 200) {
     return {
-      httpCode: 200,
+      httpCode,
       body: parsedBody,
       type: toConstructableFromRetrieveResponse(
         parsedBody,

--- a/packages/core/src/odata/v4/request-builder/create-request-builder.ts
+++ b/packages/core/src/odata/v4/request-builder/create-request-builder.ts
@@ -1,6 +1,6 @@
 /* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
 
-import { errorWithCause, MapType } from '@sap-cloud-sdk/util';
+import { errorWithCause } from '@sap-cloud-sdk/util';
 import { Constructable, EntityIdentifiable, Link } from '../../common';
 import { MethodRequestBuilderBase } from '../../common/request-builder/request-builder-base';
 import { ODataCreateRequestConfig } from '../../common/request/odata-create-request-config';
@@ -13,7 +13,7 @@ import {
   DestinationNameAndJwt
 } from '../../../scp-cf/destination-service-types';
 import { oDataUri } from '../uri-conversion';
-import { HttpReponse } from '../../../http-client';
+import { getSingleResult } from './response-data-accessor';
 /**
  * Create OData request to create an entity.
  *
@@ -87,7 +87,7 @@ export class CreateRequestBuilder<EntityT extends Entity>
       .then(request => request.execute())
       .then(response =>
         deserializeEntity(
-          extractData(response),
+          getSingleResult(response.data),
           this._entityConstructor,
           response.headers
         )
@@ -96,8 +96,4 @@ export class CreateRequestBuilder<EntityT extends Entity>
         Promise.reject(errorWithCause('Create request failed!', error))
       );
   }
-}
-
-function extractData(response: HttpReponse): MapType<any> {
-  return response.data;
 }

--- a/packages/core/src/odata/v4/request-builder/get-all-request-builder.ts
+++ b/packages/core/src/odata/v4/request-builder/get-all-request-builder.ts
@@ -21,6 +21,7 @@ import { ODataGetAllRequestConfig } from '../../common/request/odata-get-all-req
 import { Expandable } from '../../common/expandable';
 import { oDataUri } from '../uri-conversion';
 import { OneToManyLink } from '../../common/selectable/one-to-many-link';
+import { getCollectionResult } from './response-data-accessor';
 
 /**
  * Create OData request to get multiple entities based on the configuration of the request. A `GetAllRequestBuilder` allows to restrict the response in multiple dimensions.
@@ -121,7 +122,7 @@ export class GetAllRequestBuilder<EntityT extends Entity>
     return this.build(destination, options)
       .then(request => request.execute())
       .then(response =>
-        response.data.value.map(json =>
+        getCollectionResult(response.data).map(json =>
           deserializeEntity(json, this._entityConstructor, response.headers)
         )
       );

--- a/packages/core/src/odata/v4/request-builder/get-by-key-request-builder.ts
+++ b/packages/core/src/odata/v4/request-builder/get-by-key-request-builder.ts
@@ -19,6 +19,7 @@ import { ODataGetByKeyRequestConfig } from '../../common/request/odata-get-by-ke
 import { Expandable } from '../../common/expandable';
 import { oDataUri } from '../uri-conversion';
 import { HttpReponse } from '../../../http-client';
+import { getSingleResult } from './response-data-accessor';
 /**
  * Create OData request to get a single entity based on its key properties. A `GetByKeyRequestBuilder` allows to restrict the response to a selection of fields,
  * where no selection is equal to selecting all fields.
@@ -75,7 +76,7 @@ export class GetByKeyRequestBuilder<EntityT extends Entity>
       .then(request => request.execute())
       .then(response =>
         deserializeEntity(
-          extractData(response),
+          getSingleResult(response.data),
           this._entityConstructor,
           response.headers
         )

--- a/packages/core/src/odata/v4/request-builder/response-data-accessor.ts
+++ b/packages/core/src/odata/v4/request-builder/response-data-accessor.ts
@@ -1,13 +1,38 @@
 /* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
 
+import { createLogger } from '@sap-cloud-sdk/util';
+
+const logger = createLogger({
+  package: 'core',
+  messageContext: 'response-data-accessor'
+});
+
 export function getCollectionResult(data): any[] {
-  return data.value;
+  validateCollectionResult(data);
+  return data.value || [];
 }
 
 export function isCollectionResult(data): boolean {
   return Array.isArray(data.value);
 }
 
+function validateCollectionResult(data): void {
+  if (!isCollectionResult(data)) {
+    logger.warn(
+      'The given reponse data does not have the standard OData v4 format for collections.'
+    );
+  }
+}
+
 export function getSingleResult(data): Record<string, any> {
-  return data;
+  validateSingleResult(data);
+  return data || {};
+}
+
+function validateSingleResult(data): void {
+  if (!data) {
+    logger.warn(
+      'The given reponse data does not have the standard OData v4 format for single results.'
+    );
+  }
 }

--- a/packages/core/src/odata/v4/request-builder/response-data-accessor.ts
+++ b/packages/core/src/odata/v4/request-builder/response-data-accessor.ts
@@ -1,0 +1,9 @@
+/* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
+
+export function getCollectionResult(data): any[] {
+  return data.value;
+}
+
+export function getSingleResult(data): Record<string, any> {
+  return data;
+}

--- a/packages/core/src/odata/v4/request-builder/response-data-accessor.ts
+++ b/packages/core/src/odata/v4/request-builder/response-data-accessor.ts
@@ -9,7 +9,7 @@ const logger = createLogger({
 
 export function getCollectionResult(data): any[] {
   validateCollectionResult(data);
-  return data.value || [];
+  return isCollectionResult(data) ? data.value : [];
 }
 
 export function isCollectionResult(data): boolean {
@@ -26,11 +26,15 @@ function validateCollectionResult(data): void {
 
 export function getSingleResult(data): Record<string, any> {
   validateSingleResult(data);
-  return data || {};
+  return isSingleResult(data) ? data : {};
+}
+
+function isSingleResult(data): boolean {
+  return typeof data === 'object' && !Array.isArray(data);
 }
 
 function validateSingleResult(data): void {
-  if (!data) {
+  if (!isSingleResult(data)) {
     logger.warn(
       'The given reponse data does not have the standard OData v4 format for single results.'
     );

--- a/packages/core/src/odata/v4/request-builder/response-data-accessor.ts
+++ b/packages/core/src/odata/v4/request-builder/response-data-accessor.ts
@@ -4,6 +4,10 @@ export function getCollectionResult(data): any[] {
   return data.value;
 }
 
+export function isCollectionResult(data): boolean {
+  return Array.isArray(data.value);
+}
+
 export function getSingleResult(data): Record<string, any> {
   return data;
 }

--- a/packages/core/src/odata/v4/request-builder/response-transformers.ts
+++ b/packages/core/src/odata/v4/request-builder/response-transformers.ts
@@ -3,6 +3,7 @@
 import { Entity } from '../entity';
 import { deserializeEntity } from '../entity-deserializer';
 import { Constructable } from '../../common';
+import { getSingleResult, getCollectionResult } from './response-data-accessor';
 
 export function transformReturnValueForUndefined<ReturnT>(
   data: any,
@@ -16,7 +17,7 @@ export function transformReturnValueForEntity<ReturnT extends Entity>(
   entityConstructor: Constructable<ReturnT>
 ): ReturnT {
   return deserializeEntity(
-    data.d,
+    getSingleResult(data),
     entityConstructor
   ).setOrInitializeRemoteState() as ReturnT;
 }
@@ -25,7 +26,7 @@ export function transformReturnValueForEntityList<ReturnT extends Entity>(
   data: any,
   entityConstructor: Constructable<ReturnT>
 ): ReturnT[] {
-  return data.d.results.map(
+  return getCollectionResult(data).map(
     entityJson =>
       deserializeEntity(
         entityJson,
@@ -38,26 +39,26 @@ export function transformReturnValueForComplexType<ReturnT>(
   data: any,
   builderFn: (data: any) => ReturnT
 ): ReturnT {
-  return builderFn(data.d) as ReturnT;
+  return builderFn(getSingleResult(data)) as ReturnT;
 }
 
 export function transformReturnValueForComplexTypeList<ReturnT>(
   data: any,
   builderFn: (data: any) => ReturnT
 ): ReturnT[] {
-  return data.d.results.map(json => builderFn(json));
+  return getCollectionResult(data).map(json => builderFn(json));
 }
 
 export function transformReturnValueForEdmType<ReturnT>(
   data: any,
   builderFn: (data: any) => ReturnT
 ): ReturnT {
-  return builderFn(data.d);
+  return builderFn(getSingleResult(data));
 }
 
 export function transformReturnValueForEdmTypeList<ReturnT>(
   data: any,
   builderFn: (data: any) => ReturnT
 ): ReturnT[] {
-  return data.d.results.map(builderFn);
+  return getCollectionResult(data).map(builderFn);
 }

--- a/packages/core/test/odata/v2/response-data-accessor.spec.ts
+++ b/packages/core/test/odata/v2/response-data-accessor.spec.ts
@@ -1,0 +1,82 @@
+/* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
+import { createLogger } from '@sap-cloud-sdk/util';
+import {
+  getCollectionResult,
+  isCollectionResult,
+  getSingleResult
+} from '../../../src/odata/v2/request-builder/response-data-accessor';
+
+describe('response data accessor', () => {
+  const logger = createLogger('response-data-accessor');
+  const warnSpy = jest.spyOn(logger, 'warn');
+
+  afterEach(() => {
+    warnSpy.mockClear();
+  });
+
+  describe('getCollectionResult', () => {
+    it('gets data for collection', () => {
+      const results = [1, 2];
+      expect(getCollectionResult({ d: { results } })).toEqual(results);
+    });
+
+    it('gets empty array for non-collection', () => {
+      expect(getCollectionResult({ d: { results: 1 } })).toEqual([]);
+    });
+
+    it('gets empty array for wrong format', () => {
+      expect(getCollectionResult({ d: [1, 2] })).toEqual([]);
+    });
+
+    it('logs warning for wrong format', () => {
+      getCollectionResult({ d: { results: 1 } });
+      expect(warnSpy).toHaveBeenCalledWith(
+        'The given reponse data does not have the standard OData v2 format for collections.'
+      );
+    });
+  });
+
+  describe('isCollectionResult', () => {
+    it('returns true for results array', () => {
+      expect(isCollectionResult({ d: { results: [] } })).toBe(true);
+    });
+
+    it('returns false for result single value', () => {
+      expect(isCollectionResult({ d: { results: 'test' } })).toBe(false);
+    });
+
+    it('returns false for wrong format', () => {
+      expect(isCollectionResult({ d: { test: 'test' } })).toBe(false);
+    });
+  });
+
+  describe('getSingleResult', () => {
+    it('returns single result for correct format', () => {
+      const d = { a: 'b' };
+      expect(getSingleResult({ d })).toEqual(d);
+    });
+
+    it('returns empty object for wrong format', () => {
+      expect(getSingleResult({ c: 'test' })).toEqual({});
+    });
+
+    it('logs warning for wrong format', () => {
+      getSingleResult({ c: 'test' });
+      expect(warnSpy).toHaveBeenCalledWith(
+        'The given reponse data does not have the standard OData v2 format for single results.'
+      );
+    });
+
+    it('returns single result for collection result format', () => {
+      const d = { a: 'b' };
+      expect(getSingleResult({ d: { results: d } })).toEqual(d);
+    });
+
+    it('logs warning for collection result format', () => {
+      getSingleResult({ d: { results: { a: 'b' } } });
+      expect(warnSpy).toHaveBeenCalledWith(
+        'The given reponse data has the format for collections instead of the standard OData v2 format for single results.'
+      );
+    });
+  });
+});

--- a/packages/core/test/odata/v4/response-data-accessor.spec.ts
+++ b/packages/core/test/odata/v4/response-data-accessor.spec.ts
@@ -1,0 +1,70 @@
+/* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
+import { createLogger } from '@sap-cloud-sdk/util';
+import {
+  getCollectionResult,
+  isCollectionResult,
+  getSingleResult
+} from '../../../src/odata/v4/request-builder/response-data-accessor';
+
+describe('response data accessor', () => {
+  const logger = createLogger('response-data-accessor');
+  const warnSpy = jest.spyOn(logger, 'warn');
+
+  afterEach(() => {
+    warnSpy.mockClear();
+  });
+
+  describe('getCollectionResult', () => {
+    it('gets data for collection', () => {
+      const value = [1, 2];
+      expect(getCollectionResult({ value })).toEqual(value);
+    });
+
+    it('gets empty array for non-collection', () => {
+      expect(getCollectionResult({ value: 1 })).toEqual([]);
+    });
+
+    it('gets empty array for wrong format', () => {
+      expect(getCollectionResult({ d: [1, 2] })).toEqual([]);
+    });
+
+    it('logs warning for wrong format', () => {
+      getCollectionResult({ d: { results: 1 } });
+      expect(warnSpy).toHaveBeenCalledWith(
+        'The given reponse data does not have the standard OData v4 format for collections.'
+      );
+    });
+  });
+
+  describe('isCollectionResult', () => {
+    it('returns true for results array', () => {
+      expect(isCollectionResult({ value: [] })).toBe(true);
+    });
+
+    it('returns false for result single value', () => {
+      expect(isCollectionResult({ value: 'test' })).toBe(false);
+    });
+
+    it('returns false for wrong format', () => {
+      expect(isCollectionResult({ d: { test: 'test' } })).toBe(false);
+    });
+  });
+
+  describe('getSingleResult', () => {
+    it('returns single result for correct format', () => {
+      const result = { a: 'b' };
+      expect(getSingleResult(result)).toEqual(result);
+    });
+
+    it('returns empty object for wrong format', () => {
+      expect(getSingleResult('test')).toEqual({});
+    });
+
+    it('logs warning for wrong format', () => {
+      getSingleResult(false);
+      expect(warnSpy).toHaveBeenCalledWith(
+        'The given reponse data does not have the standard OData v4 format for single results.'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Context

Use centralized accessors for OData responses, that are different for v2/v4.

## Definition of Done

Please consider all items and remove only if not applicable.

- [ ] Tests created/adjusted for your changes.
- [ ] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [ ] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [ ] If applicable: Properly documented (JSDoc of public API)
- [ ] If applicable: Check if `node run doc` still works.
