### PR TITLE
Add MDI to feature-matrix

### DIFF
--- a/docs/components/data/features.js
+++ b/docs/components/data/features.js
@@ -337,6 +337,34 @@ export const features = [
       docsLink: `[docs](${baseUrl}/js/features/cli/overview)`,
       note: ''
     }
+  },
+   {
+    name: 'MDI',
+    category: 'MDI',
+    java: {
+      status: ':gear:',
+      docsLink: ``,
+      note: `Internal only or allow listed`
+    },
+    js: {
+      status: ':x:',
+      docsLink: ``,
+      note: 'Planned if requested'
+    }
+  },
+  {
+    name: 'MDO',
+    category: 'MDO',
+    java: {
+      status: ':gear:',
+      docsLink: ``,
+      note: `Internal only or allow listed`
+    },
+    js: {
+      status: ':x:',
+      docsLink: ``,
+      note: 'Planned if requested'
+    }
   }
 ];
 

--- a/docs/components/data/features.js
+++ b/docs/components/data/features.js
@@ -356,7 +356,7 @@ export const features = [
     name: 'MDO',
     category: 'MDO',
     java: {
-      status: ':gear:',
+      status: ':bulb:',
       docsLink: ``,
       note: `Internal only or allow listed`
     },

--- a/docs/components/data/features.js
+++ b/docs/components/data/features.js
@@ -342,7 +342,7 @@ export const features = [
     name: 'MDI',
     category: 'MDI',
     java: {
-      status: ':gear:',
+      status: ':bulb:',
       docsLink: ``,
       note: `Internal only or allow listed`
     },


### PR DESCRIPTION
## What Has Changed?

I decided to add MDI to the feature-matrix so that internal customers who look into it are aware it exists.
![image](https://user-images.githubusercontent.com/10460752/105699954-6db6b680-5f08-11eb-8fbb-ece6735e5276.png)

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [x] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
