### PR TITLE
Update javadoc link

### DIFF
--- a/docs/java/release-notes.mdx
+++ b/docs/java/release-notes.mdx
@@ -51,7 +51,7 @@ We highly recommend regularly updating to the latest SDK version. It will help y
 
 ## 3.37.0 - January 28, 2021
 
-[Maven Central](https://search.maven.org/search?q=g:com.sap.cloud.sdk*%20AND%20v:3.37.0) | [Javadoc](https://help.sap.com/doc/aa4a7715649349a285a13c8bc1d585d8/1.0/en-US/index.html)
+[Maven Central](https://search.maven.org/search?q=g:com.sap.cloud.sdk*%20AND%20v:3.37.0) | [Javadoc](https://help.sap.com/doc/9e7b665dbf6149ec964c148ec9bf6641/1.0/en-US/index.html)
 
 ### Compatibility Notes
 


### PR DESCRIPTION
## What Has Changed?

I have added the right javadoc link in the release notes for version 3.37.0 

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x]~ You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)~
- [x] ~You formatted all changed files with prettier (`npm run prettier`)~
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [x]~ You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.~
