### PR TITLE
Add docu about odata update strategies

### DIFF
--- a/docs/java/features/odata/type-safe-client-odata-v2.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v2.mdx
@@ -398,7 +398,7 @@ The Cloud SDK supports different strategies for updating entities which differ i
 
 <TabItem value="modify">
 
-The default strategy is the *modifying entity update strategy* which attempts to modify only the necessary entity fields in the remote system. It issues a PATCH request and includes
+The default strategy is the *modifying entity update strategy* which attempts to modify only the necessary entity fields in the remote system. It issues a PATCH request and includes only
 the changed fields in the request payload. Hence, fields whose values remain unchanged are not sent to the target system. 
 Calling the method `includingFields(fields ...)` instructs the Cloud SDK to add the mentioned fields explicitly in the update request.
 This is useful for backend systems which require some unchanged fields in the request payload for given reasons.

--- a/docs/java/features/odata/type-safe-client-odata-v2.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v2.mdx
@@ -398,8 +398,9 @@ The Cloud SDK supports different strategies for updating entities which differ i
 
 <TabItem value="modify">
 
-The default strategy is the *modifying entity update strategy* which attempts to modify only the necessary entity fields in the remote system. It issues a PATCH request and includes only
-the changed fields in the request payload. Hence, fields whose values remain unchanged are not sent to the target system. 
+The default strategy is the *modifying entity update strategy* which attempts to modify only the necessary entity fields in the remote system.
+It issues a PATCH request and includes only the fields in the request payload whose values were changed by its setter method.
+Hence, fields whose values remain unchanged are not sent to the target system. 
 Calling the method `includingFields(fields ...)` instructs the Cloud SDK to add the mentioned fields explicitly in the update request.
 This is useful for backend systems which require some unchanged fields in the request payload for given reasons.
 
@@ -418,8 +419,8 @@ service.updateBusinessPartner(partner)
 
 <TabItem value="replace">
 
-The *replacing entity update strategy* attempts to replace the full entity in the remote system. It issues a PUT request and submits
-all fields in the update request, regardless of any field changes.
+The *replacing entity update strategy* attempts to replace the full entity in the remote system. 
+It issues a PUT request and submits all fields in the update request, regardless of any field changes.
 
 This update strategy can be explicitly chosen invoking the method `replacingEntity()` while building the update request.
 
@@ -434,8 +435,8 @@ service.updateBusinessPartner(partner)
 </Tabs>
 
 :::note
-It depends on the capabilities of the OData API in the remote system which update strategies are supported in an end-to-end scenario.
-For example, there are cases where OData APIs do not support PUT requests.
+It depends on the capabilities of the specific OData service in the remote system which update strategies are supported in an end-to-end scenario.
+For example, there are cases where OData services do not support PUT requests.
 :::
 
 

--- a/docs/java/features/odata/type-safe-client-odata-v2.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v2.mdx
@@ -391,6 +391,54 @@ Function Imports / Functions & Actions
 
 -->
 
+## Entity Update Strategies
+The Cloud SDK supports different strategies for updating entities which differ in the HTTP method and the payload of the update request.
+
+<Tabs groupId="updateStrategy" defaultValue="modify" values={[ { label: 'Modify Entity (default)', value: 'modify', }, { label: 'Replace Entity', value: 'replace', }, ]}>
+
+<TabItem value="modify">
+
+The default strategy is the *modifying entity update strategy* which attempts to modify only the necessary entity fields in the remote system. It issues a PATCH request and includes
+the changed fields in the request payload. Hence, fields whose values remain unchanged are not sent to the target system. 
+Calling the method `includingFields(fields ...)` instructs the Cloud SDK to add the mentioned fields explicitly in the update request.
+This is useful for backend systems which require some unchanged fields in the request payload for given reasons.
+
+This update strategy can be explicitly chosen invoking the method `modifyingEntity()` while building the update request.
+
+```java
+service.updateBusinessPartner(partner)
+    //method call optional, since active by default
+    .modifyingEntity()
+    //add the Business Partner Full Name explicitly to the update request
+    .includingFields(BusinessPartner.BUSINESS_PARTNER_FULL_NAME)
+    .executeRequest(destination);
+```
+
+</TabItem>
+
+<TabItem value="replace">
+
+The *replacing entity update strategy* attempts to replace the full entity in the remote system. It issues a PUT request and submits
+all fields in the update request, regardless of any field changes.
+
+This update strategy can be explicitly chosen invoking the method `replacingEntity()` while building the update request.
+
+```java
+service.updateBusinessPartner(partner)
+    .replacingEntity()
+    .executeRequest(destination);
+```
+
+</TabItem>
+
+</Tabs>
+
+:::note
+It depends on the capabilities of the OData API in the remote system which update strategies are supported in an end-to-end scenario.
+For example, there are cases where OData APIs do not support PUT requests.
+:::
+
+
 ## Error Handling
 
 <Tabs groupId="odataProtocol" defaultValue="v2" values={[ { label: 'OData V2', value: 'v2', }, { label: 'OData V2 (Deprecated)', value: 'v2-deprecated', }, ]}>

