### PR TITLE
Add chapter about websocket rfc client

### DIFF
--- a/docs/java/features/bapi-and-rfc/overview.mdx
+++ b/docs/java/features/bapi-and-rfc/overview.mdx
@@ -345,6 +345,6 @@ Alternatively, you can pass the system property to the JVM via the Maven plugin 
 ```
 
 ### WebSocket RFC Client Communication
-JCo supports RFC calls from the client side via web sockets as of version `3.1.2`. For this scenario, certain configuration is required within the SAP ERP system
+JCo supports RFC calls from the client-side via web sockets as of version `3.1.2`. For this scenario, a certain configuration is required within the SAP ERP system
 as well as new RFC destination properties must be configured. Download the JCo package from [JCo product website](https://support.sap.com/jco) and check out the contained release notes
 for further details.

--- a/docs/java/features/bapi-and-rfc/overview.mdx
+++ b/docs/java/features/bapi-and-rfc/overview.mdx
@@ -343,3 +343,8 @@ Alternatively, you can pass the system property to the JVM via the Maven plugin 
         <args>-Djco.destinations.dir=here-comes-the-directory-with-the-destination</args>
 ...
 ```
+
+### WebSocket RFC Client Communication
+JCo supports RFC calls from the client side via web sockets as of version `3.1.2`. For this scenario, certain configuration is required within the SAP ERP system
+as well as new RFC destination properties must be configured. Download the JCo package from [JCo product website](https://support.sap.com/jco) and check out the contained release notes
+for further details.


### PR DESCRIPTION
Enhance the existing BAPI documentation about the Web Socket RFC client communication provided with JCo 3.1.2.