### PR TITLE
Add section on OpenAPI extensions

### DIFF
--- a/docs/java/features/rest/generate-rest-client.mdx
+++ b/docs/java/features/rest/generate-rest-client.mdx
@@ -74,6 +74,24 @@ Please note that the version of the above plugin must be specified at least once
 Also, the version of the plugin should be the same as of the SAP Cloud SDK.
 We recommend using a Maven property for defining the version of both the Maven plugin and the SAP Cloud SDK BOM.
 
+### Customizing the Generated Code
+
+The SAP Cloud SDK offers further customization of the generated code via [OpenAPI vendor exentsions](https://swagger.io/docs/specification/openapi-extensions/).
+
+#### Method Names
+
+Use the property `x-sap-cloud-sdk-operation-name` to specify the method name for an operation:
+
+```yml
+/operation/path:
+  get:
+    summary: My Operation.
+    x-sap-cloud-sdk-operation-name: performMyOperation
+    operationId: myOperation
+```
+
+This field is optional and the generator will fall back to using the `operationId` if not present.
+
 ### Generating Java Client Library for Multiple OpenAPI Specifications
 
 This Maven plugin processes one OpenAPI specification per execution.


### PR DESCRIPTION
## What Has Changed?

Add a section on customising method names in the OpenAPI generator.

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [x] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
