### PR TITLE
fix: use full url for linking to api doc

### DIFF
--- a/docs/js/features/odata/odata-v4-client.mdx
+++ b/docs/js/features/odata/odata-v4-client.mdx
@@ -24,7 +24,7 @@ For more details on **how to execute requests** using a (pre-)generated OData cl
 
 #### Filter on One-To-Many Navigation Properties
 
-OData V4 introduces [lambda operators](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#sec_LambdaOperators) e.g., `any`/`all`, so that the root property of the one-to-many navigation properties can be filtered. Below is an example that demonstrates how to use the lambda operator [any](pathname:///api/1.28.1/modules/sap_cloud_sdk_core#any).
+OData V4 introduces [lambda operators](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#sec_LambdaOperators) e.g., `any`/`all`, so that the root property of the one-to-many navigation properties can be filtered. Below is an example that demonstrates how to use the lambda operator [any](https://sap.github.io/cloud-sdk/api/1.28.1/modules/sap_cloud_sdk_core#any).
 
 ```ts
 /*

--- a/docs/js/features/odata/odata-v4-client.mdx
+++ b/docs/js/features/odata/odata-v4-client.mdx
@@ -12,8 +12,6 @@ keywords:
 - consume
 ---
 
-import useBaseUrl from '@docusaurus/useBaseUrl';
-
 :::danger OData v4 is experimental and not ready for production
 Typed client for OData v4 is under heavy development and was released only as `experimental/Beta`. Please, use it on you own discretion. We'll explicitly communicate in the release notes when it's stable and general availability.
 :::
@@ -26,7 +24,7 @@ For more details on **how to execute requests** using a (pre-)generated OData cl
 
 #### Filter on One-To-Many Navigation Properties
 
-OData V4 introduces the [lambda operators](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#sec_LambdaOperators) e.g., `any`/`all`, so that the root property of the one-to-many navigation properties can be filtered. Below is an example that demonstrates how to use the lambda operator [any]({useBaseUrl(/api/1.28.1/modules/sap_cloud_sdk_core#any)}).
+OData V4 introduces the [lambda operators](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#sec_LambdaOperators) e.g., `any`/`all`, so that the root property of the one-to-many navigation properties can be filtered. Below is an example that demonstrates how to use the lambda operator [any](https://sap.github.io/cloud-sdk/api/1.28.1/modules/sap_cloud_sdk_core#any).
 
 ```ts
 /*

--- a/docs/js/features/odata/odata-v4-client.mdx
+++ b/docs/js/features/odata/odata-v4-client.mdx
@@ -24,7 +24,7 @@ For more details on **how to execute requests** using a (pre-)generated OData cl
 
 #### Filter on One-To-Many Navigation Properties
 
-OData V4 introduces the [lambda operators](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#sec_LambdaOperators) e.g., `any`/`all`, so that the root property of the one-to-many navigation properties can be filtered. Below is an example that demonstrates how to use the lambda operator [any](https://sap.github.io/cloud-sdk/api/1.28.1/modules/sap_cloud_sdk_core#any).
+OData V4 introduces [lambda operators](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#sec_LambdaOperators) e.g., `any`/`all`, so that the root property of the one-to-many navigation properties can be filtered. Below is an example that demonstrates how to use the lambda operator [any](pathname:///api/1.28.1/modules/sap_cloud_sdk_core#any).
 
 ```ts
 /*


### PR DESCRIPTION
## Context

I made a mistake to commit to the `document` branch directly, which tried to use the `useBaseUrl `.
Switched to the full url.

Here is an related [issue](https://github.com/facebook/docusaurus/issues/3303), saying there can be false positive and how to disable it via config.
However, the config is about to change `navbar/footer` items, which is not applicable in our case.

## Definition of Done

Please consider all items and remove only if not applicable.

- [ ] Tests created/adjusted for your changes.
- [ ] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [ ] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [ ] If applicable: Properly documented (JSDoc of public API)
- [ ] If applicable: Check if `node run doc` still works.
