### PR TITLE
Server-Driven Paging

### DIFF
--- a/docs/java/features/odata/type-safe-client-odata-v2.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v2.mdx
@@ -560,7 +560,15 @@ OData service operators may decide to enable server-driven pagination to limit t
 
 In comparison the OData consumer may use query options `$top` and `$skip` (client-driven paging) to read partial data from the result-set. But relying on a consistent state while browsing through the data can be problematic. Between individual requests another user could delete or add an item. This would result in an inconsistent aggregation of data.
 
-By default the SAP Cloud SDK automatically resolves all pages of a result-set if server-driven paging is encountered. For the API consumer it is not necessary to parse the next link and instantiate follow-up requests to aggregate the full result-set. In case memory efficiency and response time is the priority, then the advanced API provides additional means to manually iterate through the internal pages. While accessing the following methods, the internal HTTP requests are executed lazily:
+By default the SAP Cloud SDK automatically resolves all pages of a result-set if server-driven paging is encountered. For the API consumer it is not necessary to parse the next link and instantiate follow-up requests to aggregate the full result-set.
+
+```java
+List<BusinessPartner> iterablePagesOfEntities = service
+  .getAllBusinessPartner()
+  .executeRequest( destination );
+```
+
+In case memory efficiency and response time of the consuming application becomes a priority, then the advanced API provides additional means to manually iterate through the internal pages. While accessing the following methods, the internal HTTP requests are executed lazily:
 
 ```java
 Iterable<List<BusinessPartner>> iterablePagesOfEntities = service

--- a/docs/java/features/odata/type-safe-client-odata-v2.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v2.mdx
@@ -551,6 +551,35 @@ POST /ODataService/API_BUSINESS_PARTNER/A_BusinessPartner(123)/to_BusinessPartne
 
 </Tabs>
 
+
+## Server-Driven Paging
+
+OData service operators may decide to enable server-driven pagination to limit the amount of data that is fetched and sent over the network to the client, in case generic query options yield huge amounts of data. By splitting the result-set into sequential pages of entities, the data can be requested incrementally. This reduces initial network load and improves overall response times. If the payload of an OData response contains a link including a `$skiptoken`, then it indicates a next page to the result-set.
+
+In comparison the OData consumer may use query options `$top` and `$skip` (client-driven paging) to read partial data from the result-set. But relying on a consistent state while browsing through the data can be problematic. Between individual requests another user could delete or add an item. This would result in an inconsistent aggregation of data.
+
+By default the SAP Cloud SDK automatically resolves all pages of a result-set if server-driven paging is encountered. For the API consumer it is not necessary to parse the next link and instantiate follow-up requests to aggregate the full result-set. In case memory efficiency and response time is the priority, then the advanced API provides additional means to manually iterate through the internal pages. While accessing the following methods, the internal HTTP requests are executed lazily:
+
+```java
+Iterable<List<BusinessPartner>> iterablePagesOfEntities = service
+  .getAllBusinessPartner()
+  .iteratingPages()
+  .executeRequest( destination );
+
+Iterable<BusinessPartner> iterableEntities = service
+  .getAllBusinessPartner()
+  .iteratingEntities()
+  .executeRequest(destination);
+  
+Stream<BusinessPartner> streamingEntities = service
+  .getAllBusinessPartner()
+  .streamingEntities()
+  .executeRequest(destination);
+```
+
+The request builder allows for setting the optional parameter for preferred page size. Please note that the OData service may not be obliged to respect this setting.
+
+
 ## Switch to improved OData v2 type-safe client
 
 - For any operation type, replace a call to `execute` with `executeRequest`.

--- a/docs/java/features/odata/type-safe-client-odata-v2.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v2.mdx
@@ -554,7 +554,9 @@ POST /ODataService/API_BUSINESS_PARTNER/A_BusinessPartner(123)/to_BusinessPartne
 
 ## Server-Driven Paging
 
-OData service operators may decide to enable server-driven pagination to limit the amount of data that is fetched and sent over the network to the client, in case generic query options yield huge amounts of data. By splitting the result-set into sequential pages of entities, the data can be requested incrementally. This reduces initial network load and improves overall response times. If the payload of an OData response contains a link including a `$skiptoken`, then it indicates a next page to the result-set.
+Pagination describes the practice of splitting a collection of entities from reading requests into one or many pages. The paging behavior is determined by both server and client.
+
+OData service operators may decide to enable server-driven pagination to limit the amount of data that is fetched and sent over the network to the client, in case generic query options yield huge amounts of data. By splitting the result-set into sequential pages of entities, the data can be requested incrementally. This reduces initial network load and improves overall response times. If the payload of an OData response contains a link including a `$skiptoken`, then it indicates a next page to the result-set. The iterable result-set is a consistent snapshot of the data, it can not change between reading individual pages.
 
 In comparison the OData consumer may use query options `$top` and `$skip` (client-driven paging) to read partial data from the result-set. But relying on a consistent state while browsing through the data can be problematic. Between individual requests another user could delete or add an item. This would result in an inconsistent aggregation of data.
 

--- a/docs/java/features/odata/type-safe-client-odata-v2.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v2.mdx
@@ -577,7 +577,7 @@ Stream<BusinessPartner> streamingEntities = service
   .executeRequest(destination);
 ```
 
-The request builder allows for setting the optional parameter for preferred page size. Please note that the OData service may not be obliged to respect this setting.
+The request builder allows for setting the optional parameter for preferred page size. Please note that the OData service is not obliged to respect this setting.
 
 
 ## Switch to improved OData v2 type-safe client

