### PR TITLE
Spell out JS/TS

### DIFF
--- a/docs/js/features/connectivity/destination.md
+++ b/docs/js/features/connectivity/destination.md
@@ -1,6 +1,6 @@
 ---
 id: destination-js-sdk
-title: Destinations in the Cloud SDK for JS/TS
+title: Destinations in the SAP Cloud SDK for JavaScript / TypeScript
 hide_title: false
 hide_table_of_contents: false
 sidebar_label: Destinations

--- a/docs/js/features/connectivity/proxy.md
+++ b/docs/js/features/connectivity/proxy.md
@@ -1,6 +1,6 @@
 ---
 id: proxy-js-sdk
-title: Proxies in the Cloud SDK for JS/TS
+title: Proxies in the SAP Cloud SDK for JavaScript / TypeScript
 hide_title: false
 hide_table_of_contents: false
 sidebar_label: Proxies

--- a/docs/js/features/odata/use-generated-client.md
+++ b/docs/js/features/odata/use-generated-client.md
@@ -1,9 +1,9 @@
 ---
 id: use-typed-odata-client-for-javascript-and-typescript
-title: Consume OData clients for JS / TS
+title: Use the OData client for JavaScript / TypeScript
 hide_title: false
 hide_table_of_contents: false
-sidebar_label: Consume OData clients for JS / TS
+sidebar_label: Use the OData client
 description: Use the SAP Cloud SDK for JavaScript to build and run OData requests in a typesafe way.
 keywords:
 - sap


### PR DESCRIPTION
I noticed that our pages for JavaScript are not visited as often. Maybe this fixes a small part of the reason.