### PR TITLE
fix: canary release by applying cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,9 +89,17 @@ jobs:
     needs: [tests, checks]
     steps:
       - uses: actions/checkout@v1
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/setup-node@v1
         with:
           node-version: '12.x'
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install --frozen-lockfile
       - name: Canary Release
         run: |


### PR DESCRIPTION
## Context

canary release failed:

```
21s
1
Run yarn install --frozen-lockfile
4
yarn install v1.22.4
5
[1/4] Resolving packages...
6
[2/4] Fetching packages...
7
warning Pattern ["@definitelytyped/typescript-versions@latest"] is trying to unpack in the same destination "/home/runner/.cache/yarn/v6/npm-@definitelytyped-typescript-versions-0.0.48-9df9179100a90422acd9e4e973277aa36cf71e5a-integrity/node_modules/@definitelytyped/typescript-versions" as pattern ["@definitelytyped/typescript-versions@^0.0.48","@definitelytyped/typescript-versions@^0.0.48"]. This could result in non-deterministic behavior, skipping.
8
error https://npm.sap.com/@sap/cds-reflect/-/cds-reflect-2.12.2.tgz: Integrity check failed for "@sap/cds-reflect" (computed integrity doesn't match our records, got "sha512-++By/q8KJMjskh4p9YXWYk+nFw1DgV/kjiliMLGBC/tvg0vAmHHVwHJX6h39XLABskibsNkVSqU6g5F8V26Ptw== sha1-Drsk7PwiLvNiRqJqUboOZHv1Bsk=")
9
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

## Definition of Done

Please consider all items and remove only if not applicable.

- [ ] Tests created/adjusted for your changes.
- [ ] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [x] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [ ] If applicable: Properly documented (JSDoc of public API)
- [ ] If applicable: Check if `node run doc` still works.
