### PR TITLE
Add sample for the `destinations` env. variable

### DIFF
--- a/docs/js/features/connectivity/destination.mdx
+++ b/docs/js/features/connectivity/destination.mdx
@@ -64,7 +64,12 @@ So local env beats service instance beats destination service in case all contai
 ### Local Environment Variable ###
 
 This option is present for deployment and testing in a local environment outside the SCP where no destination services are available.
-The SDK provides a `mockDestinationsEnv(...destinations)` method which takes a list of destination objects, transforms it to a JSON array and assigns it to the environment variable `process.env.destinations`.
+If a `destinations` environment variable is present it will be used for the destination lookup as described above.
+The value is expected to be a stringified JSON array, where the items adhere to the `Destination` interface.
+Example: `"[{name: 'TESTINATION', url: 'http://url.hana.ondemand.com', username: 'DUMMY', password: 'dummy'}]"`.
+
+The SDK provides a `mockDestinationsEnv(...destinations)` function to set the `destinations` environment variable for the current process programatically.
+It takes a list of destination objects, transforms it to a JSON array and assigns it to `process.env.destinations`.
 At runtime, the SDK will check whether a destination with the given is present and use it, if it is.
 If a destination with the same name as the one given as `destinationName` is found it is taken for example:
 ```js
@@ -77,11 +82,6 @@ mockDestinationsEnv({
 })
 ```
 would set a destination with name `TESTINATION`.
-
-The `destinations` environment variable expects a stringified JSON object. Example:
-
-    "[{name: 'ErpQueryEndpoint', url: 'http://url.hana.ondemand.com', username: 'DUMMY', password: 'dummy'}]"
-
 
 ### Service Instance ###
 
@@ -182,4 +182,3 @@ In principle it is possible to define destinations not only on the account level
 These destinations are called `instance destinations` since they are tied to an service binding called instance on SCP.
 In every request these destinations are added to the destinations returned by the destination service.
 :::
-

--- a/docs/js/features/connectivity/destination.mdx
+++ b/docs/js/features/connectivity/destination.mdx
@@ -64,7 +64,7 @@ So local env beats service instance beats destination service in case all contai
 ### Local Environment Variable ###
 
 This option is present for deployment and testing in a local environment outside the SCP where no destination services are available.
-The SDK provides a `mockDestinationsEnv(...destinations)` method which takes a list of destination objects, transforms it to a JSON array and assigns it to the `process.env.destinations`.
+The SDK provides a `mockDestinationsEnv(...destinations)` method which takes a list of destination objects, transforms it to a JSON array and assigns it to the environment variable `process.env.destinations`.
 At runtime, the SDK will check whether a destination with the given is present and use it, if it is.
 If a destination with the same name as the one given as `destinationName` is found it is taken for example:
 ```js
@@ -77,6 +77,11 @@ mockDestinationsEnv({
 })
 ```
 would set a destination with name `TESTINATION`.
+
+The `destinations` environment variable expects a stringified JSON object. Example:
+
+    "[{name: 'ErpQueryEndpoint', url: 'http://url.hana.ondemand.com', username: 'DUMMY', password: 'dummy'}]"
+
 
 ### Service Instance ###
 


### PR DESCRIPTION
to help developers set up their local development environment.

Example taken from:
https://sap.github.io/cloud-s4-sdk-book/pages/mock-odata.html

<!-- Make sure your change works as expected by running the documentation locally. -->

Please provide a description of what your change does and why it is needed.
