### PR TITLE
[Fix] Renaming to .mdx broke the Documentation Build

### DIFF
--- a/docs/dzen/getting-started.mdx
+++ b/docs/dzen/getting-started.mdx
@@ -100,7 +100,7 @@ git checkout -b java-client-generator-how-to
 
 1. All the documentation resides in the `docs` folder.
 2. Let's start with creating a file containing our _How To_. In my case it will be `java/how-to/generate-client.md`
-3. Use content from this internal [generator how-to](https://github.wdf.sap.corp/MA/sdk/edit/develop/docs/how-to/use-odata-v4.md )
+3. Use content from this internal [generator how-to](https://github.wdf.sap.corp/MA/sdk/edit/develop/docs/how-to/use-odata-v4.mdx)
 4. Add the meta-header and update the fields
 ```markdown
 ---

--- a/docs/java/features/odata/generate-client.mdx
+++ b/docs/java/features/odata/generate-client.mdx
@@ -85,7 +85,7 @@ Regardless of how the generator is invoked the generated code requires some depe
 
 :::caution Lombok and Dependency injection are mandatory!
 Lombok and dependency injections are used by the generated typed OData client classes, that is why they are needed but only with the scope _provided_.
-Furthermore, some common IDEs (e.g. IntelliJ, Eclipse) require plugins to recognize these annotations. See the note on [Missing Getters/Setters](../../troubleshooting.md#compilation-failures-in-generated-odata-vdm-classes)
+Furthermore, some common IDEs (e.g. IntelliJ, Eclipse) require plugins to recognize these annotations. See the note on [Missing Getters/Setters](../../troubleshooting.mdx#compilation-failures-in-generated-odata-vdm-classes)
 :::
 
 ### Using the OData Generator Maven Plugin ###

--- a/docs/java/features/resilience/resilience.mdx
+++ b/docs/java/features/resilience/resilience.mdx
@@ -100,10 +100,10 @@ The decorator allows for three different ways of applying a configuration:
 </tr>
 </tbody></table>
 
-In case your operation should run asynchronously we highly recommend you leverage the `queue` functionality. The decorator will ensure the [Thread Context](../multi-tenancy/thread-context.md) with Tenant and Principal information is propagated correctly to new Threads.
+In case your operation should run asynchronously we highly recommend you leverage the `queue` functionality. The decorator will ensure the [Thread Context](../multi-tenancy/thread-context.mdx) with Tenant and Principal information is propagated correctly to new Threads.
 
 :::note
-Note that the Resilience Decorator will try to propagate the current [Thread Context](../multi-tenancy/thread-context.md) at the _time the decorator is invoked_. This is important when you are decorating a Callable or Supplier and running it later. The Thread Context must be available whenever `decorateCallable` or `decorateSupplier` is evaluated. So if the call to `ResilienceDecorator` should take place asynchronously you should [follow these steps](../multi-tenancy/thread-context.md#running-asynchronous-operations) to ensure the Thread Context is available.
+Note that the Resilience Decorator will try to propagate the current [Thread Context](../multi-tenancy/thread-context.mdx) at the _time the decorator is invoked_. This is important when you are decorating a Callable or Supplier and running it later. The Thread Context must be available whenever `decorateCallable` or `decorateSupplier` is evaluated. So if the call to `ResilienceDecorator` should take place asynchronously you should [follow these steps](../multi-tenancy/thread-context.mdx#running-asynchronous-operations) to ensure the Thread Context is available.
 :::
 
 #### Failures and Fallbacks

--- a/docs/java/getting-started.mdx
+++ b/docs/java/getting-started.mdx
@@ -205,7 +205,7 @@ This is helpful when you are facing an issue and are reaching out to us for help
 
 In general, the Cloud SDK for Java integrates natively into the [Spring Boot](https://spring.io/projects/spring-boot) and [TomEE](https://tomee.apache.org/) frameworks.
 
-In particular the [SDK provides listeners](features/multi-tenancy/thread-context.md) that can extract tenant and principal information from an incoming request. To ensure these listeners are present please configure your project accordingly.
+In particular the [SDK provides listeners](features/multi-tenancy/thread-context.mdx) that can extract tenant and principal information from an incoming request. To ensure these listeners are present please configure your project accordingly.
 
 <Tabs groupId="frameworks" defaultValue="spring" values={[
 { label: 'Spring', value: 'spring', },

--- a/docs/java/guides/dependencies.mdx
+++ b/docs/java/guides/dependencies.mdx
@@ -77,7 +77,7 @@ We recommend increasing the SDK version in a dedicated change e.g. a pull reques
 Look out for `MethodNotFound` and `ClassDefNotFound` exceptions.
 - They are very typical when a library is provided with an unexpected version.
 
-Check out our [release notes](../release-notes.md).
+Check out our [release notes](../release-notes.mdx).
 - Under improvements you will see all dependency changes.
 
 Use `mvn dependency:tree` to analyze the dependency tree.

--- a/docs/java/troubleshooting.mdx
+++ b/docs/java/troubleshooting.mdx
@@ -97,7 +97,7 @@ Compilation fails due to missing _Getters_ and _Setters_ on entity objects.
 **Possible causes:**
 
 - Conflicting dependency versions may cause such issues.
-  See the section on [Managing Dependencies](guides/dependencies.md#dealing-with-dependency-conflicts).
+  See the section on [Managing Dependencies](guides/dependencies.mdx#dealing-with-dependency-conflicts).
 
 ### Java App has good performance on your local machine but utilizes 100% CPU on SCP Cloud Foundry
 

--- a/docs/js/features/connectivity/destination.mdx
+++ b/docs/js/features/connectivity/destination.mdx
@@ -25,7 +25,7 @@ On SCP this abstraction is provided by a so called destination object.
 This object can be obtained at runtime of the application and contains information like:
 - URL
 - Authentication
-- Proxy Settings (see the [proxy documentation](./proxy.md) for more details)
+- Proxy Settings (see the [proxy documentation](./proxy.mdx) for more details)
 - ...
 
 The SAP Cloud SDK helps you receiving this object and provides also options for local testing outside the SCP.

--- a/docs/js/features/connectivity/on-premise.mdx
+++ b/docs/js/features/connectivity/on-premise.mdx
@@ -31,7 +31,7 @@ Applications which are supposed to access On-Premise systems need a binding to t
 
 ### Connectivity Service ###
 
-As a first step, the SDK [looks up the destination](./destination.md).
+As a first step, the SDK [looks up the destination](./destination.mdx).
 If the `Proxy Type` of the destination is `OnPremise` the SDK will try to establish a connection via the Cloud Connector.
 
 As mentioned above, the application needs a service binding to the connectivity service.
@@ -44,7 +44,7 @@ The SDK takes the client grant to call the connectivity service and receives the
 Then the SDK creates an HTTP agent considering this proxy and the necessary `Proxy-Authorization` headers.
 The proxy is the entry point to the Cloud Connector instance connected the account.
 The proxy is only reachable from the Cloud Foundry space, so you cannot use that flow for applications running outside of Cloud Foundry. 
-The final destination containing the [proxy information](./proxy.md) will look like:
+The final destination containing the [proxy information](./proxy.mdx) will look like:
 
 ```JSON
 {
@@ -60,7 +60,7 @@ proxyConfiguration?: {
   }
 }
 ```
-and will be used by the [HTTP client](../odata/generic-http-client.md) of the SDK to execute the request.
+and will be used by the [HTTP client](../odata/generic-http-client.mdx) of the SDK to execute the request.
 We would like to mention two minor aspects of the SDK.
 
 ### Principal Propagation ### 

--- a/docs/js/features/connectivity/proxy.mdx
+++ b/docs/js/features/connectivity/proxy.mdx
@@ -59,7 +59,7 @@ This proxy will be referred to as `web proxy`.
 ## Manual Configuration ##
 
 In the `execute()` you can either give an object containing the destination name or you can configure the full destination manually.
-If you provide the destination name the SDK will try to lookup as described [here](destination.md).
+If you provide the destination name the SDK will try to lookup as described [here](destination.mdx).
 
 In productive use, the manual configuration will not be useful, but for testing, it might be valuable.
 The destination object contains a field `proxyConfiguration` in which you can configure a proxy.

--- a/docs/js/features/odata/generic-http-client.mdx
+++ b/docs/js/features/odata/generic-http-client.mdx
@@ -34,9 +34,9 @@ The generated payload and URL are passed to the Generic HTTP Client.
 **Generic HTTP Client:** Adds SAP infrastructure specific functionality on top of a standard HTTP Client.
 All OData services use the same generic HTTP client, so it contains no service specific information.
 The client handles connectivity related issues such as:
-- [destination lookup](../connectivity/destination.md) 
-- Connections to [On-Premise](../connectivity/on-premise.md)  system via the connectivity service 
-- [web proxies](../connectivity/proxy.md).
+- [destination lookup](../connectivity/destination.mdx)
+- Connections to [On-Premise](../connectivity/on-premise.mdx)  system via the connectivity service
+- [web proxies](../connectivity/proxy.mdx).
 
 In the end, all information from the destination, connectivity service and proxy configuration ends up in header-fields and [proxy-agents](https://www.npmjs.com/package/proxy-agent).
 The information goes one level down to the Axios client.
@@ -53,7 +53,7 @@ executeHttpRequest(destination, requestConfig)
 ```
 
 The `destination` argument is either a full destination object you have already fetched or an object containing a destination name and JWT.
-In the latter case the SDK [fetches the destination](../connectivity/destination.md) for you.
+In the latter case the SDK [fetches the destination](../connectivity/destination.mdx) for you.
 The [request config](pathname:///api/1.28.1/interfaces/sap_cloud_sdk_core.httprequestconfig) argument contains the request configuration. 
 A minimal config would look like this:
 ```JSON

--- a/docs/js/getting-started.mdx
+++ b/docs/js/getting-started.mdx
@@ -121,7 +121,7 @@ The project contains the following files and folders, among others, to get you s
 #### SDK specific
 
 - **`systems.json`+`credentials.json`**: Allows you to maintain destinations for testing purposes.
-- **`sap-cloud-sdk-analytics.json`**: Only if you have agreed to usage analytics during the initialization of your project. You can find more information about anonymous usage analytics [in the CLI's repository](https://github.com/SAP/cloud-sdk-cli/blob/master/usage-analytics.md).
+- **`sap-cloud-sdk-analytics.json`**: Only if you have agreed to usage analytics during the initialization of your project. You can find more information about anonymous usage analytics [in the CLI's repository](https://github.com/SAP/cloud-sdk-cli/blob/master/usage-analytics.mdx).
 
 
 ## Run the project

--- a/docs/js/guides/bas-external-system.mdx
+++ b/docs/js/guides/bas-external-system.mdx
@@ -116,7 +116,7 @@ The `preLaunchTask` executes the build before each run which compiles the TypeSc
 The `outFiles` properties defines where the compiled files will be located.
 
 As discussed [in the beginning](#background) we need to set the `destinations` environment variable.
-This will interrupt the [destination lookup](../../js/features/connectivity/destination.md) and lead to a destination with the HTTP_PROXY considered. 
+This will interrupt the [destination lookup](../../js/features/connectivity/destination.mdx) and lead to a destination with the HTTP_PROXY considered.
 The easiest way to do that is via a `.env` file which is read when starting the application.
 If you do not have a `.env` file create one or adjust the existing one.
 Just add the following entry to the `.env` file:


### PR DESCRIPTION
## Context

I renamed the .md files consistently to .mdx but this broke the build. This PR tries to fix it.