### PR TITLE
Add info about retrieving entities before updating

### DIFF
--- a/docs/java/features/odata/type-safe-client-odata-v2.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v2.mdx
@@ -441,7 +441,7 @@ Refer to the [section about ETags for details](#handling-of-etags).
 <TabItem value="modify">
 
 The default strategy is the _modifying entity update strategy_ which attempts to modify only the necessary entity fields in the remote system.
-It issues a PATCH request and includes only the fields in the request payload whose values were changed by its setter method.
+It issues a PATCH request and includes only the fields in the request payload whose values were _changed by its setter method_.
 Hence, fields whose values remain unchanged are not sent to the target system.
 Calling the method `includingFields(fields ...)` instructs the SAP Cloud SDK to add the mentioned fields explicitly in the update request.
 This is useful for backend systems that require some unchanged fields in the request payload for given reasons.

--- a/docs/java/features/odata/type-safe-client-odata-v2.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v2.mdx
@@ -428,6 +428,14 @@ You have to cast the entity representations from the generic type `VdmEntity` to
 
 The SAP Cloud SDK supports different strategies for updating entities which differ in the HTTP method and the payload of the update request.
 
+:::info
+To update an entity it should first be retrieved from the service.
+This ensures the latest state of the entity is updated.
+Otherwise updating with old data could erase changes that have been made to the entity in the mean time.
+Many services will enforce this behaviour with optimistic locking mechanisms.
+Refer to the [section about ETags for details](#handling-of-etags).
+:::
+
 <Tabs groupId="updateStrategy" defaultValue="modify" values={[ { label: 'Modify Entity (default)', value: 'modify', }, { label: 'Replace Entity', value: 'replace', }, ]}>
 
 <TabItem value="modify">

--- a/docs/java/features/odata/type-safe-client-odata-v4.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v4.mdx
@@ -290,6 +290,14 @@ Hence, if the changeset was a failure then evaluating the result of any of the c
 
 The SAP Cloud SDK supports different strategies for updating entities which differ in the HTTP method and the payload of the update request.
 
+:::info
+To update an entity it should first be retrieved from the service.
+This ensures the latest state of the entity is updated.
+Otherwise updating with old data could erase changes that have been made to the entity in the mean time.
+Many services will enforce this behaviour with optimistic locking mechanisms.
+Refer to the [section about ETags for details](#handling-of-etags).
+:::
+
 <Tabs groupId="updateStrategy" defaultValue="modify" values={[ { label: 'Modify Entity (default)', value: 'modify', }, { label: 'Replace Entity', value: 'replace', }, ]}>
 
 <TabItem value="modify">

--- a/docs/java/features/odata/type-safe-client-odata-v4.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v4.mdx
@@ -303,7 +303,7 @@ Refer to the [section about ETags for details](#handling-of-etags).
 <TabItem value="modify">
 
 The default strategy is the _modifying entity update strategy_ which attempts to modify only the necessary entity fields in the remote system.
-It issues a PATCH request and includes only the fields in the request payload whose values were changed by its setter method.
+It issues a PATCH request and includes only the fields in the request payload whose values were _changed by its setter method_.
 Hence, fields whose values remain unchanged are not sent to the target system.
 Calling the method `includingFields(fields ...)` instructs the SAP Cloud SDK to add the mentioned fields explicitly in the update request.
 This is useful for backend systems that require some unchanged fields in the request payload for given reasons.

--- a/docs/java/features/rest/generate-rest-client.mdx
+++ b/docs/java/features/rest/generate-rest-client.mdx
@@ -43,7 +43,7 @@ Thereby you can leave the `tag` and `operationId` fields untouched if they need 
 
 ### Java Class Name
 
-The Java class name can be influenced with the extension field `x-sap-cloud-sdk-api-name`. 
+The Java class name can be influenced with the extension field `x-sap-cloud-sdk-api-name`.
 The OpenAPI generator takes the value of `x-sap-cloud-sdk-api-name` and adds the `Api` prefix to determine the class name.
 
 In the following example the custom value `CustomOperations` takes precedence over the `tag` value `Operations`
@@ -56,7 +56,7 @@ In the following example the custom value `CustomOperations` takes precedence ov
     x-sap-cloud-sdk-api-name: CustomOperations
     tags:
       - Operations
-```		
+```
 
 The Java class for this service operation will be named `CustomOperationsApi`.
 


### PR DESCRIPTION
## What Has Changed?

Add an info note about retrieving an entity first before updating. See: https://stackoverflow.com/questions/66573358/attempt-to-create-simple-contact-gives-error-patch-requests-require-components

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [x] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
