### PR TITLE
docs: More verbose, but redirects should work now

### DIFF
--- a/docs/java/features/odata/redirect-typed-client.md
+++ b/docs/java/features/odata/redirect-typed-client.md
@@ -11,5 +11,6 @@ keywords:
 ---
 
 import {Redirect} from '@docusaurus/router';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 
-<Redirect to="use-typed-odata-v2-client-in-sap-cloud-sdk-for-java" />
+<Redirect to={useBaseUrl('docs/java/features/odata/use-typed-odata-v2-client-in-sap-cloud-sdk-for-java')} ></Redirect>

--- a/docs/js/features/odata/redirect-generate-typed-odata-v2-and-v4-client-for-javascript-and-typescript.md
+++ b/docs/js/features/odata/redirect-generate-typed-odata-v2-and-v4-client-for-javascript-and-typescript.md
@@ -11,5 +11,6 @@ keywords:
 ---
 
 import {Redirect} from '@docusaurus/router';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 
-<Redirect to="generate-odata-client" />
+<Redirect to={useBaseUrl('docs/js/features/odata/generate-odata-client')} ></Redirect>

--- a/docs/js/features/odata/redirect-generator-js-sdk.md
+++ b/docs/js/features/odata/redirect-generator-js-sdk.md
@@ -11,5 +11,6 @@ keywords:
 ---
 
 import {Redirect} from '@docusaurus/router';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 
-<Redirect to="generate-odata-client" />
+<Redirect to={useBaseUrl('docs/js/features/odata/generate-odata-client')} ></Redirect>

--- a/docs/js/features/odata/redirect-use-typed-odata-client-for-javascript-and-typescript.md
+++ b/docs/js/features/odata/redirect-use-typed-odata-client-for-javascript-and-typescript.md
@@ -11,5 +11,6 @@ keywords:
 ---
 
 import {Redirect} from '@docusaurus/router';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 
-<Redirect to="odata-v2-client" />
+<Redirect to={useBaseUrl('docs/js/features/odata/odata-v2-client')} ></Redirect>

--- a/docs/js/features/odata/redirect-use-typed-odata-client-for-js.md
+++ b/docs/js/features/odata/redirect-use-typed-odata-client-for-js.md
@@ -11,5 +11,6 @@ keywords:
 ---
 
 import {Redirect} from '@docusaurus/router';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 
-<Redirect to="./odata-v2-client" />
+<Redirect to={useBaseUrl('docs/js/features/odata/odata-v2-client')} ></Redirect>

--- a/docs/js/features/odata/redirect-use-typed-odata-v2-client-for-javascript-and-typescript.md
+++ b/docs/js/features/odata/redirect-use-typed-odata-v2-client-for-javascript-and-typescript.md
@@ -11,5 +11,6 @@ keywords:
 ---
 
 import {Redirect} from '@docusaurus/router';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 
-<Redirect to="odata-v2-client" />
+<Redirect to={useBaseUrl('docs/js/features/odata/odata-v2-client')} ></Redirect>

--- a/docs/js/features/odata/redirect-use-typed-odata-v4-client-for-javascript-and-typescript.md
+++ b/docs/js/features/odata/redirect-use-typed-odata-v4-client-for-javascript-and-typescript.md
@@ -11,5 +11,6 @@ keywords:
 ---
 
 import {Redirect} from '@docusaurus/router';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 
-<Redirect to="odata-v4-client" />
+<Redirect to={useBaseUrl('docs/js/features/odata/odata-v4-client')} ></Redirect>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -17,7 +17,7 @@ module.exports = {
       apiKey: '84d46c71e9f2445436400effad7c4e1b',
       indexName: 'sap_cloud-sdk',
       // appId: 'app-id', // Optional, if you run the DocSearch crawler on your own
-      algoliaOptions: {}, // Optional, if provided by Algolia
+      algoliaOptions: {} // Optional, if provided by Algolia
     },
     // ***************************************************************
     // Activate this announcement bar for global urgent notifications
@@ -36,7 +36,7 @@ module.exports = {
         alt: 'SAP Cloud SDK',
         src: 'img/logo.svg'
       },
-    items: [
+      items: [
         {
           to: 'docs/overview/about',
           label: 'Docs',
@@ -174,7 +174,7 @@ module.exports = {
             {
               label: 'Cloud SDK for Java',
               href: 'https://search.maven.org/search?q=g:com.sap.cloud.sdk'
-            },
+            }
           ]
         }
       ],
@@ -198,7 +198,7 @@ module.exports = {
         theme: {
           customCss: require.resolve('./src/css/custom.css')
         },
-        sitempa: {
+        sitemap: {
           cacheTime: 600 * 1000, // 600 sec - cache purge period
           changefreq: 'weekly',
           priority: 0.5

--- a/sidebars.js
+++ b/sidebars.js
@@ -102,7 +102,7 @@ module.exports = {
           'java/guides/manage-dependencies',
           'java/guides/logging-overview',
           'java/guides/tutorial-overview-sdk-java',
-          'java/guides/sap-cloud-sdk-linux-how-to',
+          'java/guides/sap-cloud-sdk-linux-how-to'
           //       'java/how-to/test-odata-service',
           //       'java/how-to/build-client-for-cap',
           //       'java/how-to/cap-with-client-sdk',
@@ -125,7 +125,7 @@ module.exports = {
           'java/video/video-tutorial-about-getting-started-with-sap-cloudsdk-for-java',
           'java/video/video-tutorial-about-type-safe-client-generator-for-odata-with-sap-cloudsdk-for-java',
           'java/video/video-tutorial-about-connectivity--for-odata-with-sap-cloudsdk-for-java'
-        ],
+        ]
       },
       'java/sdk-java-troubleshooting-frequent-problems',
       'java/release-notes-sap-cloud-sdk-for-java',
@@ -164,7 +164,7 @@ module.exports = {
         label: 'Guides',
         items: [
           'js/guides/migrate-to-open-source-version-of-cloud-sdk-for-javascript-typescript'
-        ],
+        ]
       },
       'js/api-reference-js-ts',
       'js/release-notes-sap-cloud-sdk-for-javascript-and-typescript',
@@ -172,7 +172,7 @@ module.exports = {
     ],
     'Continuous Delivery': ['devops/getting-started'],
     // Support: ['support/support'],
-    'Community': ['community/community-call'],
+    Community: ['community/community-call'],
     'Related projects': [
       'related-projects/cloud-application-model',
       'related-projects/sap-xsuaa-security-library-for-javascript-and-java'


### PR DESCRIPTION
## Context

As in the title - I made the redirect more verbose, I don't see a reason why it wouldn't work correctly now...

## Definition of Done

Please consider all items and remove only if not applicable.

- [ ] Tests created/adjusted for your changes.
- [ ] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [ ] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [ ] If applicable: Properly documented (JSDoc of public API)
- [ ] If applicable: Check if `node run doc` still works.
