### PR TITLE
[Fix] In the TsDoc was a reference to a type

### DIFF
--- a/packages/core/src/odata/v2/entity-deserializer.ts
+++ b/packages/core/src/odata/v2/entity-deserializer.ts
@@ -8,7 +8,7 @@ import { getLinkedCollectionResult } from './request-builder/response-data-acces
 
 /**
  * Entity deserializer instance for v2 entities.
- * See [[EntityDeserializerType]] for the provided methods.
+ * See [[EntityDeserializer]] for the provided methods.
  */
 export const entityDeserializerV2: EntityDeserializer = entityDeserializer(
   edmToTsV2,

--- a/packages/core/src/odata/v2/entity-serializer.ts
+++ b/packages/core/src/odata/v2/entity-serializer.ts
@@ -6,7 +6,7 @@ import { tsToEdmV2 } from './payload-value-converter';
 
 /**
  * Entity serializer instance for v2 entities.
- * See [[EntitySerializerType]] for the provided methods.
+ * See [[EntitySerializer]] for the provided methods.
  */
 export const entitySerializerV2: EntitySerializer = entitySerializer(tsToEdmV2);
 

--- a/packages/core/src/odata/v4/entity-deserializer.ts
+++ b/packages/core/src/odata/v4/entity-deserializer.ts
@@ -8,7 +8,7 @@ import { getLinkedCollectionResult } from './request-builder/response-data-acces
 
 /**
  * Entity deserializer instance for v4 entities.
- * See [[EntityDeserializerType]] for the provided methods.
+ * See [[EntityDeserializer]] for the provided methods.
  */
 export const entityDeserializerV4: EntityDeserializer = entityDeserializer(
   edmToTsV4,

--- a/packages/core/src/odata/v4/entity-serializer.ts
+++ b/packages/core/src/odata/v4/entity-serializer.ts
@@ -6,7 +6,7 @@ import { tsToEdmV4 } from './payload-value-converter';
 
 /**
  * Entity serializer instance for v4 entities.
- * See [[EntitySerializerType]] for the provided methods.
+ * See [[EntitySerializer]] for the provided methods.
  */
 export const entitySerializerV4: EntitySerializer = entitySerializer(tsToEdmV4);
 


### PR DESCRIPTION
## Context

There was an error in a reference to [[EntitySerializerType]] which is an interface now an just called [[EntitySerializer]].