--- a/docs/java/features/odata/type-safe-client-odata-v4.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v4.mdx
@@ -15,6 +15,8 @@ keywords:
 - generate
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
 ## Build and execute OData Requests with the typed OData client
@@ -258,6 +260,55 @@ As per the OData specification, either all operations or none within the same ch
 Function Imports / Functions & Actions
 
 -->
+
+## Entity Update Strategies
+
+The Cloud SDK supports different strategies for updating entities which differ in the HTTP method and the payload of the update request.
+
+<Tabs groupId="updateStrategy" defaultValue="modify" values={[ { label: 'Modify Entity (default)', value: 'modify', }, { label: 'Replace Entity', value: 'replace', }, ]}>
+
+<TabItem value="modify">
+
+The default strategy is the *modifying entity update strategy* which attempts to modify only the necessary entity fields in the remote system. It issues a PATCH request and includes
+the changed fields in the request payload. Hence, fields whose values remain unchanged are not sent to the target system. 
+Calling the method `includingFields(fields ...)` instructs the Cloud SDK to add the mentioned fields explicitly in the update request.
+This is useful for backend systems which require some unchanged fields in the request payload for given reasons.
+
+This update strategy can be explicitly chosen invoking the method `modifyingEntity()` while building the update request.
+
+```java
+service.updateBusinessPartner(partner)
+    //method call optional, since active by default
+    .modifyingEntity()
+    //add the Business Partner Full Name explicitly to the update request
+    .includingFields(BusinessPartner.BUSINESS_PARTNER_FULL_NAME)
+    .executeRequest(destination);
+```
+
+</TabItem>
+
+<TabItem value="replace">
+
+The *replacing entity update strategy* attempts to replace the full entity in the remote system. It issues a PUT request and submits
+all fields in the update request, regardless of any field changes.
+
+This update strategy can be explicitly chosen invoking the method `replacingEntity()` while building the update request.
+
+```java
+service.updateBusinessPartner(partner)
+    .replacingEntity()
+    .executeRequest(destination);
+```
+
+</TabItem>
+
+</Tabs>
+
+:::note
+It depends on the capabilities of the OData API in the remote system which update strategies are supported in an end-to-end scenario.
+For example, there are cases where OData APIs do not support PUT requests.
+:::
+
 
 ## Error Handling
 

--- a/docs/java/features/odata/type-safe-client-odata-v4.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v4.mdx
@@ -269,8 +269,9 @@ The Cloud SDK supports different strategies for updating entities which differ i
 
 <TabItem value="modify">
 
-The default strategy is the *modifying entity update strategy* which attempts to modify only the necessary entity fields in the remote system. It issues a PATCH request and includes
-the changed fields in the request payload. Hence, fields whose values remain unchanged are not sent to the target system. 
+The default strategy is the *modifying entity update strategy* which attempts to modify only the necessary entity fields in the remote system. 
+It issues a PATCH request and includes only the fields in the request payload whose values were changed by its setter method.
+Hence, fields whose values remain unchanged are not sent to the target system. 
 Calling the method `includingFields(fields ...)` instructs the Cloud SDK to add the mentioned fields explicitly in the update request.
 This is useful for backend systems which require some unchanged fields in the request payload for given reasons.
 
@@ -289,8 +290,8 @@ service.updateBusinessPartner(partner)
 
 <TabItem value="replace">
 
-The *replacing entity update strategy* attempts to replace the full entity in the remote system. It issues a PUT request and submits
-all fields in the update request, regardless of any field changes.
+The *replacing entity update strategy* attempts to replace the full entity in the remote system.
+It issues a PUT request and submits all fields in the update request, regardless of any field changes.
 
 This update strategy can be explicitly chosen invoking the method `replacingEntity()` while building the update request.
 
@@ -305,8 +306,8 @@ service.updateBusinessPartner(partner)
 </Tabs>
 
 :::note
-It depends on the capabilities of the OData API in the remote system which update strategies are supported in an end-to-end scenario.
-For example, there are cases where OData APIs do not support PUT requests.
+It depends on the capabilities of the specific OData service in the remote system which update strategies are supported in an end-to-end scenario.
+For example, there are cases where OData services do not support PUT requests.
 :::
 
 


### PR DESCRIPTION
Extends the OData documentation with supported update strategies as we had seen some confusion about it lately.