### PR TITLE
fix: Remove dangerous prepare method

### DIFF
--- a/packages/core/src/odata/v2/request-builder/create-request-builder.ts
+++ b/packages/core/src/odata/v2/request-builder/create-request-builder.ts
@@ -33,6 +33,10 @@ export class CreateRequestBuilderV2<EntityT extends EntityV2>
     readonly _entity: EntityT
   ) {
     super(new ODataCreateRequestConfig(_entityConstructor, oDataUriV2));
+    this.requestConfig.payload = serializeEntityV2(
+      this._entity,
+      this._entityConstructor
+    );
   }
 
   get entity(): EntityT {
@@ -40,8 +44,7 @@ export class CreateRequestBuilderV2<EntityT extends EntityV2>
   }
 
   /**
-   * Builds the payload of the query.
-   *
+   * @deprecated Since v1.29.0. This method should never be called, it has severe side effects.   * Builds the payload of the query.
    * @returns the builder itself
    */
   prepare(): this {
@@ -82,7 +85,6 @@ export class CreateRequestBuilderV2<EntityT extends EntityV2>
     destination: Destination | DestinationNameAndJwt,
     options?: DestinationOptions
   ): Promise<EntityT> {
-    this.prepare();
     return this.build(destination, options)
       .then(request => request.execute())
       .then(response =>

--- a/packages/core/src/odata/v2/request-builder/update-request-builder.ts
+++ b/packages/core/src/odata/v2/request-builder/update-request-builder.ts
@@ -42,11 +42,22 @@ export class UpdateRequestBuilderV2<EntityT extends EntityV2>
     this.requestConfig.eTag = _entity.versionIdentifier;
     this.required = new Set<string>();
     this.ignored = new Set<string>();
+
+    this.requestConfig.keys = oDataUriV2.getEntityKeys(
+      this._entity,
+      this._entityConstructor
+    );
+
+    this.requestConfig.payload = this.getPayload();
+  }
+
+  get entity(): EntityT {
+    return this._entity;
   }
 
   /**
+   * @deprecated Since v1.29.0. This method should never be called, it has severe side effects.
    * Builds the payload and the entity keys of the query.
-   *
    * @returns the builder itself
    */
   prepare(): this {
@@ -55,20 +66,7 @@ export class UpdateRequestBuilderV2<EntityT extends EntityV2>
       this._entityConstructor
     );
 
-    let updateBody;
-    switch (this.requestConfig.method) {
-      case 'put':
-        updateBody = serializeEntityV2(this._entity, this._entityConstructor);
-        break;
-      case 'patch':
-        updateBody = this.getUpdateBody();
-        break;
-      default:
-        throw new Error(
-          `${this.requestConfig.method} is not a valid method of the update request.`
-        );
-    }
-    this.requestConfig.payload = updateBody;
+    this.requestConfig.payload = this.getPayload();
 
     return this;
   }
@@ -84,7 +82,6 @@ export class UpdateRequestBuilderV2<EntityT extends EntityV2>
     destination: Destination | DestinationNameAndJwt,
     options?: DestinationOptions
   ): Promise<EntityT> {
-    this.prepare();
     if (this.isEmptyObject(this.requestConfig.payload)) {
       return this._entity;
     }
@@ -112,6 +109,7 @@ export class UpdateRequestBuilderV2<EntityT extends EntityV2>
    */
   replaceWholeEntityWithPut(): this {
     this.requestConfig.updateWithPut();
+    this.requestConfig.payload = this.getPayload();
     return this;
   }
 
@@ -123,6 +121,7 @@ export class UpdateRequestBuilderV2<EntityT extends EntityV2>
    */
   requiredFields(...fields: Selectable<EntityT>[]): this {
     this.required = this.toSet(...fields);
+    this.requestConfig.payload = this.getPayload();
     return this;
   }
 
@@ -134,6 +133,7 @@ export class UpdateRequestBuilderV2<EntityT extends EntityV2>
    */
   ignoredFields(...fields: Selectable<EntityT>[]): this {
     this.ignored = this.toSet(...fields);
+    this.requestConfig.payload = this.getPayload();
     return this;
   }
 
@@ -158,19 +158,22 @@ export class UpdateRequestBuilderV2<EntityT extends EntityV2>
     return this;
   }
 
