### PR TITLE
Indicate default destination retrieval strategy

### DIFF
--- a/docs/java/features/connectivity/destinations.mdx
+++ b/docs/java/features/connectivity/destinations.mdx
@@ -264,7 +264,7 @@ final DestinationOptions options = DestinationOptions.builder().build();
 
 For a provider/subscriber setup, a [retrieval strategy](https://help.sap.com/doc/b579bf8578954412aea2b458e8452201/1.0/en-US/com/sap/cloud/sdk/cloudplatform/connectivity/ScpCfDestinationRetrievalStrategy.html) must be chosen according to your particular use case from:
 
-- `ALWAYS_SUBSCRIBER`
+- `ALWAYS_SUBSCRIBER` (default)
 - `ALWAYS_PROVIDER`
 - `SUBSCRIBER_THEN_PROVIDER`.
 


### PR DESCRIPTION
## What Has Changed?

To avoid confusion, let's publicly declare the default behavior for retrieving destinations.

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [x] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
