### PR TITLE
Response accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ## Fixed Issues
 
-- [OData] Fix deserialization of one to many links in C4C where the navigation property is not wrapped in a `result` object.
+- [OData] Fix deserialization of one to many links, where the navigation property is not wrapped in a `result` object.
 - [OData] Fix `$orderby` parameter in expanded subqueries.
 
 # 1.28.1

--- a/packages/core/src/odata/common/entity-deserializer.ts
+++ b/packages/core/src/odata/common/entity-deserializer.ts
@@ -63,7 +63,8 @@ type ExtractDataFromOneToManyLinkType = (data: any) => any[] | undefined;
  */
 export function entityDeserializer<EntityT, JsonT>(
   edmToTs: EdmToTsTypeV2 | EdmToTsTypeV4,
-  extractODataETag: ExtractODataETagType
+  extractODataETag: ExtractODataETagType,
+  extractDataFromOneToManyLink: ExtractDataFromOneToManyLinkType
 ): EntityDeserializer {
   /**
    * Converts the JSON payload for a single entity into an instance of the corresponding generated entity class.
@@ -156,7 +157,7 @@ export function entityDeserializer<EntityT, JsonT>(
     link: Link<EntityT, LinkedEntityT>
   ): LinkedEntityT[] | undefined {
     if (isSelectedProperty(json, link)) {
-      const results = getOneToManyLinkResult(json[link._fieldName]);
+      const results = extractDataFromOneToManyLink(json[link._fieldName]) || [];
       return results.map(linkJson =>
         deserializeEntity(linkJson, link._linkedEntity)
       );
@@ -279,24 +280,4 @@ export function extractCustomFields<EntityT extends EntityBase, JsonT>(
       customFields[key] = json[key];
       return customFields;
     }, {});
-}
-
-/**
- * Data extractor for one to many links for v2/v4 entity used in [[entityDeserializer]]
- * It first tries if data.result is an array and returns it.
- * Then it tires if data itself is an array and return it.
- * If both are not the case it returns empty array.
- * @param data - One to many link response data
- * @returns The content of the one to many link
- */
-export function getOneToManyLinkResult(data):any[]{
-  //OData v2 standard
-  if (data.results && Array.isArray(data.results)) {
-    return data.results;
-  }
-  //OData v4 standard and some C4C v2 services
-  if (Array.isArray(data)) {
-    return data;
-  }
-  return [];
 }

--- a/packages/core/src/odata/common/entity-deserializer.ts
+++ b/packages/core/src/odata/common/entity-deserializer.ts
@@ -289,12 +289,12 @@ export function extractCustomFields<EntityT extends EntityBase, JsonT>(
  * @param data - One to many link response data
  * @returns The content of the one to many link
  */
-export function getOneToManyLinkResult(data): any[] {
-  // OData v2 standard
+export function getOneToManyLinkResult(data):any[]{
+  //OData v2 standard
   if (data.results && Array.isArray(data.results)) {
     return data.results;
   }
-  // OData v4 standard and some C4C v2 services
+  //OData v4 standard and some C4C v2 services
   if (Array.isArray(data)) {
     return data;
   }

--- a/packages/core/src/odata/v2/entity-deserializer.ts
+++ b/packages/core/src/odata/v2/entity-deserializer.ts
@@ -6,6 +6,7 @@ import {
 } from '../common/entity-deserializer';
 import { edmToTsV2 } from './payload-value-converter';
 import { extractODataEtagV2 } from './extract-odata-etag';
+import { extractDataFromOneToManyLink } from './extract-data-from-one-to-many-link';
 
 /**
  * Entity deserializer instance for v2 entities.

--- a/packages/core/src/odata/v2/entity-deserializer.ts
+++ b/packages/core/src/odata/v2/entity-deserializer.ts
@@ -14,7 +14,8 @@ import { extractDataFromOneToManyLink } from './extract-data-from-one-to-many-li
  */
 const deserializer: EntityDeserializer = entityDeserializer(
   edmToTsV2,
-  extractODataEtagV2
+  extractODataEtagV2,
+  extractDataFromOneToManyLink
 );
 
 export const deserializeEntityV2 = deserializer.deserializeEntity;

--- a/packages/core/src/odata/v2/extract-data-from-one-to-many-link.ts
+++ b/packages/core/src/odata/v2/extract-data-from-one-to-many-link.ts
@@ -1,19 +1,13 @@
 /* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
 
+import { getLinkedCollectionResult } from './request-builder/response-data-accessor';
+
 /**
+ * @deprecated Since v1.28.2. Use [[getLinkedCollectionResult]] instead.
  * Data extractor for one to many links for v2 entity used in [[entityDeserializer]]
- * It first tries if data.result is an array and returns it.
- * Then it tires if data itself is an array and return it.
- * If both are not the case it returns undefined
  * @param data - One to many link response data
  * @returns The content of the one to many link
  */
 export function extractDataFromOneToManyLink(data): any[] | undefined {
-  if (data.results && Array.isArray(data.results)) {
-    return data.results;
-  }
-  if (Array.isArray(data)) {
-    return data;
-  }
-  return undefined;
+  return getLinkedCollectionResult(data);
 }

--- a/packages/core/src/odata/v2/extract-data-from-one-to-many-link.ts
+++ b/packages/core/src/odata/v2/extract-data-from-one-to-many-link.ts
@@ -2,10 +2,18 @@
 
 /**
  * Data extractor for one to many links for v2 entity used in [[entityDeserializer]]
- * @deprecated since version 1.28.2 use [[getOneToManyLinkResult]] instead
+ * It first tries if data.result is an array and returns it.
+ * Then it tires if data itself is an array and return it.
+ * If both are not the case it returns undefined
  * @param data - One to many link response data
  * @returns The content of the one to many link
  */
 export function extractDataFromOneToManyLink(data): any[] | undefined {
-  return data.results;
+  if (data.results && Array.isArray(data.results)) {
+    return data.results;
+  }
+  if (Array.isArray(data)) {
+    return data;
+  }
+  return undefined;
 }

--- a/packages/core/src/odata/v2/request-builder/response-data-accessor.ts
+++ b/packages/core/src/odata/v2/request-builder/response-data-accessor.ts
@@ -40,6 +40,19 @@ function validateCollectionResult(data): void {
 }
 
 /**
+ * Extract the collection data from the one to many link response.
+ * If the data does not contain a collection an empty array is returned.
+ * @param data - Response of the one to many link
+ * @returns any[] - Collection extracted from the response
+ */
+export function getLinkedCollectionResult(data): any[] | undefined {
+  if (Array.isArray(data?.results)) {
+    return data.results;
+  }
+  return Array.isArray(data) ? data : [];
+}
+
+/**
  * Checks if the data contains a collection result.
  * @param data - Response of the OData v2 service
  * @returns boolean - true if the data is a collection result

--- a/packages/core/src/odata/v4/entity-deserializer.ts
+++ b/packages/core/src/odata/v4/entity-deserializer.ts
@@ -6,6 +6,7 @@ import {
 } from '../common/entity-deserializer';
 import { edmToTsV4 } from './payload-value-converter';
 import { extractODataEtagV4 } from './extract-odata-etag';
+import { extractDataFromOneToManyLink } from './extract-data-from-one-to-many-link';
 
 /**
  * Entity deserializer instance for v4 entities.

--- a/packages/core/src/odata/v4/entity-deserializer.ts
+++ b/packages/core/src/odata/v4/entity-deserializer.ts
@@ -14,7 +14,8 @@ import { extractDataFromOneToManyLink } from './extract-data-from-one-to-many-li
  */
 const deserializer: EntityDeserializer = entityDeserializer(
   edmToTsV4,
-  extractODataEtagV4
+  extractODataEtagV4,
+  extractDataFromOneToManyLink
 );
 
 export const deserializeEntityV4 = deserializer.deserializeEntity;

--- a/packages/core/src/odata/v4/extract-data-from-one-to-many-link.ts
+++ b/packages/core/src/odata/v4/extract-data-from-one-to-many-link.ts
@@ -2,7 +2,6 @@
 
 /**
  * Data extractor for one to many links for v4 entity used in [[entityDeserializer]]
- * @deprecated since version 1.28.2 use [[getOneToManyLinkResult]] instead
  * @param data - One to many link response data
  * @returns The content of the one to many link
  */

--- a/packages/core/src/odata/v4/extract-data-from-one-to-many-link.ts
+++ b/packages/core/src/odata/v4/extract-data-from-one-to-many-link.ts
@@ -1,10 +1,13 @@
 /* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
 
+import { getLinkedCollectionResult } from './request-builder/response-data-accessor';
+
 /**
+ * @deprecated Since v1.28.2. Use [[getLinkedCollectionResult]] instead.
  * Data extractor for one to many links for v4 entity used in [[entityDeserializer]]
  * @param data - One to many link response data
  * @returns The content of the one to many link
  */
 export function extractDataFromOneToManyLink(data): any[] | undefined {
-  return data;
+  return getLinkedCollectionResult(data);
 }

--- a/packages/core/src/odata/v4/request-builder/response-data-accessor.ts
+++ b/packages/core/src/odata/v4/request-builder/response-data-accessor.ts
@@ -45,7 +45,7 @@ function validateCollectionResult(data): void {
  * @param data - Response of the one to many link
  * @returns any[] - Collection extracted from the response
  */
-export function getLinkedCollectionResult(data): any[] | undefined {
+export function getLinkedCollectionResult(data): any[] {
   return Array.isArray(data) ? data : [];
 }
 

--- a/packages/core/src/odata/v4/request-builder/response-data-accessor.ts
+++ b/packages/core/src/odata/v4/request-builder/response-data-accessor.ts
@@ -40,6 +40,16 @@ function validateCollectionResult(data): void {
 }
 
 /**
+ * Extract the collection data from the one to many link response.
+ * If the data does not contain a collection an empty array is returned.
+ * @param data - Response of the one to many link
+ * @returns any[] - Collection extracted from the response
+ */
+export function getLinkedCollectionResult(data): any[] | undefined {
+  return Array.isArray(data) ? data : [];
+}
+
+/**
  * Extract the single entry data from the response.
  * If the data does not contain a single object an empty object is returned.
  * @param data - Response of the OData v4 service


### PR DESCRIPTION
## Context

This is what I meant with "use the response accessor". I think we should definitely pass the response accessor to the deserializer not some specific functions, but this should happen on a separate ticket. This would only be the first step to have the "data accessing" functionality in one place. I created a separate PR for your branch, @FrankEssenberger, to make it easier for you to see the changes (that I reverted to before my comments and then used the accessor).
