### PR TITLE
Fix:  Generator error for services without Entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ## Fixed Issues
 
--
+- [Generator] Skip generation of Batch.ts for services without entities.
 
 
 # 1.27.0

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -215,7 +215,7 @@ export async function generateSourcesForService(
   otherFile(serviceDir, 'tsconfig.json', tsConfig(), options.forceOverwrite);
 
   if (service.entities && service.entities.length > 0) {
-    logger.info(`Generating batch file service: ${service.namespace}...`);
+    logger.info(`Generating batch request builder for: ${service.namespace}...`);
     sourceFile(
       serviceDir,
       'BatchRequest',

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -215,7 +215,9 @@ export async function generateSourcesForService(
   otherFile(serviceDir, 'tsconfig.json', tsConfig(), options.forceOverwrite);
 
   if (service.entities && service.entities.length > 0) {
-    logger.info(`Generating batch request builder for: ${service.namespace}...`);
+    logger.info(
+      `Generating batch request builder for: ${service.namespace}...`
+    );
     sourceFile(
       serviceDir,
       'BatchRequest',

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -214,7 +214,7 @@ export async function generateSourcesForService(
 
   otherFile(serviceDir, 'tsconfig.json', tsConfig(), options.forceOverwrite);
 
-  if(service.entities && service.entities.length > 0) {
+  if (service.entities && service.entities.length > 0) {
     logger.info(`Generating batch file service: ${service.namespace}...`);
     sourceFile(
       serviceDir,

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -214,12 +214,15 @@ export async function generateSourcesForService(
 
   otherFile(serviceDir, 'tsconfig.json', tsConfig(), options.forceOverwrite);
 
-  sourceFile(
-    serviceDir,
-    'BatchRequest',
-    batchSourceFile(service),
-    options.forceOverwrite
-  );
+  if(service.entities && service.entities.length > 0) {
+    logger.info(`Generating batch file service: ${service.namespace}...`);
+    sourceFile(
+      serviceDir,
+      'BatchRequest',
+      batchSourceFile(service),
+      options.forceOverwrite
+    );
+  }
 
   service.entities.forEach(entity => {
     logger.info(`Generating entity: ${entity.className}...`);


### PR DESCRIPTION
## Context

In the VDM we found an error for the `API_PRODUCT_AVAILY_INFO_BASIC` service. This service does not have any entities. Only function imports and some types. In this case the `Batch.ts` files were erroneous. I just skipped the generation of the batch file in this case. 

Should we add an extra test for this? This would mean a edmx without an entity?

## Definition of Done

Please consider all items and remove only if not applicable.

- [ ] Tests created/adjusted for your changes.
- [x] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [x] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
~~- [ ] If applicable: Properly documented (JSDoc of public API)~~
~~- [ ] If applicable: Check if `node run doc` still works.~~
