### PR TITLE
fix: generated index file should not export batch when no batch can be found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ## Fixed Issues
 
--
+- [Generator] Remove `Batch.ts` from the index file when the file does not exist.
 
 
 # 1.28.0
@@ -41,8 +41,8 @@ Blog: TBD<br>
 
 ## Fixed Issues
 
-- [Generator] Skip generation of Batch.ts for services without entities.
-- [RequestBuilder] Fix serialization of "Edm.Time" fields in OData V4. 
+- [Generator] Skip generation of `Batch.ts` for services without entities.
+- [RequestBuilder] Fix serialization of `Edm.Time` fields in OData V4. 
 
 # 1.27.0
 

--- a/packages/generator/src/generator-utils.ts
+++ b/packages/generator/src/generator-utils.ts
@@ -3,7 +3,11 @@
 import { EdmTypeShared } from '@sap-cloud-sdk/core';
 import { createLogger, ODataVersion } from '@sap-cloud-sdk/util';
 import { pipe } from 'rambda';
-import { VdmNavigationProperty, VdmProperty } from './vdm-types';
+import {
+  VdmNavigationProperty,
+  VdmProperty,
+  VdmServiceMetadata
+} from './vdm-types';
 
 const logger = createLogger({
   package: 'generator',
@@ -308,3 +312,7 @@ const makeNpmCompliant = pipe(
 
 const npmMaxLength = 214;
 const npmRegex = /^(?:@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
+
+export function hasBatchRequest(service: VdmServiceMetadata): boolean {
+  return service.entities && service.entities.length > 0;
+}

--- a/packages/generator/src/generator-utils.ts
+++ b/packages/generator/src/generator-utils.ts
@@ -313,6 +313,6 @@ const makeNpmCompliant = pipe(
 const npmMaxLength = 214;
 const npmRegex = /^(?:@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
 
-export function hasBatchRequest(service: VdmServiceMetadata): boolean {
-  return service.entities && service.entities.length > 0;
+export function hasEntities(service: VdmServiceMetadata): boolean {
+  return !!service.entities?.length;
 }

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -25,7 +25,7 @@ import { copyFile, otherFile, sourceFile } from './file-generator';
 import { GeneratorOptions } from './generator-options';
 import {
   cloudSdkVdmHack,
-  hasBatchRequest,
+  hasEntities,
   npmCompliantName
 } from './generator-utils';
 import {
@@ -218,7 +218,7 @@ export async function generateSourcesForService(
 
   otherFile(serviceDir, 'tsconfig.json', tsConfig(), options.forceOverwrite);
 
-  if (hasBatchRequest(service)) {
+  if (hasEntities(service)) {
     logger.info(
       `Generating batch request builder for: ${service.namespace}...`
     );

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -23,7 +23,11 @@ import { complexTypeSourceFile } from './complex-type/file';
 import { entitySourceFile } from './entity/file';
 import { copyFile, otherFile, sourceFile } from './file-generator';
 import { GeneratorOptions } from './generator-options';
-import { cloudSdkVdmHack, npmCompliantName } from './generator-utils';
+import {
+  cloudSdkVdmHack,
+  hasBatchRequest,
+  npmCompliantName
+} from './generator-utils';
 import {
   genericDescription,
   s4hanaCloudDescription
@@ -214,7 +218,7 @@ export async function generateSourcesForService(
 
   otherFile(serviceDir, 'tsconfig.json', tsConfig(), options.forceOverwrite);
 
-  if (service.entities && service.entities.length > 0) {
+  if (hasBatchRequest(service)) {
     logger.info(
       `Generating batch request builder for: ${service.namespace}...`
     );

--- a/packages/generator/src/service/index-file.ts
+++ b/packages/generator/src/service/index-file.ts
@@ -6,26 +6,24 @@ import {
   StructureKind
 } from 'ts-morph';
 import { VdmServiceMetadata } from '../vdm-types';
-import { hasBatchRequest } from '../generator-utils';
+import { hasEntities } from '../generator-utils';
 
 export function indexFile(service: VdmServiceMetadata): SourceFileStructure {
-  const basicStatements = [
-    ...service.entities.map(entity => exportStatement(entity.className)),
-    ...service.entities.map(entity =>
-      exportStatement(`${entity.className}RequestBuilder`)
-    ),
-    ...service.complexTypes.map(complexType =>
-      exportStatement(complexType.typeName)
-    ),
-    ...(service.functionImports && service.functionImports.length
-      ? [exportStatement('function-imports')]
-      : [])
-  ];
   return {
     kind: StructureKind.SourceFile,
-    statements: hasBatchRequest(service)
-      ? [...basicStatements, exportStatement('BatchRequest')]
-      : basicStatements
+    statements: [
+      ...service.entities.map(entity => exportStatement(entity.className)),
+      ...service.entities.map(entity =>
+        exportStatement(`${entity.className}RequestBuilder`)
+      ),
+      ...service.complexTypes.map(complexType =>
+        exportStatement(complexType.typeName)
+      ),
+      ...(service.functionImports && service.functionImports.length
+        ? [exportStatement('function-imports')]
+        : []),
+      ...(hasEntities(service) ? [exportStatement('BatchRequest')] : [])
+    ]
   };
 }
 

--- a/packages/generator/src/service/index-file.ts
+++ b/packages/generator/src/service/index-file.ts
@@ -6,23 +6,26 @@ import {
   StructureKind
 } from 'ts-morph';
 import { VdmServiceMetadata } from '../vdm-types';
+import { hasBatchRequest } from '../generator-utils';
 
 export function indexFile(service: VdmServiceMetadata): SourceFileStructure {
+  const basicStatements = [
+    ...service.entities.map(entity => exportStatement(entity.className)),
+    ...service.entities.map(entity =>
+      exportStatement(`${entity.className}RequestBuilder`)
+    ),
+    ...service.complexTypes.map(complexType =>
+      exportStatement(complexType.typeName)
+    ),
+    ...(service.functionImports && service.functionImports.length
+      ? [exportStatement('function-imports')]
+      : [])
+  ];
   return {
     kind: StructureKind.SourceFile,
-    statements: [
-      ...service.entities.map(entity => exportStatement(entity.className)),
-      ...service.entities.map(entity =>
-        exportStatement(`${entity.className}RequestBuilder`)
-      ),
-      ...service.complexTypes.map(complexType =>
-        exportStatement(complexType.typeName)
-      ),
-      ...(service.functionImports && service.functionImports.length
-        ? [exportStatement('function-imports')]
-        : []),
-      exportStatement('BatchRequest')
-    ]
+    statements: hasBatchRequest(service)
+      ? basicStatements.concat(exportStatement('BatchRequest'))
+      : basicStatements
   };
 }
 

--- a/packages/generator/src/service/index-file.ts
+++ b/packages/generator/src/service/index-file.ts
@@ -24,7 +24,7 @@ export function indexFile(service: VdmServiceMetadata): SourceFileStructure {
   return {
     kind: StructureKind.SourceFile,
     statements: hasBatchRequest(service)
-      ? basicStatements.concat(exportStatement('BatchRequest'))
+      ? [...basicStatements, exportStatement('BatchRequest')]
       : basicStatements
   };
 }


### PR DESCRIPTION
## Context

We stopped generating the `Batch.ts` when there is no entity. In this case, the index file should not export the batch.
I manually tested the generated folder for compilation checks, which should be done automatically soon.

## Definition of Done

Please consider all items and remove only if not applicable.

- [ ] Tests created/adjusted for your changes.
- [ ] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [x] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [ ] If applicable: Properly documented (JSDoc of public API)
- [ ] If applicable: Check if `node run doc` still works.
