### PR TITLE
chore: add debug/warning msg when using custom header 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ## Improvements
 
 - Remove the `rambda` library to save  approx 2MB or 10% of the SDK size.
+- [Connectivity] Warn the user when using custom headers for executing http requests.
 
 ## Fixed Issues
 

--- a/packages/core/src/http-client/http-client.ts
+++ b/packages/core/src/http-client/http-client.ts
@@ -1,6 +1,6 @@
 import * as http from 'http';
 import * as https from 'https';
-import { errorWithCause } from '@sap-cloud-sdk/util';
+import { createLogger, errorWithCause } from '@sap-cloud-sdk/util';
 import axios from 'axios';
 import { buildHeadersForDestination } from '../header-builder/header-builder-for-destination';
 import {
@@ -18,6 +18,11 @@ import {
   HttpResponse
 } from './http-client-types';
 
+const logger = createLogger({
+  package: 'core',
+  messageContext: 'http-client'
+});
+
 /**
  * Builds a [[DestinationHttpRequestConfig]] for the given destination.
  * If a destination name (and a JWT) are provided, it will try to resolve the destination.
@@ -30,6 +35,13 @@ export async function buildHttpRequest(
   destination: Destination | DestinationNameAndJwt,
   customHeaders?: Record<string, any>
 ): Promise<DestinationHttpRequestConfig> {
+  if (customHeaders) {
+    logger.warn(
+      `The custom headers are provided with the keys: ${Object.keys(
+        customHeaders
+      )}.`
+    );
+  }
   const resolvedDestination = await resolveDestination(destination);
   if (!resolvedDestination) {
     throw Error(

--- a/packages/core/test/http-client/http-client.spec.ts
+++ b/packages/core/test/http-client/http-client.spec.ts
@@ -11,6 +11,7 @@ import {
   HttpRequest,
   Protocol
 } from '../../src';
+import { createLogger } from '@sap-cloud-sdk/util';
 
 describe('generic http client', () => {
   const httpsDestination: Destination = {
@@ -70,6 +71,17 @@ describe('generic http client', () => {
 
       expect(actualProxy).toMatchObject(expectedProxy);
       expect(actualProxy.httpAgent).toBeDefined();
+    });
+
+    it('warn when custom headers are used', async () => {
+      const logger = createLogger({
+        package: 'core',
+        messageContext: 'http-client'
+      });
+      const warnSpy = jest.spyOn(logger, 'warn');
+
+      await buildHttpRequest(httpsDestination, {'authorization' : 'abc', 'sap-client': '001', 'SAP-Connectivity-SCC-Location_ID': 'efg'})
+      expect(warnSpy).toBeCalledWith('The custom headers are provided with the keys: authorization,sap-client,SAP-Connectivity-SCC-Location_ID.');
     });
 
     it('throws useful error messages when finding the destination fails', async () => {

--- a/packages/core/test/http-client/http-client.spec.ts
+++ b/packages/core/test/http-client/http-client.spec.ts
@@ -86,7 +86,7 @@ describe('generic http client', () => {
         'SAP-Connectivity-SCC-Location_ID': 'efg'
       });
       expect(warnSpy).toBeCalledWith(
-        'The custom headers are provided with the keys: authorization,sap-client,SAP-Connectivity-SCC-Location_ID.'
+        'The custom headers are provided with the keys: authorization,sap-client,SAP-Connectivity-SCC-Location_ID. These keys will overwrite the headers created by the SDK.'
       );
     });
 

--- a/packages/core/test/http-client/http-client.spec.ts
+++ b/packages/core/test/http-client/http-client.spec.ts
@@ -1,6 +1,7 @@
 import https from 'https';
 import Axios from 'axios';
 import nock from 'nock';
+import { createLogger } from '@sap-cloud-sdk/util';
 import {
   addDestinationToRequestConfig,
   buildHttpRequest,
@@ -11,7 +12,6 @@ import {
   HttpRequest,
   Protocol
 } from '../../src';
-import { createLogger } from '@sap-cloud-sdk/util';
 
 describe('generic http client', () => {
   const httpsDestination: Destination = {
@@ -80,8 +80,14 @@ describe('generic http client', () => {
       });
       const warnSpy = jest.spyOn(logger, 'warn');
 
-      await buildHttpRequest(httpsDestination, {'authorization' : 'abc', 'sap-client': '001', 'SAP-Connectivity-SCC-Location_ID': 'efg'})
-      expect(warnSpy).toBeCalledWith('The custom headers are provided with the keys: authorization,sap-client,SAP-Connectivity-SCC-Location_ID.');
+      await buildHttpRequest(httpsDestination, {
+        authorization: 'abc',
+        'sap-client': '001',
+        'SAP-Connectivity-SCC-Location_ID': 'efg'
+      });
+      expect(warnSpy).toBeCalledWith(
+        'The custom headers are provided with the keys: authorization,sap-client,SAP-Connectivity-SCC-Location_ID.'
+      );
     });
 
     it('throws useful error messages when finding the destination fails', async () => {


### PR DESCRIPTION
## Context

Custom header are supported when executing http request. Since it will be used instead of the ones fetched from the destination service, more warning messages should be helpful.

## Definition of Done

Please consider all items and remove only if not applicable.

- [x] Tests created/adjusted for your changes.
- [ ] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [x] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [ ] If applicable: Properly documented (JSDoc of public API)
- [ ] If applicable: Check if `node run doc` still works.
