### PR TITLE
[Chore] Remove BL security warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
   "dependencies": {},
   "resolutions": {
     "@types/node": "^12.0.0",
-    "dot-prop": "^5.1.1"
+    "dot-prop": "^5.1.1",
+    "tar-stream/**/bl": "^1.2.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2563,10 +2563,10 @@ binary-extensions@^2.0.0:
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz#30fa40c9e7fe07dbc895678cd287024dea241dd9"
   integrity sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==
 
-bl@^1.0.0:
-  version "1.2.2"
-  resolved "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz#a160911717103c07410cef63ef51b397c025af9c"
-  integrity sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==
+bl@^1.0.0, bl@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz#1e8dd80142eac80d7158c9dccc047fb620e035e7"
+  integrity sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==
   dependencies:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"


### PR DESCRIPTION
## Context

we have a security warning due to `bl@1.2.2` which is fixed in version `1.2.3` of `bl`. This comes in via the `dtslint` type test package, so it does not affect any productive situation. But it good to not have this yellow banner every time I open the SDK.

Yarn is very convinient:
- `yarn why bl` tells you why the dependency is installed
- with an entry in the resolution entry `libHavingItAsDependency/libToReplaceVersion: newVersion`  you can overrule the version used.

