### PR TITLE
[Chore] Add E2E test for asChildOf

### DIFF
--- a/test-packages/e2e-tests/test/request-builder.spec.ts
+++ b/test-packages/e2e-tests/test/request-builder.spec.ts
@@ -145,18 +145,21 @@ describe('Request builder test', () => {
     ]);
   });
 
-  it('should create an entity with related entities via asChildOf()',async ()=>{
-    const parent = await createEntity(entityKey)
+  it('should create an entity with related entities via asChildOf()', async () => {
+    const parent = await createEntity(entityKey);
     const child = TestEntityLink.builder()
       .keyToTestEntity(entityKey)
       .keyTestEntityLink(20)
-      .build()
+      .build();
 
-    await TestEntityLink.requestBuilder().create(child).asChildOf(parent, TestEntity.TO_MULTI_LINK).execute(destination)
-    const parentWithChild = await queryEntity(entityKey)
-    expect(parentWithChild.toMultiLink.length).toBe(1)
-    expect(parentWithChild.toMultiLink[0].keyTestEntityLink).toBe(20)
-  })
+    await TestEntityLink.requestBuilder()
+      .create(child)
+      .asChildOf(parent, TestEntity.TO_MULTI_LINK)
+      .execute(destination);
+    const parentWithChild = await queryEntity(entityKey);
+    expect(parentWithChild.toMultiLink.length).toBe(1);
+    expect(parentWithChild.toMultiLink[0].keyTestEntityLink).toBe(20);
+  });
 
   // Only supported in OData 4.01 and CAP is 4.0
   xit('should update an entity including existing related entites', async () => {

--- a/test-packages/e2e-tests/test/request-builder.spec.ts
+++ b/test-packages/e2e-tests/test/request-builder.spec.ts
@@ -145,6 +145,19 @@ describe('Request builder test', () => {
     ]);
   });
 
+  it('should create an entity with related entities via asChildOf()',async ()=>{
+    const parent = await createEntity(entityKey)
+    const child = TestEntityLink.builder()
+      .keyToTestEntity(entityKey)
+      .keyTestEntityLink(20)
+      .build()
+
+    await TestEntityLink.requestBuilder().create(child).asChildOf(parent, TestEntity.TO_MULTI_LINK).execute(destination)
+    const parentWithChild = await queryEntity(entityKey)
+    expect(parentWithChild.toMultiLink.length).toBe(1)
+    expect(parentWithChild.toMultiLink[0].keyTestEntityLink).toBe(20)
+  })
+
   // Only supported in OData 4.01 and CAP is 4.0
   xit('should update an entity including existing related entites', async () => {
     const entity = TestEntity.builder()


### PR DESCRIPTION
## Context

I picked the documentation issue for the `asChildOf` functionality. When I was going over the code samples I realized, that we do not have an E2E test for this functionality. So I added a test against the CAP service. Works just fine.
