### PR TITLE
[Fix] Response parsing of 1:N relations in C4C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,7 @@
 - [Generator] Generator will fail, when it generates `.ts` files that have compilation errors.
 
 ## Fixed Issues
-
--
-
+- [OData] Fix deserialization of one to many links in C4C where the navigation property is not wrapped in a `result` object.
 
 # 1.28.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ## Fixed Issues
 
-- [OData] Fix deserialization of one to many links in C4C where the navigation property is not wrapped in a `result` object.
+- [OData] Fix deserialization of one to many links, where the navigation property is not wrapped in a `result` object.
 - [OData] Fix `$orderby` parameter in expanded subqueries.
 
 # 1.28.1

--- a/packages/core/src/odata/common/entity-deserializer.ts
+++ b/packages/core/src/odata/common/entity-deserializer.ts
@@ -289,12 +289,12 @@ export function extractCustomFields<EntityT extends EntityBase, JsonT>(
  * @param data - One to many link response data
  * @returns The content of the one to many link
  */
-export function getOneToManyLinkResult(data):any[]{
-  //OData v2 standard
+export function getOneToManyLinkResult(data): any[] {
+  // OData v2 standard
   if (data.results && Array.isArray(data.results)) {
     return data.results;
   }
-  //OData v4 standard and some C4C v2 services
+  // OData v4 standard and some C4C v2 services
   if (Array.isArray(data)) {
     return data;
   }

--- a/packages/core/src/odata/common/entity-deserializer.ts
+++ b/packages/core/src/odata/common/entity-deserializer.ts
@@ -51,7 +51,7 @@ type EdmToTsTypeV4<EdmT extends EdmTypeV4 = any> = (
   edmType: EdmTypeShared<'v4'>
 ) => EdmToPrimitiveV4<EdmT>;
 type ExtractODataETagType = (json: Record<string, any>) => string | undefined;
-type ExtractDataFromOneToManyLinkType = (data: any) => any[] | undefined;
+type ExtractDataFromOneToManyLinkType = (data: any) => any[];
 
 /**
  * Constructs an entityDeserializer given the OData v2 or v4 specific methods.
@@ -157,7 +157,7 @@ export function entityDeserializer<EntityT, JsonT>(
     link: Link<EntityT, LinkedEntityT>
   ): LinkedEntityT[] | undefined {
     if (isSelectedProperty(json, link)) {
-      const results = extractDataFromOneToManyLink(json[link._fieldName]) || [];
+      const results = extractDataFromOneToManyLink(json[link._fieldName]);
       return results.map(linkJson =>
         deserializeEntity(linkJson, link._linkedEntity)
       );

--- a/packages/core/src/odata/common/entity-deserializer.ts
+++ b/packages/core/src/odata/common/entity-deserializer.ts
@@ -63,7 +63,8 @@ type ExtractDataFromOneToManyLinkType = (data: any) => any[] | undefined;
  */
 export function entityDeserializer<EntityT, JsonT>(
   edmToTs: EdmToTsTypeV2 | EdmToTsTypeV4,
-  extractODataETag: ExtractODataETagType
+  extractODataETag: ExtractODataETagType,
+  extractDataFromOneToManyLink: ExtractDataFromOneToManyLinkType
 ): EntityDeserializer {
   /**
    * Converts the JSON payload for a single entity into an instance of the corresponding generated entity class.
@@ -156,7 +157,7 @@ export function entityDeserializer<EntityT, JsonT>(
     link: Link<EntityT, LinkedEntityT>
   ): LinkedEntityT[] | undefined {
     if (isSelectedProperty(json, link)) {
-      const results = getOneToManyLinkResult(json[link._fieldName]);
+      const results = extractDataFromOneToManyLink(json[link._fieldName]) || [];
       return results.map(linkJson =>
         deserializeEntity(linkJson, link._linkedEntity)
       );
@@ -279,24 +280,4 @@ export function extractCustomFields<EntityT extends EntityBase, JsonT>(
       customFields[key] = json[key];
       return customFields;
     }, {});
-}
-
-/**
- * Data extractor for one to many links for v2/v4 entity used in [[entityDeserializer]]
- * It first tries if data.result is an array and returns it.
- * Then it tires if data itself is an array and return it.
- * If both are not the case it returns empty array.
- * @param data - One to many link response data
- * @returns The content of the one to many link
- */
-export function getOneToManyLinkResult(data): any[] {
-  // OData v2 standard
-  if (data.results && Array.isArray(data.results)) {
-    return data.results;
-  }
-  // OData v4 standard and some C4C v2 services
-  if (Array.isArray(data)) {
-    return data;
-  }
-  return [];
 }

--- a/packages/core/src/odata/common/entity-deserializer.ts
+++ b/packages/core/src/odata/common/entity-deserializer.ts
@@ -63,8 +63,7 @@ type ExtractDataFromOneToManyLinkType = (data: any) => any[] | undefined;
  */
 export function entityDeserializer<EntityT, JsonT>(
   edmToTs: EdmToTsTypeV2 | EdmToTsTypeV4,
-  extractODataETag: ExtractODataETagType,
-  extractDataFromOneToManyLink: ExtractDataFromOneToManyLinkType
+  extractODataETag: ExtractODataETagType
 ): EntityDeserializer {
   /**
    * Converts the JSON payload for a single entity into an instance of the corresponding generated entity class.
@@ -157,7 +156,7 @@ export function entityDeserializer<EntityT, JsonT>(
     link: Link<EntityT, LinkedEntityT>
   ): LinkedEntityT[] | undefined {
     if (isSelectedProperty(json, link)) {
-      const results = extractDataFromOneToManyLink(json[link._fieldName]) || [];
+      const results = getOneToManyLinkResult(json[link._fieldName]);
       return results.map(linkJson =>
         deserializeEntity(linkJson, link._linkedEntity)
       );
@@ -280,4 +279,24 @@ export function extractCustomFields<EntityT extends EntityBase, JsonT>(
       customFields[key] = json[key];
       return customFields;
     }, {});
+}
+
+/**
+ * Data extractor for one to many links for v2/v4 entity used in [[entityDeserializer]]
+ * It first tries if data.result is an array and returns it.
+ * Then it tires if data itself is an array and return it.
+ * If both are not the case it returns empty array.
+ * @param data - One to many link response data
+ * @returns The content of the one to many link
+ */
+export function getOneToManyLinkResult(data):any[]{
+  //OData v2 standard
+  if (data.results && Array.isArray(data.results)) {
+    return data.results;
+  }
+  //OData v4 standard and some C4C v2 services
+  if (Array.isArray(data)) {
+    return data;
+  }
+  return [];
 }

--- a/packages/core/src/odata/v2/entity-deserializer.ts
+++ b/packages/core/src/odata/v2/entity-deserializer.ts
@@ -6,6 +6,7 @@ import {
 } from '../common/entity-deserializer';
 import { edmToTsV2 } from './payload-value-converter';
 import { extractODataEtagV2 } from './extract-odata-etag';
+import { extractDataFromOneToManyLink } from './extract-data-from-one-to-many-link';
 
 /**
  * Entity deserializer instance for v2 entities.
@@ -13,7 +14,8 @@ import { extractODataEtagV2 } from './extract-odata-etag';
  */
 const deserializer: EntityDeserializer = entityDeserializer(
   edmToTsV2,
-  extractODataEtagV2
+  extractODataEtagV2,
+  extractDataFromOneToManyLink
 );
 
 export const deserializeEntityV2 = deserializer.deserializeEntity;

--- a/packages/core/src/odata/v2/entity-deserializer.ts
+++ b/packages/core/src/odata/v2/entity-deserializer.ts
@@ -6,7 +6,7 @@ import {
 } from '../common/entity-deserializer';
 import { edmToTsV2 } from './payload-value-converter';
 import { extractODataEtagV2 } from './extract-odata-etag';
-import { extractDataFromOneToManyLink } from './extract-data-from-one-to-many-link';
+import { getLinkedCollectionResult } from './request-builder/response-data-accessor';
 
 /**
  * Entity deserializer instance for v2 entities.
@@ -15,7 +15,7 @@ import { extractDataFromOneToManyLink } from './extract-data-from-one-to-many-li
 const deserializer: EntityDeserializer = entityDeserializer(
   edmToTsV2,
   extractODataEtagV2,
-  extractDataFromOneToManyLink
+  getLinkedCollectionResult
 );
 
 export const deserializeEntityV2 = deserializer.deserializeEntity;

--- a/packages/core/src/odata/v2/entity-deserializer.ts
+++ b/packages/core/src/odata/v2/entity-deserializer.ts
@@ -14,8 +14,7 @@ import { extractDataFromOneToManyLink } from './extract-data-from-one-to-many-li
  */
 const deserializer: EntityDeserializer = entityDeserializer(
   edmToTsV2,
-  extractODataEtagV2,
-  extractDataFromOneToManyLink
+  extractODataEtagV2
 );
 
 export const deserializeEntityV2 = deserializer.deserializeEntity;

--- a/packages/core/src/odata/v2/entity-deserializer.ts
+++ b/packages/core/src/odata/v2/entity-deserializer.ts
@@ -6,7 +6,6 @@ import {
 } from '../common/entity-deserializer';
 import { edmToTsV2 } from './payload-value-converter';
 import { extractODataEtagV2 } from './extract-odata-etag';
-import { extractDataFromOneToManyLink } from './extract-data-from-one-to-many-link';
 
 /**
  * Entity deserializer instance for v2 entities.

--- a/packages/core/src/odata/v2/extract-data-from-one-to-many-link.ts
+++ b/packages/core/src/odata/v2/extract-data-from-one-to-many-link.ts
@@ -2,9 +2,18 @@
 
 /**
  * Data extractor for one to many links for v2 entity used in [[entityDeserializer]]
+ * It first tries if data.result is an array and returns it.
+ * Then it tires if data itself is an array and return it.
+ * If both are not the case it returns undefined
  * @param data - One to many link response data
  * @returns The content of the one to many link
  */
 export function extractDataFromOneToManyLink(data): any[] | undefined {
-  return data.results;
+  if (data.results && Array.isArray(data.results)) {
+    return data.results;
+  }
+  if (Array.isArray(data)) {
+    return data;
+  }
+  return undefined;
 }

--- a/packages/core/src/odata/v2/extract-data-from-one-to-many-link.ts
+++ b/packages/core/src/odata/v2/extract-data-from-one-to-many-link.ts
@@ -2,18 +2,10 @@
 
 /**
  * Data extractor for one to many links for v2 entity used in [[entityDeserializer]]
- * It first tries if data.result is an array and returns it.
- * Then it tires if data itself is an array and return it.
- * If both are not the case it returns undefined
+ * @deprecated since version 1.28.2 use [[getOneToManyLinkResult]] instead
  * @param data - One to many link response data
  * @returns The content of the one to many link
  */
 export function extractDataFromOneToManyLink(data): any[] | undefined {
-  if (data.results && Array.isArray(data.results)) {
-    return data.results;
-  }
-  if (Array.isArray(data)) {
-    return data;
-  }
-  return undefined;
+  return data.results;
 }

--- a/packages/core/src/odata/v2/extract-data-from-one-to-many-link.ts
+++ b/packages/core/src/odata/v2/extract-data-from-one-to-many-link.ts
@@ -1,11 +1,13 @@
 /* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
 
+import { getLinkedCollectionResult } from './request-builder/response-data-accessor';
+
 /**
+ * @deprecated Since v1.28.2. Use [[getLinkedCollectionResult]] instead.
  * Data extractor for one to many links for v2 entity used in [[entityDeserializer]]
- * @deprecated since version 1.28.2 use [[getOneToManyLinkResult]] instead
  * @param data - One to many link response data
  * @returns The content of the one to many link
  */
 export function extractDataFromOneToManyLink(data): any[] | undefined {
-  return data.results;
+  return getLinkedCollectionResult(data);
 }

--- a/packages/core/src/odata/v2/request-builder/response-data-accessor.ts
+++ b/packages/core/src/odata/v2/request-builder/response-data-accessor.ts
@@ -45,7 +45,7 @@ function validateCollectionResult(data): void {
  * @param data - Response of the one to many link
  * @returns any[] - Collection extracted from the response
  */
-export function getLinkedCollectionResult(data): any[] | undefined {
+export function getLinkedCollectionResult(data): any[] {
   if (Array.isArray(data?.results)) {
     return data.results;
   }

--- a/packages/core/src/odata/v2/request-builder/response-data-accessor.ts
+++ b/packages/core/src/odata/v2/request-builder/response-data-accessor.ts
@@ -40,6 +40,19 @@ function validateCollectionResult(data): void {
 }
 
 /**
+ * Extract the collection data from the one to many link response.
+ * If the data does not contain a collection an empty array is returned.
+ * @param data - Response of the one to many link
+ * @returns any[] - Collection extracted from the response
+ */
+export function getLinkedCollectionResult(data): any[] | undefined {
+  if (Array.isArray(data?.results)) {
+    return data.results;
+  }
+  return Array.isArray(data) ? data : [];
+}
+
+/**
  * Checks if the data contains a collection result.
  * @param data - Response of the OData v2 service
  * @returns boolean - true if the data is a collection result

--- a/packages/core/src/odata/v4/entity-deserializer.ts
+++ b/packages/core/src/odata/v4/entity-deserializer.ts
@@ -6,7 +6,6 @@ import {
 } from '../common/entity-deserializer';
 import { edmToTsV4 } from './payload-value-converter';
 import { extractODataEtagV4 } from './extract-odata-etag';
-import { extractDataFromOneToManyLink } from './extract-data-from-one-to-many-link';
 
 /**
  * Entity deserializer instance for v4 entities.

--- a/packages/core/src/odata/v4/entity-deserializer.ts
+++ b/packages/core/src/odata/v4/entity-deserializer.ts
@@ -6,7 +6,7 @@ import {
 } from '../common/entity-deserializer';
 import { edmToTsV4 } from './payload-value-converter';
 import { extractODataEtagV4 } from './extract-odata-etag';
-import { extractDataFromOneToManyLink } from './extract-data-from-one-to-many-link';
+import { getLinkedCollectionResult } from './request-builder/response-data-accessor';
 
 /**
  * Entity deserializer instance for v4 entities.
@@ -15,7 +15,7 @@ import { extractDataFromOneToManyLink } from './extract-data-from-one-to-many-li
 const deserializer: EntityDeserializer = entityDeserializer(
   edmToTsV4,
   extractODataEtagV4,
-  extractDataFromOneToManyLink
+  getLinkedCollectionResult
 );
 
 export const deserializeEntityV4 = deserializer.deserializeEntity;

--- a/packages/core/src/odata/v4/entity-deserializer.ts
+++ b/packages/core/src/odata/v4/entity-deserializer.ts
@@ -14,8 +14,7 @@ import { extractDataFromOneToManyLink } from './extract-data-from-one-to-many-li
  */
 const deserializer: EntityDeserializer = entityDeserializer(
   edmToTsV4,
-  extractODataEtagV4,
-  extractDataFromOneToManyLink
+  extractODataEtagV4
 );
 
 export const deserializeEntityV4 = deserializer.deserializeEntity;

--- a/packages/core/src/odata/v4/entity-deserializer.ts
+++ b/packages/core/src/odata/v4/entity-deserializer.ts
@@ -6,6 +6,7 @@ import {
 } from '../common/entity-deserializer';
 import { edmToTsV4 } from './payload-value-converter';
 import { extractODataEtagV4 } from './extract-odata-etag';
+import { extractDataFromOneToManyLink } from './extract-data-from-one-to-many-link';
 
 /**
  * Entity deserializer instance for v4 entities.
@@ -13,7 +14,8 @@ import { extractODataEtagV4 } from './extract-odata-etag';
  */
 const deserializer: EntityDeserializer = entityDeserializer(
   edmToTsV4,
-  extractODataEtagV4
+  extractODataEtagV4,
+  extractDataFromOneToManyLink
 );
 
 export const deserializeEntityV4 = deserializer.deserializeEntity;

--- a/packages/core/src/odata/v4/extract-data-from-one-to-many-link.ts
+++ b/packages/core/src/odata/v4/extract-data-from-one-to-many-link.ts
@@ -1,11 +1,13 @@
 /* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
 
+import { getLinkedCollectionResult } from './request-builder/response-data-accessor';
+
 /**
+ * @deprecated Since v1.28.2. Use [[getLinkedCollectionResult]] instead.
  * Data extractor for one to many links for v4 entity used in [[entityDeserializer]]
- * @deprecated since version 1.28.2 use [[getOneToManyLinkResult]] instead
  * @param data - One to many link response data
  * @returns The content of the one to many link
  */
 export function extractDataFromOneToManyLink(data): any[] | undefined {
-  return data;
+  return getLinkedCollectionResult(data);
 }

--- a/packages/core/src/odata/v4/extract-data-from-one-to-many-link.ts
+++ b/packages/core/src/odata/v4/extract-data-from-one-to-many-link.ts
@@ -2,6 +2,7 @@
 
 /**
  * Data extractor for one to many links for v4 entity used in [[entityDeserializer]]
+ * @deprecated since version 1.28.2 use [[getOneToManyLinkResult]] instead
  * @param data - One to many link response data
  * @returns The content of the one to many link
  */

--- a/packages/core/src/odata/v4/request-builder/response-data-accessor.ts
+++ b/packages/core/src/odata/v4/request-builder/response-data-accessor.ts
@@ -40,6 +40,16 @@ function validateCollectionResult(data): void {
 }
 
 /**
+ * Extract the collection data from the one to many link response.
+ * If the data does not contain a collection an empty array is returned.
+ * @param data - Response of the one to many link
+ * @returns any[] - Collection extracted from the response
+ */
+export function getLinkedCollectionResult(data): any[] {
+  return Array.isArray(data) ? data : [];
+}
+
+/**
  * Extract the single entry data from the response.
  * If the data does not contain a single object an empty object is returned.
  * @param data - Response of the OData v4 service

--- a/packages/core/test/odata/v2/entity-deserializer.spec.ts
+++ b/packages/core/test/odata/v2/entity-deserializer.spec.ts
@@ -18,7 +18,7 @@ describe('entity-deserializer', () => {
     expect(deserializeEntityV2(response, TestEntity)).toEqual(testEntity);
   });
 
-  it('should build an entity with multi link', () => {
+  it('should build an entity with multi link from response with results object (S/4)', () => {
     const prop = 'test';
     const multiLinkEntity = new TestEntityMultiLink();
     multiLinkEntity.stringProperty = prop;
@@ -29,6 +29,19 @@ describe('entity-deserializer', () => {
       to_MultiLink: {
         results: [{ StringProperty: prop }]
       }
+    };
+    expect(deserializeEntityV2(response, TestEntity)).toEqual(testEntity);
+  });
+
+  it('should build an entity with multi link from response without results object (C4C)', () => {
+    const prop = 'test';
+    const multiLinkEntity = new TestEntityMultiLink();
+    multiLinkEntity.stringProperty = prop;
+    const testEntity = new TestEntity();
+    testEntity.toMultiLink = [multiLinkEntity];
+
+    const response = {
+      to_MultiLink: [{ StringProperty: prop }]
     };
     expect(deserializeEntityV2(response, TestEntity)).toEqual(testEntity);
   });

--- a/packages/core/test/odata/v2/response-data-accessor.spec.ts
+++ b/packages/core/test/odata/v2/response-data-accessor.spec.ts
@@ -3,7 +3,8 @@ import { createLogger } from '@sap-cloud-sdk/util';
 import {
   getCollectionResult,
   isCollectionResult,
-  getSingleResult
+  getSingleResult,
+  getLinkedCollectionResult
 } from '../../../src/odata/v2/request-builder/response-data-accessor';
 
 describe('response data accessor', () => {
@@ -77,6 +78,28 @@ describe('response data accessor', () => {
       expect(warnSpy).toHaveBeenCalledWith(
         'The given reponse data has the format for collections instead of the standard OData v2 format for single results.'
       );
+    });
+  });
+
+  describe('getLinkedCollectionResult', () => {
+    it('returns data for wrapped data (OData v2 spec)', () => {
+      expect(getLinkedCollectionResult({ results: ['a', 'b', 'c'] })).toEqual([
+        'a',
+        'b',
+        'c'
+      ]);
+    });
+
+    it('returns data for non wrapped data (OData v2 C4C)', () => {
+      expect(getLinkedCollectionResult(['a', 'b', 'c'])).toEqual([
+        'a',
+        'b',
+        'c'
+      ]);
+    });
+
+    it('returns empty array as fallback', () => {
+      expect(getLinkedCollectionResult({ a: 'b' })).toEqual([]);
     });
   });
 });

--- a/packages/core/test/odata/v4/response-data-accessor.spec.ts
+++ b/packages/core/test/odata/v4/response-data-accessor.spec.ts
@@ -3,7 +3,8 @@ import { createLogger } from '@sap-cloud-sdk/util';
 import {
   getCollectionResult,
   isCollectionResult,
-  getSingleResult
+  getSingleResult,
+  getLinkedCollectionResult
 } from '../../../src/odata/v4/request-builder/response-data-accessor';
 
 describe('response data accessor', () => {
@@ -65,6 +66,20 @@ describe('response data accessor', () => {
       expect(warnSpy).toHaveBeenCalledWith(
         'The given reponse data does not have the standard OData v4 format for single results.'
       );
+    });
+  });
+
+  describe('getLinkedCollectionResult', () => {
+    it('returns data', () => {
+      expect(getLinkedCollectionResult(['a', 'b', 'c'])).toEqual([
+        'a',
+        'b',
+        'c'
+      ]);
+    });
+
+    it('returns empty array as fallback', () => {
+      expect(getLinkedCollectionResult({ a: 'b' })).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## Context

In general for OData v2 an expanded nav property as the form `{results:[]} i.e. the navigation entities are wrapped in a results object. For C4C this seems to be not the case see here #508 
This PR makes the data extraction more flexible.

## Definition of Done

Please consider all items and remove only if not applicable.

- [x] Tests created/adjusted for your changes.
- [x] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [x] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [x] If applicable: Properly documented (JSDoc of public API)
~~- [ ] If applicable: Check if `node run doc` still works.~~
