### PR TITLE
Adjust documentation for destination look via issuerlinter prettier

### DIFF
--- a/docs/js/features/connectivity/destination.mdx
+++ b/docs/js/features/connectivity/destination.mdx
@@ -121,7 +121,9 @@ In a productive environment, you will use a [Destination service](https://help.s
 
 #### Authentication and JSON Web Token Retrieval
 
-To access the destination service, the SAP Cloud SDK will first fetch an access token from the XSUAA service via one of the supported authentication flows:
+To access the destination service, the SAP Cloud SDK will first fetch an access token from the XSUAA service.
+The token retrieved from the XSUAA service is used to make a call to the destination service and receive the destinations.
+The destination service returns a destination with all relevant authentication information depending on the used authentication flow:
 
 - `PrincipalPropagation`
 - `NoAuthentication`
@@ -131,7 +133,7 @@ To access the destination service, the SAP Cloud SDK will first fetch an access 
 - `OAuth2ClientCredentials`
 - `ClientCertificateAuthentication`
 
-The token retrieved from the XSUAA service is used to make a call to the destination service and receive the destinations.
+The SDK automatically parses the response of the destination service and uses the provided authentication information for the request to the target system.
 For a simple service, this would be the end of the story.
 
 #### Multi-Tenancy
@@ -193,4 +195,25 @@ One aspect has been left out for simplicity.
 In principle, it is possible to define destinations not only on the account level but also on the destination service level.
 These destinations are called `instance destinations` since they are tied to a service binding called instance on SCP.
 In every request, these destinations are added to the destinations returned by the destination service.
+:::
+
+#### Destination Lookup without a JWT
+
+There are situations where you do not have a JWT issued by the XSUAA but need to lookup a destination e.g. background processes.
+In such situations the property `iss` of the `DestinationAccessorOptions` can be used:
+
+```js
+.execute({destinationName: 'myDestination'},{iss:yourIssuerValue})
+```
+
+The value for `iss` is supposed to be the same as in a JWT issued from the XSUAA e.g. `https://yourSubdomain.localhost:8080/uaa/oauth/token`.
+In principle only the host of the url is relevant but since the same parsing and replace methods are used for the `iss` and `userJWT` case please provide the URL as stated before.
+
+:::note
+If a JWT is used in the destination lookup a validation of the provided token is performed.
+This validation ensures that no values of the JWT have been manipulated.
+If only the `iss` is provided no such validation is performed.
+Note that the subdomain value defines from which cloud foundry tenant destinations are fetched.
+So a wrong value may break the tenant isolation.
+It is your responsibility as a developer to ensure that the provided value for the `iss` property is valid.
 :::

--- a/docs/js/features/connectivity/destination.mdx
+++ b/docs/js/features/connectivity/destination.mdx
@@ -211,9 +211,9 @@ In principle only the host of the url is relevant but since the same parsing and
 
 :::note
 If a JWT is used in the destination lookup a validation of the provided token is performed.
-This validation ensures that no values of the JWT have been manipulated.
+This validation ensures that the JWT has not been manipulated.
 If only the `iss` is provided no such validation is performed.
-Note that the subdomain value defines from which cloud foundry tenant destinations are fetched.
+Note that the given subdomain value defines from which tenant destinations are fetched.
 So a wrong value may break the tenant isolation.
 It is your responsibility as a developer to ensure that the provided value for the `iss` property is valid.
 :::

--- a/docs/js/features/connectivity/destination.mdx
+++ b/docs/js/features/connectivity/destination.mdx
@@ -203,7 +203,10 @@ There are situations where you do not have a JWT issued by the XSUAA but need to
 In such situations the property `iss` of the `DestinationAccessorOptions` can be used:
 
 ```js
-.execute({destinationName: 'myDestination'},{iss:yourIssuerValue})
+.execute(
+  { destinationName: 'myDestination' },
+  { iss:yourIssuerValue }
+ )
 ```
 
 The value for `iss` is supposed to be the same as in a JWT issued from the XSUAA e.g. `https://yourSubdomain.localhost:8080/uaa/oauth/token`.

--- a/docs/js/features/connectivity/destination.mdx
+++ b/docs/js/features/connectivity/destination.mdx
@@ -199,7 +199,7 @@ In every request, these destinations are added to the destinations returned by t
 
 #### Destination Lookup without a JWT
 
-There are situations where you do not have a JWT issued by the XSUAA but need to lookup a destination e.g. background processes.
+There are situations where you do not have a JWT issued by the XSUAA but need to look a destination up e.g. in background processes.
 In such situations the property `iss` of the `DestinationAccessorOptions` can be used:
 
 ```js

--- a/docs/js/features/connectivity/destination.mdx
+++ b/docs/js/features/connectivity/destination.mdx
@@ -216,6 +216,6 @@ If a JWT is used in the destination lookup a validation of the provided token is
 This validation ensures that the JWT has not been manipulated.
 If only the `iss` is provided no such validation is performed.
 Note that the given subdomain value defines from which tenant destinations are fetched.
-So a wrong value may break the tenant isolation.
+So a wrong value may break the isolation for tenants.
 It is your responsibility as a developer to ensure that the provided value for the `iss` property is valid.
 :::

--- a/docs/js/features/connectivity/destination.mdx
+++ b/docs/js/features/connectivity/destination.mdx
@@ -207,7 +207,7 @@ In such situations the property `iss` of the `DestinationAccessorOptions` can be
 ```
 
 The value for `iss` is supposed to be the same as in a JWT issued from the XSUAA e.g. `https://yourSubdomain.localhost:8080/uaa/oauth/token`.
-In principle only the host of the url is relevant but since the same parsing and replace methods are used for the `iss` and `userJWT` case please provide the URL as stated before.
+In principle only the host of the url is relevant but since the same parsing and replacement methods are used as for the JWT handling, the URL has to be provided in the format above.
 
 :::note
 If a JWT is used in the destination lookup a validation of the provided token is performed.

--- a/docs/js/features/connectivity/destination.mdx
+++ b/docs/js/features/connectivity/destination.mdx
@@ -133,7 +133,7 @@ The destination service returns a destination with all relevant authentication i
 - `OAuth2ClientCredentials`
 - `ClientCertificateAuthentication`
 
-The SDK automatically parses the response of the destination service and uses the provided authentication information for the request to the target system.
+The SAP Cloud SDK automatically parses the response of the destination service and uses the provided authentication information for the request to the target system.
 For a simple service, this would be the end of the story.
 
 #### Multi-Tenancy

--- a/docs/js/features/connectivity/destination.mdx
+++ b/docs/js/features/connectivity/destination.mdx
@@ -205,9 +205,8 @@ In such situations the property `iss` of the `DestinationAccessorOptions` can be
 ```js
 .execute(
   { destinationName: 'myDestination' },
-  { iss:yourIssuerValue }
+  { iss: yourIssuerValue }
  )
-```
 
 The value for `iss` is supposed to be the same as in a JWT issued from the XSUAA e.g. `https://yourSubdomain.localhost:8080/uaa/oauth/token`.
 In principle only the host of the url is relevant but since the same parsing and replacement methods are used as for the JWT handling, the URL has to be provided in the format above.

--- a/docs/js/features/connectivity/destination.mdx
+++ b/docs/js/features/connectivity/destination.mdx
@@ -209,7 +209,7 @@ In such situations the property `iss` of the `DestinationAccessorOptions` can be
  )
 
 The value for `iss` is supposed to be the same as in a JWT issued from the XSUAA e.g. `https://yourSubdomain.localhost:8080/uaa/oauth/token`.
-In principle only the host of the url is relevant but since the same parsing and replacement methods are used as for the JWT handling, the URL has to be provided in the format above.
+In principle only the host of the URL is relevant but since the same parsing and replacement methods are used for the JWT handling, the URL has to be provided in the format above.
 
 :::note
 If a JWT is used in the destination lookup a validation of the provided token is performed.


### PR DESCRIPTION
## What Has Changed?

Added a section for destintaion lookup using the issuer field.

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [x] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
