### PR TITLE
chore: Enable marking issues as stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,11 @@
+daysUntilStale: 60
+daysUntilClose: 7
+exemptLabels:
+  - pinned
+  - security
+staleLabel: stale
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+closeComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,4 +1,4 @@
-daysUntilStale: 14
+daysUntilStale: 30
 daysUntilClose: 7
 exemptLabels:
   - pinned

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,8 +1,9 @@
-daysUntilStale: 60
+daysUntilStale: 14
 daysUntilClose: 7
 exemptLabels:
   - pinned
   - security
+  - in backlog
 staleLabel: stale
 markComment: >
   This issue has been automatically marked as stale because it has not had

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,8 +5,5 @@ exemptLabels:
   - security
   - in backlog
 staleLabel: stale
-markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
-closeComment: false
+markComment: This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs within 7 days. Feel free to comment, if you want to keep it open. Thank you for your contributions!
+closeComment: This issue has been automatically closed because it has not had recent activity. If you need further assistance feel free to comment or create a new issue. Thank you for your contributions!

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -4,6 +4,7 @@ exemptLabels:
   - pinned
   - security
   - in backlog
+  - needs documentation
 staleLabel: stale
 markComment: This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs within 7 days. Feel free to comment, if you want to keep it open. Thank you for your contributions!
 closeComment: This issue has been automatically closed because it has not had recent activity. If you need further assistance feel free to comment or create a new issue. Thank you for your contributions!


### PR DESCRIPTION
## Context

After our discussion about the support board today, I thought it would be nice to have a stale bot, that marks issues that have not been reacted to as stale. This is both nice for us to reconsider low priority issues and nice for the users, because it is a bot closing the issues, not a person.

This configuration would mark issues as stale after 60 days and close them if within 7 days there was no reaction.