### PR TITLE
Add note on dependency scope change for multi tenancy with BAPI

### DIFF
--- a/docs/java/features/bapi-and-rfc/overview.mdx
+++ b/docs/java/features/bapi-and-rfc/overview.mdx
@@ -346,7 +346,7 @@ env:
 
 In case you want to use multitenancy or multithreading you need to adapt the dependency scope of `java-api` in your project.
 This dependency comes in via the SAP Cloud SDK with the usual `compile` scope.
-However, for this special use case it has to be overriden with `provided` when using the `SAP Java Buildpack`.
+However, for this special use-case, it has to be overridden with `provided` when using the `SAP Java Buildpack`.
 At the top of your dependency management section, before including any Cloud SDK dependencies in your project, insert the following:
 
 ```xml
@@ -356,12 +356,6 @@ At the top of your dependency management section, before including any Cloud SDK
     <version>latest-version-here</version>
     <scope>provided</scope>
 </dependency>
-```
- 
-:::tip
-This is necessary only if you are relying on the `SAP Java Buildpack` and want to use the [resilience](/docs/java/features/resilience/) or [multithreading and multitenancy](/docs/java/features/multi-tenancy/multi-tenancy-thread-context) capabilities of the SDK.
-:::
-
 ### Decoration of RFC Destinations
 
 In the realm of HTTP, destinations allow decoration to add further features to them.

--- a/docs/java/features/bapi-and-rfc/overview.mdx
+++ b/docs/java/features/bapi-and-rfc/overview.mdx
@@ -342,7 +342,7 @@ env:
 
 - Furthermore, you must specify the environment variable `USE_JCO` to load JCo during app deployment.
 
-### Subscriber Tenant is not found at Runtime
+### Subscriber Tenant Is Not Found at Runtime
 
 In case you want to use multitenancy or multithreading you need to adapt the dependency scope of `java-api` in your project.
 This dependency comes in via the SAP Cloud SDK with the usual `compile` scope.

--- a/docs/java/features/bapi-and-rfc/overview.mdx
+++ b/docs/java/features/bapi-and-rfc/overview.mdx
@@ -342,6 +342,26 @@ env:
 
 - Furthermore, you must specify the environment variable `USE_JCO` to load JCo during app deployment.
 
+### Subscriber Tenant is not found at Runtime
+
+In case you want to use multitenancy or multithreading you need to adapt the dependency scope of `java-api` in your project.
+This dependency comes in via the SAP Cloud SDK with the usual `compile` scope.
+However, for this special use case it has to be overriden with `provided` when using the `SAP Java Buildpack`.
+At the top of your dependency management section, before including any Cloud SDK dependencies in your project, insert the following:
+
+```xml
+<dependency>
+    <groupId>com.sap.cloud.security</groupId>
+    <artifactId>java-api</artifactId>
+    <version>latest-version-here</version>
+    <scope>provided</scope>
+</dependency>
+```
+ 
+:::tip
+This is necessary only if you are relying on the `SAP Java Buildpack` and want to use the [resilience](/docs/java/features/resilience/) or [multithreading and multitenancy](/docs/java/features/multi-tenancy/multi-tenancy-thread-context) capabilities of the SDK.
+:::
+
 ### Decoration of RFC Destinations
 
 In the realm of HTTP, destinations allow decoration to add further features to them.

--- a/docs/java/troubleshooting.mdx
+++ b/docs/java/troubleshooting.mdx
@@ -44,7 +44,7 @@ Tenant or principal information is not available or an incorrect tenant is used.
 - There was no JWT in the authorization header.
 
 - A BAPI/RFC call was attempted while using resilience or multithreading capabilities of the SAP Cloud SDK.
-  See [Subscriber Tenant is not found at Runtime](features/bapi-and-rfc/bapi-and-rfc-overview#subscriber-tenant-is-not-found-at-runtime)
+  See [Subscriber Tenant Is Not Found at Runtime](features/bapi-and-rfc/bapi-and-rfc-overview#subscriber-tenant-is-not-found-at-runtime)
 
 ### Provider Instead of Subscriber Account Used
 

--- a/docs/java/troubleshooting.mdx
+++ b/docs/java/troubleshooting.mdx
@@ -43,7 +43,7 @@ Tenant or principal information is not available or an incorrect tenant is used.
 
 - There was no JWT in the authorization header.
 
-- A BAPI/RFC call was attempted while using resilience or multithreading capabilities of the SDK.
+- A BAPI/RFC call was attempted while using resilience or multithreading capabilities of the SAP Cloud SDK.
   See [Subscriber Tenant is not found at Runtime](features/bapi-and-rfc/bapi-and-rfc-overview#subscriber-tenant-is-not-found-at-runtime)
 
 ### Provider Instead of Subscriber Account Used

--- a/docs/java/troubleshooting.mdx
+++ b/docs/java/troubleshooting.mdx
@@ -43,6 +43,9 @@ Tenant or principal information is not available or an incorrect tenant is used.
 
 - There was no JWT in the authorization header.
 
+- A BAPI/RFC call was attempted while using resilience or multithreading capabilities of the SDK.
+  See [Subscriber Tenant is not found at Runtime](features/bapi-and-rfc/bapi-and-rfc-overview#subscriber-tenant-is-not-found-at-runtime)
+
 ### Provider Instead of Subscriber Account Used
 
 :::info **Symptoms**


### PR DESCRIPTION
## What Has Changed?

Adds a note in the BAPI docs that for multi-threading or resilience a dependency scope change is needed when using the SAP Java Buildpack. Also adds an entry under the troubleshooting guide.

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on it's own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
