### PR TITLE
fix: the original error is shown when retrieving csrf token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 ## Fixed Issues
 
 - [Generator] Fix the function import (OData V2 + V4) and action import, where the return type is an primitive edm type like `Edm.String`.
+- [CSRF] Fix the error message of fetching the csrf token, it should show original error.
 
 
 # 1.30.0

--- a/packages/core/src/header-builder/csrf-token-header.ts
+++ b/packages/core/src/header-builder/csrf-token-header.ts
@@ -49,7 +49,9 @@ function makeCsrfRequest<T extends HttpRequestConfig>(
     .then(response => response.headers)
     .catch(error => {
       if (!error.response) {
-        throw new Error(`The error response is undefined. The original error is: ${error}.`);
+        throw new Error(
+          `The error response is undefined. The original error is: ${error}.`
+        );
       }
       return error.response.headers;
     });

--- a/packages/core/src/header-builder/csrf-token-header.ts
+++ b/packages/core/src/header-builder/csrf-token-header.ts
@@ -49,7 +49,7 @@ function makeCsrfRequest<T extends HttpRequestConfig>(
     .then(response => response.headers)
     .catch(error => {
       if (!error.response) {
-        throw new Error('The error response is undefined.');
+        throw new Error(`The error response is undefined. The original error is: ${error}.`);
       }
       return error.response.headers;
     });

--- a/packages/core/src/header-builder/csrf-token-header.ts
+++ b/packages/core/src/header-builder/csrf-token-header.ts
@@ -1,4 +1,4 @@
-import { createLogger } from '@sap-cloud-sdk/util';
+import { createLogger, errorWithCause } from '@sap-cloud-sdk/util';
 import { HttpRequestConfig, executeHttpRequest } from '../http-client';
 import { Destination, DestinationNameAndJwt } from '../scp-cf';
 import { filterNullishValues, getHeader, getHeaderValue } from './header-util';
@@ -49,9 +49,7 @@ function makeCsrfRequest<T extends HttpRequestConfig>(
     .then(response => response.headers)
     .catch(error => {
       if (!error.response) {
-        throw new Error(
-          `The error response is undefined. The original error is: ${error}.`
-        );
+        throw errorWithCause('The error response is undefined.', error);
       }
       return error.response.headers;
     });


### PR DESCRIPTION
## Context

In e2e test vdm, batch failed with OP destination, the error was:
`The error response is undefined.\n    at /home/vcap/app/node_modules/@sap-cloud-sdk/core/src/header-builder/csrf-token-header.ts`

## Definition of Done

Please consider all items and remove only if not applicable.

- [ ] Tests created/adjusted for your changes.
- [x] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [x] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [ ] If applicable: Properly documented (JSDoc of public API)
- [ ] If applicable: Check if `node run doc` still works.
