### PR TITLE
chore: Improve auth header warning

### DIFF
--- a/packages/core/src/header-builder/authorization-header.ts
+++ b/packages/core/src/header-builder/authorization-header.ts
@@ -66,7 +66,7 @@ export async function getAuthHeaders(
 
   if (Object.keys(customAuthHeaders).length && hasAuthHeaders(destination)) {
     logger.warn(
-      `You provided authorization headers in the request config, although, your destination '${destination.name}' also provides authorization headers. This might be unintended. The custom headers from the request config will be used.`
+      'Found custom authorization headers. The given destination also provides authorization headers. This might be unintended. The custom headers from the request config will be used.'
     );
   }
   return Object.keys(customAuthHeaders).length

--- a/packages/core/src/header-builder/authorization-header.ts
+++ b/packages/core/src/header-builder/authorization-header.ts
@@ -66,10 +66,7 @@ export async function getAuthHeaders(
 
   if (Object.keys(customAuthHeaders).length && hasAuthHeaders(destination)) {
     logger.warn(
-      'You provided authorization headers in the request config.' +
-        `However, your destination ${destination.name} also provides authorization headers.` +
-        'To have authorization information from both sources is often unintended.' +
-        'The custom headers from the request config will be used.'
+      `You provided authorization headers in the request config, although, your destination '${destination.name}' also provides authorization headers. This might be unintended. The custom headers from the request config will be used.`
     );
   }
   return Object.keys(customAuthHeaders).length

--- a/packages/core/src/odata/common/response-data-accessor.ts
+++ b/packages/core/src/odata/common/response-data-accessor.ts
@@ -1,7 +1,0 @@
-/* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
-
-export interface ResponseDataAccessor {
-  getCollectionResult: (data) => any[];
-  isCollectionResult: (data) => boolean;
-  getSingleResult: (data: any) => Record<string, any>;
-}

--- a/packages/core/src/odata/common/response-data-accessor.ts
+++ b/packages/core/src/odata/common/response-data-accessor.ts
@@ -1,0 +1,7 @@
+/* Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. */
+
+export interface ResponseDataAccessor {
+  getCollectionResult: (data) => any[];
+  isCollectionResult: (data) => boolean;
+  getSingleResult: (data: any) => Record<string, any>;
+}

--- a/packages/core/test/request-builder/header-builder/authorization-header.spec.ts
+++ b/packages/core/test/request-builder/header-builder/authorization-header.spec.ts
@@ -84,9 +84,7 @@ describe('Authorization header builder', () => {
     const warnSpy = jest.spyOn(logger, 'warn');
     buildHeadersForDestination(destination, { authorization: 'SomeThing' });
     expect(warnSpy).toBeCalledWith(
-      expect.stringMatching(
-        /.*To have authorization information from both sources is often unintended.*/
-      )
+      'Found custom authorization headers. The given destination also provides authorization headers. This might be unintended. The custom headers from the request config will be used.'
     );
   });
 


### PR DESCRIPTION
## Context

The warning message had some weird formatting. Also, I got this message, when I passed a destination directly. Those don't have a name so I got a message telling me that the "destination undefined" had auth headers.

In general I think we need to rethink how we go about headers. At the moment this warning also occurs when there are no custom headers set. I guess this is because the generic http client uses them. As this is only a warning, maybe this is low priority.
 
## Definition of Done

Please consider all items and remove only if not applicable.

- [ ] Tests created/adjusted for your changes.
- [ ] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [ ] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [ ] If applicable: Properly documented (JSDoc of public API)
- [ ] If applicable: Check if `node run doc` still works.
