### PR TITLE
fix: Deprecate .npmrc generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ## Compatibility Notes
 
 - In version 1.25.0 we introduced the property `_complexType` on complex types. This property is removed in this version as it introduced a bug causing some generated OData clients to not be able to compile. OData clients generated using version 1.25.0 will be incompatible with future versions of the SAP Cloud SDK.
+- Deprecated the `generateNpmrc` option of the SAP Cloud SDK generator. From now on `@sap` scoped packages do not need the private registry anymore.
 
 ## New Functionality
 

--- a/packages/generator/src/generator-options.ts
+++ b/packages/generator/src/generator-options.ts
@@ -110,9 +110,9 @@ export const generatorOptionsCli: KeysToOptions = {
   },
   generateNpmrc: {
     describe:
-      'By default, the generator will generate a .npmrc file specifying a registry for @sap scoped dependencies. When set to false, the generator will skip the generation of .npmrc.',
+      'Deprecated. If set to true the generator will generate an .npmrc file specifying a registry for @sap scoped dependencies. This is not necessary anymore and will be skipped by default.',
     type: 'boolean',
-    default: true
+    default: false
   },
   generateTypedocJson: {
     describe:


### PR DESCRIPTION
## Context

As in the title + I changed the default of the option in the generator.

## Definition of Done

Please consider all items and remove only if not applicable.

- [ ] Tests created/adjusted for your changes.
- [x] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [x] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [ ] If applicable: Properly documented (JSDoc of public API)
- [ ] If applicable: Check if `node run doc` still works.