--- a/docs/java/features/odata/type-safe-client-odata-v4.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v4.mdx
@@ -392,7 +392,15 @@ OData service operators may decide to enable server-driven pagination to limit t
 
 In comparison the OData consumer may use query options `$top` and `$skip` (client-driven paging) to read partial data from the result-set. But relying on a consistent state while browsing through the data can be problematic. Between individual requests another user could delete or add an item. This would result in an inconsistent aggregation of data.
 
-By default the SAP Cloud SDK automatically resolves all pages of a result-set if server-driven paging is encountered. For the API consumer it is not necessary to parse the next link and instantiate follow-up requests to aggregate the full result-set. In case memory efficiency and response time is the priority, then the advanced API provides additional means to manually iterate through the internal pages. While accessing the following methods, the internal HTTP requests are executed lazily:
+By default the SAP Cloud SDK automatically resolves all pages of a result-set if server-driven paging is encountered. For the API consumer it is not necessary to parse the next link and instantiate follow-up requests to aggregate the full result-set.
+
+```java
+List<BusinessPartner> iterablePagesOfEntities = service
+  .getAllBusinessPartner()
+  .execute( destination );
+```
+
+In case memory efficiency and response time of the consuming application becomes a priority, then the advanced API provides additional means to manually iterate through the internal pages. While accessing the following methods, the internal HTTP requests are executed lazily:
 
 ```java
 Iterable<List<BusinessPartner>> iterablePagesOfEntities = service

--- a/docs/java/features/odata/type-safe-client-odata-v4.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v4.mdx
@@ -386,7 +386,9 @@ POST /ODataService/API_BUSINESS_PARTNER/A_BusinessPartner(123)/to_BusinessPartne
 
 ## Server-Driven Paging
 
-OData service operators may decide to enable server-driven pagination to limit the amount of data that is fetched and sent over the network to the client, in case generic query options yield huge amounts of data. By splitting the result-set into sequential pages of entities, the data can be requested incrementally. This reduces initial network load and improves overall response times. If the payload of an OData response contains a link including a `$skiptoken`, then it indicates a next page to the result-set.
+Pagination describes the practice of splitting a collection of entities from reading requests into one or many pages. The paging behavior is determined by both server and client.
+
+OData service operators may decide to enable server-driven pagination to limit the amount of data that is fetched and sent over the network to the client, in case generic query options yield huge amounts of data. By splitting the result-set into sequential pages of entities, the data can be requested incrementally. This reduces initial network load and improves overall response times. If the payload of an OData response contains a link including a `$skiptoken`, then it indicates a next page to the result-set. The iterable result-set is a consistent snapshot of the data, it can not change between reading individual pages.
 
 In comparison the OData consumer may use query options `$top` and `$skip` (client-driven paging) to read partial data from the result-set. But relying on a consistent state while browsing through the data can be problematic. Between individual requests another user could delete or add an item. This would result in an inconsistent aggregation of data.
 
@@ -409,4 +411,4 @@ Stream<BusinessPartner> streamingEntities = service
   .execute(destination);
 ```
 
-The request builder allows for setting the optional parameter for preferred page size. Please note that the OData service may not be obliged to respect this setting.
+The request builder allows for setting the optional parameter for preferred page size. Please note that the OData service is not obliged to respect this setting.

--- a/docs/java/features/odata/type-safe-client-odata-v4.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v4.mdx
@@ -383,3 +383,30 @@ POST /ODataService/API_BUSINESS_PARTNER/A_BusinessPartner(123)/to_BusinessPartne
   "country": "de"
 }
 ```
+
+## Server-Driven Paging
+
+OData service operators may decide to enable server-driven pagination to limit the amount of data that is fetched and sent over the network to the client, in case generic query options yield huge amounts of data. By splitting the result-set into sequential pages of entities, the data can be requested incrementally. This reduces initial network load and improves overall response times. If the payload of an OData response contains a link including a `$skiptoken`, then it indicates a next page to the result-set.
+
+In comparison the OData consumer may use query options `$top` and `$skip` (client-driven paging) to read partial data from the result-set. But relying on a consistent state while browsing through the data can be problematic. Between individual requests another user could delete or add an item. This would result in an inconsistent aggregation of data.
+
+By default the SAP Cloud SDK automatically resolves all pages of a result-set if server-driven paging is encountered. For the API consumer it is not necessary to parse the next link and instantiate follow-up requests to aggregate the full result-set. In case memory efficiency and response time is the priority, then the advanced API provides additional means to manually iterate through the internal pages. While accessing the following methods, the internal HTTP requests are executed lazily:
+
+```java
+Iterable<List<BusinessPartner>> iterablePagesOfEntities = service
+  .getAllBusinessPartner()
+  .iteratingPages()
+  .execute( destination );
+
+Iterable<BusinessPartner> iterableEntities = service
+  .getAllBusinessPartner()
+  .iteratingEntities()
+  .execute(destination);
+  
+Stream<BusinessPartner> streamingEntities = service
+  .getAllBusinessPartner()
+  .streamingEntities()
+  .execute(destination);
+```
+
+The request builder allows for setting the optional parameter for preferred page size. Please note that the OData service may not be obliged to respect this setting.


### PR DESCRIPTION
Documentation for the upcoming experimental server-driven paging feature of Cloud SDK.
Planned release date: 4th of December.

Sources
https://www.odata.org/documentation/odata-version-2-0/json-format/
https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_ServerDrivenPaging