### PR TITLE
[Fix] add orderBy in expanded subqueries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 
 ## Fixed Issues
 
+- [OData] Fix `oderBy` parameter in expanded subqueries.
+
 -
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ## Fixed Issues
 
-- [OData] Fix `oderBy` parameter in expanded subqueries.
+- [OData] Fix `$orderby` parameter in expanded subqueries.
 
 -
 

--- a/packages/core/src/odata/v4/uri-conversion/get-expand.ts
+++ b/packages/core/src/odata/v4/uri-conversion/get-expand.ts
@@ -12,6 +12,7 @@ import {
 import { OneToManyLink } from '../../common/selectable/one-to-many-link';
 import { getSelectV4 } from './get-select';
 import { uriConverterV4 } from './uri-value-converter';
+import { oDataUriV4 } from './odata-uri';
 
 function prependDollar(param: string): string {
   return `$${param}`;
@@ -63,7 +64,8 @@ function getExpandAsString<EntityT extends EntityV4>(
           entityConstructor
         ),
         ...(expand._skip && { skip: expand._skip }),
-        ...(expand._top && { top: expand._top })
+        ...(expand._top && { top: expand._top }),
+        ...(expand._orderBy && oDataUriV4.getOrderBy(expand._orderBy))
       };
     }
     const subQuery = Object.entries(params)

--- a/packages/core/test/request-builder/request/v4/get-expand.spec.ts
+++ b/packages/core/test/request-builder/request/v4/get-expand.spec.ts
@@ -52,5 +52,5 @@ const testExpandMultiLink = {
     .top(1)
     .skip(1),
   odataStr:
-    "to_MultiLink($select=StringProperty,BooleanProperty;$filter=(StringProperty eq 'test');$skip=1;$top=1)"
+    "to_MultiLink($select=StringProperty,BooleanProperty;$filter=(StringProperty eq 'test');$skip=1;$top=1;$orderby=StringProperty asc)"
 };


### PR DESCRIPTION
## Context

We did not consider the `orderBy` in expanded subqieries.

## Definition of Done

Please consider all items and remove only if not applicable.

- [x] Tests created/adjusted for your changes.
- [x] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [x] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
~~- [ ] If applicable: Properly documented (JSDoc of public API)~~
~~- [ ] If applicable: Check if `node run doc` still works.~~
