### PR TITLE
chore: Separate basic headers from other dest + csrf headers

### DIFF
--- a/packages/core/src/odata/common/request-builder/request-builder-base.ts
+++ b/packages/core/src/odata/common/request-builder/request-builder-base.ts
@@ -51,15 +51,6 @@ export abstract class MethodRequestBuilderBase<
   }
 
   /**
-   * Create object containing all basic headers for the given request, including custom headers, but excluding destination related and csrf headers.
-   *
-   * @returns Key-value pairs where the key is the name of a header property and the value is the respective value
-   */
-  basicHeaders(): Record<string, any> {
-    return new ODataRequest(this.requestConfig).basicHeaders();
-  }
-
-  /**
    * Add custom headers to the request.
    *
    * @param headers - Key-value pairs denoting additional custom headers

--- a/packages/core/src/odata/common/request-builder/request-builder-base.ts
+++ b/packages/core/src/odata/common/request-builder/request-builder-base.ts
@@ -51,6 +51,15 @@ export abstract class MethodRequestBuilderBase<
   }
 
   /**
+   * Create object containing all basic headers for the given request, including custom headers, but excluding destination related and csrf headers.
+   *
+   * @returns Key-value pairs where the key is the name of a header property and the value is the respective value
+   */
+  basicHeaders(): Record<string, any> {
+    return new ODataRequest(this.requestConfig).basicHeaders();
+  }
+
+  /**
    * Add custom headers to the request.
    *
    * @param headers - Key-value pairs denoting additional custom headers

--- a/packages/core/src/odata/common/request-builder/request-builder-base.ts
+++ b/packages/core/src/odata/common/request-builder/request-builder-base.ts
@@ -47,7 +47,7 @@ export abstract class MethodRequestBuilderBase<
    * @returns The relative url for the request
    */
   relativeUrl(): string {
-    return new ODataRequest(this.requestConfig).relativeUrl();
+    return this.build().relativeUrl();
   }
 
   /**
@@ -84,29 +84,37 @@ export abstract class MethodRequestBuilderBase<
     return this;
   }
 
+  build(): ODataRequest<RequestConfigT>;
+  build(
+    destination: Destination | DestinationNameAndJwt,
+    options?: DestinationRetrievalOptions
+  ): Promise<ODataRequest<RequestConfigT>>;
   /**
    * Build an ODataRequest that holds essential configuration for the service request and executes it.
    *
    * @param destination - Targeted destination on which the request is performed.
    * @param options - Options to employ when fetching destinations.
-   * @returns The OData request executor including the destination configuration.
+   * @returns The OData request executor including the destination configuration, if one was given.
    */
   build(
-    destination: Destination | DestinationNameAndJwt,
+    destination?: Destination | DestinationNameAndJwt,
     options?: DestinationRetrievalOptions
-  ): Promise<ODataRequest<RequestConfigT>> {
-    return useOrFetchDestination(destination, options)
-      .then(dest => {
-        if (!dest) {
-          throw Error(noDestinationErrorMessage(destination));
-        }
-        return new ODataRequest(this.requestConfig, dest);
-      })
-      .catch(error =>
-        Promise.reject(
-          errorWithCause(noDestinationErrorMessage(destination), error)
-        )
-      );
+  ): ODataRequest<RequestConfigT> | Promise<ODataRequest<RequestConfigT>> {
+    if (destination) {
+      return useOrFetchDestination(destination, options)
+        .then(dest => {
+          if (!dest) {
+            throw Error(noDestinationErrorMessage(destination));
+          }
+          return new ODataRequest(this.requestConfig, dest);
+        })
+        .catch(error =>
+          Promise.reject(
+            errorWithCause(noDestinationErrorMessage(destination), error)
+          )
+        );
+    }
+    return new ODataRequest(this.requestConfig);
   }
 }
 

--- a/packages/core/src/odata/common/request/odata-request.ts
+++ b/packages/core/src/odata/common/request/odata-request.ts
@@ -157,14 +157,6 @@ export class ODataRequest<RequestConfigT extends ODataRequestConfig> {
       if (!this.destination) {
         throw Error('The destination is undefined.');
       }
-      const defaultHeaders = replaceDuplicateKeys(
-        filterNullishValues({
-          accept: 'application/json',
-          'content-type': this.config.contentType,
-          ...this.getETagHeader()
-        }),
-        this.config.customHeaders
-      );
 
       const destinationRelatedHeaders = await buildHeadersForDestination(
         this.destination,
@@ -179,14 +171,34 @@ export class ODataRequest<RequestConfigT extends ODataRequestConfig> {
       return {
         ...destinationRelatedHeaders,
         ...csrfHeaders,
-        ...defaultHeaders,
-        ...this.config.customHeaders
+        ...this.basicHeaders()
       };
     } catch (error) {
       return Promise.reject(
         errorWithCause('Constructing headers for OData request failed!', error)
       );
     }
+  }
+
+  /**
+   * Create object containing all basic headers for the given request, including custom headers, but excluding destination related and csrf headers.
+   *
+   * @returns Key-value pairs where the key is the name of a header property and the value is the respective value
+   */
+  basicHeaders(): Record<string, any> {
+    const defaultHeaders = replaceDuplicateKeys(
+      filterNullishValues({
+        accept: 'application/json',
+        'content-type': this.config.contentType,
+        ...this.getETagHeader()
+      }),
+      this.config.customHeaders
+    );
+
+    return {
+      ...defaultHeaders,
+      ...this.config.customHeaders
+    };
   }
 
   /**

--- a/packages/core/src/odata/common/request/odata-request.ts
+++ b/packages/core/src/odata/common/request/odata-request.ts
@@ -172,7 +172,9 @@ export class ODataRequest<RequestConfigT extends ODataRequestConfig> {
       return {
         ...destinationRelatedHeaders,
         ...csrfHeaders,
-        ...this.basicHeaders()
+        ...this.defaultHeaders(),
+        ...this.eTagHeaders(),
+        ...this.customHeaders()
       };
     } catch (error) {
       return Promise.reject(


### PR DESCRIPTION
## Context

Add an extra function that separates the destination and csrf headers from "basic" headers. Those are the only ones relevant for batch.

## Definition of Done

Please consider all items and remove only if not applicable.

- [ ] Tests created/adjusted for your changes.
- [ ] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [ ] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [ ] If applicable: Properly documented (JSDoc of public API)
- [ ] If applicable: Check if `node run doc` still works.