-  private getUpdateBody(): Record<string, any> {
+  private getPayload(): Record<string, any> {
     const serializedBody = serializeEntityV2(
       this._entity,
       this._entityConstructor
     );
 
-    return pipe(
-      () => this.serializedDiff(),
-      body => this.removeNavPropsAndComplexTypes(body),
-      body => this.removeKeyFields(body),
-      body => this.addRequiredFields(serializedBody, body),
-      body => this.removeIgnoredFields(body)
-    )();
+    if (this.requestConfig.method === 'patch') {
+      return pipe(
+        () => this.serializedDiff(),
+        body => this.removeNavPropsAndComplexTypes(body),
+        body => this.removeKeyFields(body),
+        body => this.addRequiredFields(serializedBody, body),
+        body => this.removeIgnoredFields(body)
+      )();
+    }
+    return serializedBody;
   }
 
   private serializedDiff(): Record<string, any> {

--- a/packages/core/src/odata/v4/request-builder/create-request-builder.ts
+++ b/packages/core/src/odata/v4/request-builder/create-request-builder.ts
@@ -33,6 +33,11 @@ export class CreateRequestBuilderV4<EntityT extends EntityV4>
     readonly _entity: EntityT
   ) {
     super(new ODataCreateRequestConfig(_entityConstructor, oDataUriV4));
+
+    this.requestConfig.payload = serializeEntityV4(
+      this._entity,
+      this._entityConstructor
+    );
   }
 
   get entity(): EntityT {
@@ -40,8 +45,8 @@ export class CreateRequestBuilderV4<EntityT extends EntityV4>
   }
 
   /**
+   * @deprecated Since v1.29.0. This method should never be called, it has severe side effects.
    * Builds the payload of the query.
-   *
    * @returns the builder itself
    */
   prepare(): this {

--- a/packages/core/src/odata/v4/request-builder/update-request-builder.ts
+++ b/packages/core/src/odata/v4/request-builder/update-request-builder.ts
@@ -42,11 +42,22 @@ export class UpdateRequestBuilderV4<EntityT extends EntityV4>
     this.requestConfig.eTag = _entity.versionIdentifier;
     this.required = new Set<string>();
     this.ignored = new Set<string>();
+
+    this.requestConfig.keys = oDataUriV4.getEntityKeys(
+      this._entity,
+      this._entityConstructor
+    );
+
+    this.requestConfig.payload = this.getPayload();
+  }
+
+  get entity(): EntityT {
+    return this._entity;
   }
 
   /**
+   * @deprecated Since v1.29.0. This method should never be called, it has severe side effects.
    * Builds the payload and the entity keys of the query.
-   *
    * @returns the builder itself
    */
   prepare(): this {
@@ -55,20 +66,7 @@ export class UpdateRequestBuilderV4<EntityT extends EntityV4>
       this._entityConstructor
     );
 
-    let updateBody;
-    switch (this.requestConfig.method) {
-      case 'put':
-        updateBody = serializeEntityV4(this._entity, this._entityConstructor);
-        break;
-      case 'patch':
-        updateBody = this.getUpdateBody();
-        break;
-      default:
-        throw new Error(
-          `${this.requestConfig.method} is not a valid method of the update request.`
-        );
-    }
-    this.requestConfig.payload = updateBody;
+    this.requestConfig.payload = this.getPayload();
 
     return this;
   }
@@ -84,7 +82,6 @@ export class UpdateRequestBuilderV4<EntityT extends EntityV4>
     destination: Destination | DestinationNameAndJwt,
     options?: DestinationOptions
   ): Promise<EntityT> {
-    this.prepare();
     if (this.isEmptyObject(this.requestConfig.payload)) {
       return this._entity;
     }
@@ -112,6 +109,7 @@ export class UpdateRequestBuilderV4<EntityT extends EntityV4>
    */
   replaceWholeEntityWithPut(): this {
     this.requestConfig.updateWithPut();
+    this.requestConfig.payload = this.getPayload();
     return this;
   }
 
@@ -123,6 +121,7 @@ export class UpdateRequestBuilderV4<EntityT extends EntityV4>
    */
   requiredFields(...fields: Selectable<EntityT>[]): this {
     this.required = this.toSet(...fields);
+    this.requestConfig.payload = this.getPayload();
     return this;
   }
 
@@ -134,6 +133,7 @@ export class UpdateRequestBuilderV4<EntityT extends EntityV4>
    */
   ignoredFields(...fields: Selectable<EntityT>[]): this {
     this.ignored = this.toSet(...fields);
+    this.requestConfig.payload = this.getPayload();
     return this;
   }
 
@@ -158,19 +158,22 @@ export class UpdateRequestBuilderV4<EntityT extends EntityV4>
     return this;
   }
 
-  private getUpdateBody(): Record<string, any> {
+  private getPayload(): Record<string, any> {
     const serializedBody = serializeEntityV4(
       this._entity,
       this._entityConstructor
     );
 
-    return pipe(
-      () => this.serializedDiff(),
-      body => this.removeNavPropsAndComplexTypes(body),
-      body => this.removeKeyFields(body),
-      body => this.addRequiredFields(serializedBody, body),
-      body => this.removeIgnoredFields(body)
-    )();
+    if (this.requestConfig.method === 'patch') {
+      return pipe(
+        () => this.serializedDiff(),
+        body => this.removeNavPropsAndComplexTypes(body),
+        body => this.removeKeyFields(body),
+        body => this.addRequiredFields(serializedBody, body),
+        body => this.removeIgnoredFields(body)
+      )();
+    }
+    return serializedBody;
   }
 
   private serializedDiff(): Record<string, any> {


### PR DESCRIPTION
## Context

The `prepare` function was introduced a long time ago. The name does not say what this function does, it has a side effect and in order to execute a request it had to be called before. I deprecated it and replaced its usage.

## Definition of Done

Please consider all items and remove only if not applicable.

- [ ] Tests created/adjusted for your changes.
- [ ] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [ ] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [ ] If applicable: Properly documented (JSDoc of public API)
- [ ] If applicable: Check if `node run doc` still works.
