### PR TITLE
chore: as child of

### DIFF
--- a/test-packages/e2e-tests/test/request-builder.spec.ts
+++ b/test-packages/e2e-tests/test/request-builder.spec.ts
@@ -145,25 +145,6 @@ describe('Request builder test', () => {
     ]);
   });
 
-  it('a', async () => {
-    const entity = TestEntity.builder().keyTestEntity(entityKey).build();
-    const entityLink = TestEntityLink.builder()
-      .keyTestEntityLink(entityLinkKey)
-      .build();
-
-    await TestEntityLink.requestBuilder()
-      .create(entityLink)
-      .asChildOf(entity, TestEntity.TO_MULTI_LINK)
-      .execute(destination);
-
-    // const quried = await queryEntity(entityKey);
-    // expect(quried.toMultiLink.length).toBe(2);
-    // expect(quried.toMultiLink.map(link => link.keyTestEntityLink)).toEqual([
-    //   20,
-    //   30
-    // ]);
-  });
-
   // Only supported in OData 4.01 and CAP is 4.0
   xit('should update an entity including existing related entites', async () => {
     const entity = TestEntity.builder()

--- a/test-packages/e2e-tests/test/request-builder.spec.ts
+++ b/test-packages/e2e-tests/test/request-builder.spec.ts
@@ -87,24 +87,26 @@ describe('Request builder test', () => {
   it('should create an entity and a link as child of the entity', async () => {
     const testEntity = await createEntity(entityKey);
 
-    const entityLink = TestEntityLink.builder().keyTestEntityLink(entityLinkKey)
+    const entityLink = TestEntityLink.builder()
+      .keyTestEntityLink(entityLinkKey)
       .build();
 
-    await TestEntityLink.requestBuilder().create(entityLink)
+    await TestEntityLink.requestBuilder()
+      .create(entityLink)
       .asChildOf(testEntity, TestEntity.TO_MULTI_LINK)
       .execute(destination);
 
     const queried = await queryEntity(entityKey);
 
     expect(queried.dateProperty?.toISOString()).toBe(moment(0).toISOString());
-    expect(queried.toMultiLink).toEqual(expect.arrayContaining([
-      expect.objectContaining(
-        {
+    expect(queried.toMultiLink).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
           keyTestEntityLink: entityLinkKey,
           keyToTestEntity: entityKey
-        }
-      )
-    ]));
+        })
+      ])
+    );
   });
 
   it('should update an entity', async () => {
@@ -144,13 +146,13 @@ describe('Request builder test', () => {
   });
 
   it('a', async () => {
-    const entity = TestEntity.builder()
-      .keyTestEntity(entityKey)
-      .build();
-    const entityLink = TestEntityLink.builder().keyTestEntityLink(entityLinkKey)
+    const entity = TestEntity.builder().keyTestEntity(entityKey).build();
+    const entityLink = TestEntityLink.builder()
+      .keyTestEntityLink(entityLinkKey)
       .build();
 
-    await TestEntityLink.requestBuilder().create(entityLink)
+    await TestEntityLink.requestBuilder()
+      .create(entityLink)
       .asChildOf(entity, TestEntity.TO_MULTI_LINK)
       .execute(destination);
 


### PR DESCRIPTION
## Context

The v4 version of the `asChildOf` does the same thing as the v2. Therefore, as expected, the implementation is there and can be moved to abstract request builder later. The idea of this ticket is then to verify against a real v4 system (CAP). 

## Definition of Done

Please consider all items and remove only if not applicable.

- [x] Tests created/adjusted for your changes.
- [ ] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [x] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [ ] If applicable: Properly documented (JSDoc of public API)
- [ ] If applicable: Check if `node run doc` still works.
