### PR TITLE
chore: Make execa a dependency not a dev dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ## Fixed Issues
 
--
+- [Generator] Fix reference to `execa` dependency.
 
 
 # 1.29.0

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -40,6 +40,7 @@
     "@sap/edm-converters": "^1.0.21",
     "@types/fs-extra": "^9.0.1",
     "@types/glob": "^7.1.2",
+    "execa": "^4.0.3",
     "fast-xml-parser": "^3.16.0",
     "fs-extra": "^9.0.0",
     "glob": "^7.1.6",
@@ -50,7 +51,6 @@
     "yargs": "^16.0.3"
   },
   "devDependencies": {
-    "@types/yargs": "^15.0.4",
-    "execa": "^4.0.3"
+    "@types/yargs": "^15.0.4"
   }
 }


### PR DESCRIPTION
## Context

`execa` was declared as a dev dependency, but used in the productive code. This PR fixes that.
Reported in #559.

## Definition of Done

Please consider all items and remove only if not applicable.

- [ ] Tests created/adjusted for your changes.
- [ ] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [ ] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [ ] If applicable: Properly documented (JSDoc of public API)
- [ ] If applicable: Check if `node run doc` still works.
