### PR TITLE
Mark SDK for CI/CD as deprecated and link gpp guide

### DIFF
--- a/docs/devops/getting-started.mdx
+++ b/docs/devops/getting-started.mdx
@@ -20,6 +20,6 @@ keywords:
 
 ### Deprecation ###
 
-The SAP Cloud SDK for Continuous Delivery and its features has been merged into [project "Piper"](../related-projects/piper.mdx).
+The SAP Cloud SDK for Continuous Delivery and its features have been merged into [project "Piper"](../related-projects/piper.mdx).
 Therefore we recommend to use the [General Purpose Pipeline of project "Piper"](https://sap.github.io/jenkins-library/stages/introduction/) instead of the SAP Cloud SDK pipeline. 
-The reasoning for this change, as well as further information how to adopt the General Purpose Pipeline, are described in this [guide](https://github.com/SAP/cloud-s4-sdk-pipeline/blob/master/gpp-guide.md).
+The reasoning for this change, as well as further information on how to adopt the General Purpose Pipeline, are described in this [guide](https://github.com/SAP/cloud-s4-sdk-pipeline/blob/master/gpp-guide.md).

--- a/docs/devops/getting-started.mdx
+++ b/docs/devops/getting-started.mdx
@@ -22,4 +22,4 @@ keywords:
 
 The SAP Cloud SDK for Continuous Delivery and its features has been merged into [project "Piper"](../related-projects/piper.mdx).
 Therefore we recommend to use the [General Purpose Pipeline of project "Piper"](https://sap.github.io/jenkins-library/stages/introduction/) instead of the SAP Cloud SDK pipeline. 
-The reasoning as well as further information how to adopt the General Purpose Pipeline are described in our [guide](https://github.com/SAP/cloud-s4-sdk-pipeline/blob/master/gpp-guide.md).
+The reasoning for this change, as well as further information how to adopt the General Purpose Pipeline, are described in this [guide](https://github.com/SAP/cloud-s4-sdk-pipeline/blob/master/gpp-guide.md).

--- a/docs/devops/getting-started.mdx
+++ b/docs/devops/getting-started.mdx
@@ -20,6 +20,6 @@ keywords:
 
 ### Deprecation ###
 
-The SAP Cloud SDK for Continuous Delivery and its features has been migrated into [project "Piper"](../related-projects/piper.mdx).
+The SAP Cloud SDK for Continuous Delivery and its features has been merged into [project "Piper"](../related-projects/piper.mdx).
 Therefore we recommend to use the [General Purpose Pipeline of project "Piper"](https://sap.github.io/jenkins-library/stages/introduction/) instead of the SAP Cloud SDK pipeline. 
 The reasoning as well as further information how to adopt the General Purpose Pipeline are described in our [guide](https://github.com/SAP/cloud-s4-sdk-pipeline/blob/master/gpp-guide.md).

--- a/docs/devops/getting-started.mdx
+++ b/docs/devops/getting-started.mdx
@@ -18,33 +18,8 @@ keywords:
 - project "Piper"
 ---
 
-## Best DevOps practices at SAP ##
+### Deprecation ###
 
-Continuous delivery is a method to develop software with short feedback cycles.
-It applies to projects both for SAP Cloud Platform and SAP on-premise platforms.
-SAP implements tooling for continuous delivery in the project "Piper".
-The goal of the project "Piper" is to substantially ease setting up continuous delivery in your project using SAP technologies.
-
-### SAP Cloud SDK for Continuous Delivery ###
-
-[SAP Cloud SDK for Continuous Delivery](https://github.com/SAP/cloud-s4-sdk-pipeline) is open source and free to use.
-This ready-made pipeline is part of the project "Piper" and allows you to start with continuous delivery without writing any pipeline code -- only declarative configuration is required.
-It helps you to quickly deliver high-quality applications to SAP Cloud Platform.
-
-Check out the [documentation of SAP Cloud SDK for Continuous Delivery](https://sap.github.io/jenkins-library/pipelines/cloud-sdk/introduction/) for more details and usage hints.
-
-## Where to look next? ##
-
-### Learn about project "Piper" ###
-
-For more information on continuous integration and continuous delivery (CI/CD) in the SAP ecosystem, please refer to the documentation of [project "Piper"](https://sap.github.io/jenkins-library).
-
-### Open SAP courses ###
-Check **Week 3** of [Create and Deliver Cloud-Native SAP S/4HANA Extensions](https://open.sap.com/courses/s4h13/items/5F9Yrn3QwX0aIFg7JmSS9H) course.
-
-### Video tutorial ###
-This video tutorial is a good example of SAP Cloud SDK for continuous delivery used with [SAP Cloud Programming Model](https://cap.cloud.sap/docs/)
-
-<div class="sdk-video-container">
-<iframe class='sdk-video' src="https://www.youtube.com/embed/Ss0mFfaE5t4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-</div>
+The SAP Cloud SDK for Continuous Delivery and its features has been migrated into [project "Piper"](../related-projects/piper.mdx).
+Therefore we recommend to use the [General Purpose Pipeline of project "Piper"](https://sap.github.io/jenkins-library/stages/introduction/) instead of the SAP Cloud SDK pipeline. 
+The reasoning as well as further information how to adopt the General Purpose Pipeline are described in our [guide](https://github.com/SAP/cloud-s4-sdk-pipeline/blob/master/gpp-guide.md).

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -78,7 +78,7 @@ module.exports = {
                 'docs/js/release-notes-sap-cloud-sdk-for-javascript-and-typescript'
             },
             {
-              label: 'CI/CD Toolkit',
+              label: 'Continuous Delivery (Deprecated)',
               href: 'https://github.com/SAP/cloud-s4-sdk-pipeline/releases'
             }
           ]

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -78,7 +78,7 @@ module.exports = {
                 'docs/js/release-notes-sap-cloud-sdk-for-javascript-and-typescript'
             },
             {
-              label: 'Continuous Delivery (Deprecated)',
+              label: 'Continuous Delivery',
               href: 'https://github.com/SAP/cloud-s4-sdk-pipeline/releases'
             }
           ]

--- a/sidebars.js
+++ b/sidebars.js
@@ -179,7 +179,8 @@ module.exports = {
     Community: ['community/community-call'],
     'Related projects': [
       'related-projects/cloud-application-model',
-      'related-projects/sap-xsuaa-security-library-for-javascript-and-java'
+      'related-projects/sap-xsuaa-security-library-for-javascript-and-java',
+      'related-projects/project-piper'
     ]
   }
 }


### PR DESCRIPTION
<!-- Make sure your change works as expected by running the documentation locally. -->

Mark SDK for CI/CD as deprecated and link gpp guide
