### PR TITLE
Update BAPI Document

### DIFF
--- a/docs/java/features/bapi-and-rfc/overview.mdx
+++ b/docs/java/features/bapi-and-rfc/overview.mdx
@@ -554,6 +554,7 @@ Example value: `-Djco.destinations.dir=here-comes-the-directory-with-the-destina
 </Tabs>
 
 #### Set Destination as Environment Variable
+
 In order to your destination to be found in the local environment you need to supply destinations as an environment variable in your local machine:
 
 <Tabs groupId="os" defaultValue="windows" values={[ { label: 'Windows', value: 'windows', }, { label: 'Mac', value: 'mac', }]}>

--- a/docs/java/features/bapi-and-rfc/overview.mdx
+++ b/docs/java/features/bapi-and-rfc/overview.mdx
@@ -561,7 +561,7 @@ In order to your destination to be found in the local environment you need to su
 
 <TabItem value="windows">
 
-You can set the destinations environment variable by the follwing command:
+You can set the destinations environment variable by the following command:
 
 ```
 set destinations=[{name: "destinationName"}]
@@ -571,7 +571,7 @@ set destinations=[{name: "destinationName"}]
 
 <TabItem value="mac">
 
-You can set the destinations environment variable by the follwing command:
+You can set the destinations environment variable by the following command:
 
 ```
 export destinations=[{name: "destinationName"}]

--- a/docs/java/features/bapi-and-rfc/overview.mdx
+++ b/docs/java/features/bapi-and-rfc/overview.mdx
@@ -553,6 +553,33 @@ Example value: `-Djco.destinations.dir=here-comes-the-directory-with-the-destina
 
 </Tabs>
 
+#### Set Destination as Environment Variable
+In order to your destination to be found in the local environment you need to supply destinations as an environment variable in your local machine:
+
+<Tabs groupId="os" defaultValue="windows" values={[ { label: 'Windows', value: 'windows', }, { label: 'Mac', value: 'mac', }]}>
+
+<TabItem value="windows">
+
+You can set the destinations environment variable by the follwing command:
+
+```
+set destinations=[{name: "destinationName"}]
+```
+
+</TabItem>
+
+<TabItem value="mac">
+
+You can set the destinations environment variable by the follwing command:
+
+```
+export destinations=[{name: "destinationName"}]
+```
+
+</TabItem>
+
+</Tabs>
+
 #### Launch App on Localhost
 
 <Tabs groupId="archetype" defaultValue="tomee" values={[ { label: 'TomEE', value: 'tomee', }, { label: 'Spring', value: 'spring', }]}>

--- a/docs/java/features/bapi-and-rfc/overview.mdx
+++ b/docs/java/features/bapi-and-rfc/overview.mdx
@@ -555,7 +555,7 @@ Example value: `-Djco.destinations.dir=here-comes-the-directory-with-the-destina
 
 #### Set Destination as Environment Variable
 
-In order to your destination to be found in the local environment you need to supply destinations as an environment variable in your local machine:
+To let your destination be found in the local environment you need to supply an environment variable `destinations` on your local machine:
 
 <Tabs groupId="os" defaultValue="windows" values={[ { label: 'Windows', value: 'windows', }, { label: 'Mac', value: 'mac', }]}>
 

--- a/docs/java/features/bapi-and-rfc/overview.mdx
+++ b/docs/java/features/bapi-and-rfc/overview.mdx
@@ -561,7 +561,7 @@ To let your destination be found in the local environment you need to supply an 
 
 <TabItem value="windows">
 
-You can set the destinations environment variable by the following command:
+You can set the `destinations` environment variable by the following command:
 
 ```
 set destinations=[{name: "destinationName"}]


### PR DESCRIPTION
## What Has Changed?

Added a section in BAPI Local deployment to set the destinations environment variable. 
WRT to this SO Issue: https://stackoverflow.com/questions/65806231/the-destination-could-not-be-found-when-calling-bapi-locally-with-cloud-sdk-spri
## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [ ] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [ ] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
