### PR TITLE
[Support] Configurable Timeout in ScpCfDestinationLoader

### DIFF
--- a/docs/java/features/connectivity/destinations.mdx
+++ b/docs/java/features/connectivity/destinations.mdx
@@ -214,7 +214,7 @@ If your app requires more time when fetching destinations, you may create your o
 final DestinationLoader destinationLoader = new ScpCfDestinationLoader(Duration.ofSecond(10));
 ```
 
-This operation will override the default timeout duration so that you are free to choose whatever value fits your needs.
+This operation overrides the default timeout duration so that you are free to choose whatever value fits your needs.
 
 :::note Hint
 

--- a/docs/java/features/connectivity/destinations.mdx
+++ b/docs/java/features/connectivity/destinations.mdx
@@ -138,7 +138,7 @@ That means the new loader can operate as a fallback.
 Use `prependDestinationLoader()` to add it at the beginning if you would like it to take precedence.
 Lastly use `setLoader()` to replace all existing loaders.
 
-## Provide Headers For Destinations
+## Provide Headers for Destinations
 
 ### How It Works
 
@@ -203,6 +203,30 @@ final Try<Iterable<ScpCfDestination>> destinations = destinationLoader.tryGetAll
 ```
 
 In the above call `destinationLoader` needs to be an instance of `ScpCfDestinationLoader`.
+
+#### Configuring Timeout Durations When Querying the Destination Service on Cloud Foundry
+
+By default, the [TimeLimiter resilience pattern](/cloud-sdk/docs/java/features/resilience/resilience#resilience-capabilities) aborts requests to the Destination Service on Cloud Foundry after 6 seconds.
+If your app requires more time when fetching destinations, you may create your own `ScpCfDestinationLoader` instance by:
+
+```java
+// Allow requests to take up to 10 seconds instead of just 6
+final DestinationLoader destinationLoader = new ScpCfDestinationLoader(Duration.ofSecond(10));
+```
+
+This operation will override the default timeout duration so that you are free to choose whatever value fits your needs.
+
+:::note Hint
+
+You may register your `destinationLoader` within the `DestinationAccessor` by:
+
+```java
+DestinationAccessor.setLoader(destinationLoader);
+```
+
+That way, all future requests to the Destination Service will use the increased timeout duration.
+
+:::
 
 #### Building Destination Options
 


### PR DESCRIPTION
## What Has Changed?

Add documentation on how to configure the TimeLimiter timeout when using the `ScpCfDestinationLoader`.

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [x] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
