### PR TITLE
Removed unnecessary spring-context dep from Rest Generator guide

### DIFF
--- a/docs/java/features/rest/generate-rest-client.mdx
+++ b/docs/java/features/rest/generate-rest-client.mdx
@@ -34,11 +34,6 @@ The generated Java classes need the following dependencies to be present in your
 	<artifactId>swagger-annotations</artifactId>
 	<version>use-latest-version</version>
 </dependency>
-<dependency>
-    <groupId>org.springframework</groupId>
-    <artifactId>spring-context</artifactId>
-    <version>use-latest-version</version>
-</dependency>
 ```
 
 <!-- vale on -->


### PR DESCRIPTION
## What Has Changed?

Removed unnecessary dependency spring-context from the rest generator document 
## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on it's own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [ ] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
