### PR TITLE
fix: client credential cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 ## Fixed Issues
 
 - [Generator] Fix the function import (OData V2 + V4) and action import, where the return type is a primitive edm type like `Edm.String`.
-- [Cache] Fix the client credentials cache, which is never hit due to wrong expire time.
+- [Cache] Fix expiration times in the client credentials cache.
 - [CSRF] Fix the error message of fetching the csrf token, it should show original error.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 ## Fixed Issues
 
 - [Generator] Fix the function import (OData V2 + V4) and action import, where the return type is a primitive edm type like `Edm.String`.
-- [Cache] Fix the client credential cache, which is never hit due to wrong expire time.
+- [Cache] Fix the client credentials cache, which is never hit due to wrong expire time.
 - [CSRF] Fix the error message of fetching the csrf token, it should show original error.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@
 
 ## Fixed Issues
 
-- [Generator] Fix the function import (OData V2 + V4) and action import, where the return type is an primitive edm type like `Edm.String`.
+- [Generator] Fix the function import (OData V2 + V4) and action import, where the return type is a primitive edm type like `Edm.String`.
+- [Cache] Fix the client credential cache, which is never hit due to wrong expire time.
 - [CSRF] Fix the error message of fetching the csrf token, it should show original error.
 
 

--- a/packages/core/src/scp-cf/client-credentials-token-cache.ts
+++ b/packages/core/src/scp-cf/client-credentials-token-cache.ts
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import { Cache } from './cache';
 import { headerForClientCredentials } from './xsuaa-service';
 import {
@@ -21,7 +22,11 @@ const ClientCredentialsTokenCache = (
     credentials: ClientCredentials,
     token: ClientCredentialsResponse
   ): void => {
-    cache.set(getGrantTokenCacheKey(url, credentials), token, token.expires_in);
+    cache.set(
+      getGrantTokenCacheKey(url, credentials),
+      token,
+      moment().add(token.expires_in, 'second').unix() * 1000
+    );
   },
   clear: (): void => {
     cache.clear();

--- a/packages/core/src/scp-cf/client-credentials-token-cache.ts
+++ b/packages/core/src/scp-cf/client-credentials-token-cache.ts
@@ -27,7 +27,7 @@ const ClientCredentialsTokenCache = (
       token,
       token.expires_in
         ? moment().add(token.expires_in, 'second').unix() * 1000
-        : 0
+        : undefined
     );
   },
   clear: (): void => {

--- a/packages/core/src/scp-cf/client-credentials-token-cache.ts
+++ b/packages/core/src/scp-cf/client-credentials-token-cache.ts
@@ -27,7 +27,7 @@ const ClientCredentialsTokenCache = (
       token,
       token.expires_in
         ? moment().add(token.expires_in, 'second').unix() * 1000
-        : undefined
+        : 0
     );
   },
   clear: (): void => {

--- a/packages/core/src/scp-cf/client-credentials-token-cache.ts
+++ b/packages/core/src/scp-cf/client-credentials-token-cache.ts
@@ -25,7 +25,9 @@ const ClientCredentialsTokenCache = (
     cache.set(
       getGrantTokenCacheKey(url, credentials),
       token,
-      moment().add(token.expires_in, 'second').unix() * 1000
+      token.expires_in
+        ? moment().add(token.expires_in, 'second').unix() * 1000
+        : undefined
     );
   },
   clear: (): void => {

--- a/packages/core/src/scp-cf/client-credentials-token-cache.ts
+++ b/packages/core/src/scp-cf/client-credentials-token-cache.ts
@@ -25,7 +25,7 @@ const ClientCredentialsTokenCache = (
     cache.set(
       getGrantTokenCacheKey(url, credentials),
       token,
-      token.expires_in && moment().add(token.expires_in, 'second').unix() * 1000
+      moment().add(token.expires_in, 'second').unix() * 1000
     );
   },
   clear: (): void => {

--- a/packages/core/src/scp-cf/client-credentials-token-cache.ts
+++ b/packages/core/src/scp-cf/client-credentials-token-cache.ts
@@ -25,7 +25,7 @@ const ClientCredentialsTokenCache = (
     cache.set(
       getGrantTokenCacheKey(url, credentials),
       token,
-      moment().add(token.expires_in, 'second').unix() * 1000
+      token.expires_in && moment().add(token.expires_in, 'second').unix() * 1000
     );
   },
   clear: (): void => {

--- a/packages/core/src/scp-cf/xsuaa-service-types.ts
+++ b/packages/core/src/scp-cf/xsuaa-service-types.ts
@@ -5,6 +5,7 @@ export interface ClientCredentials {
 
 /**
  * @hidden
+ * @property expires_in - The number of seconds until the access token expires.
  */
 export interface ClientCredentialsResponse {
   access_token: string;

--- a/packages/core/test/scp-cf/client-credentials-token-cache.spec.ts
+++ b/packages/core/test/scp-cf/client-credentials-token-cache.spec.ts
@@ -4,18 +4,20 @@ import { clientCredentialsTokenCache } from '../../src/scp-cf';
 describe('ClientCredentialsTokenCache', () => {
   it('should return token when valid, return undefined otherwise', () => {
     const clock = install();
+    const expires_in_one_hour_with_unit_second = 60 * 60;
+    const expires_in_three_hours_with_unit_second = 60 * 60 * 3;
+    const two_hours_later_with_unit_millisecond = 60 * 60 * 2 * 1000;
     const validToken = {
       access_token: '1234567890',
       token_type: 'UserToken',
-      // x second later
-      expires_in: 100000,
+      expires_in: expires_in_three_hours_with_unit_second,
       jti: '',
       scope: ''
     };
     const expiredToken = {
       access_token: '1234567890',
       token_type: 'UserToken',
-      expires_in: 50000,
+      expires_in: expires_in_one_hour_with_unit_second,
       jti: '',
       scope: ''
     };
@@ -31,8 +33,7 @@ describe('ClientCredentialsTokenCache', () => {
       credentials,
       expiredToken
     );
-    // millisecond
-    clock.tick(75000 * 1000);
+    clock.tick(two_hours_later_with_unit_millisecond);
 
     const valid = clientCredentialsTokenCache.getGrantTokenFromCache(
       'https://url_valid',

--- a/packages/core/test/scp-cf/client-credentials-token-cache.spec.ts
+++ b/packages/core/test/scp-cf/client-credentials-token-cache.spec.ts
@@ -1,4 +1,5 @@
 import { install } from '@sinonjs/fake-timers';
+import moment from 'moment';
 import { clientCredentialsTokenCache } from '../../src/scp-cf';
 
 describe('ClientCredentialsTokenCache', () => {
@@ -8,14 +9,15 @@ describe('ClientCredentialsTokenCache', () => {
     const validToken = {
       access_token: '1234567890',
       token_type: 'UserToken',
-      expires_in: now + 100000,
+      // x second later
+      expires_in: 100000,
       jti: '',
       scope: ''
     };
     const expiredToken = {
       access_token: '1234567890',
       token_type: 'UserToken',
-      expires_in: now + 50000,
+      expires_in: 50000,
       jti: '',
       scope: ''
     };
@@ -31,8 +33,8 @@ describe('ClientCredentialsTokenCache', () => {
       credentials,
       expiredToken
     );
-
-    clock.tick(75000);
+    // millisecond
+    clock.tick(75000 * 1000);
 
     const valid = clientCredentialsTokenCache.getGrantTokenFromCache(
       'https://url_valid',

--- a/packages/core/test/scp-cf/client-credentials-token-cache.spec.ts
+++ b/packages/core/test/scp-cf/client-credentials-token-cache.spec.ts
@@ -1,11 +1,9 @@
 import { install } from '@sinonjs/fake-timers';
-import moment from 'moment';
 import { clientCredentialsTokenCache } from '../../src/scp-cf';
 
 describe('ClientCredentialsTokenCache', () => {
   it('should return token when valid, return undefined otherwise', () => {
     const clock = install();
-    const now = Date.now();
     const validToken = {
       access_token: '1234567890',
       token_type: 'UserToken',


### PR DESCRIPTION
## Context

Currently, the cache is never hit even with 2 get all requests within a second.

## Definition of Done

Please consider all items and remove only if not applicable.

- [x] Tests created/adjusted for your changes.
- [ ] Release notes updated.
  * Provide sufficient context so that each entry can be understood on its own.
  * Be specific about names of functions, classes, modules, etc.
  * Describe when or where this is relevant
  * Use indicative and present tense. For example, write "Provide function `name` that does X in order to Y" over "Now X can be done by calling a new function".
- [x] PR title adheres to [conventional commit guidelines](https://www.conventionalcommits.org) (please note that only `fix:` and `feat:` will end up in the release notes)
- [ ] If applicable: Properly documented (JSDoc of public API)
- [ ] If applicable: Check if `node run doc` still works.
