### PR TITLE
[3.41.0] OData v2 Batch Read API

### DIFF
--- a/docs/java/features/odata/type-safe-client-odata-v2.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v2.mdx
@@ -385,26 +385,41 @@ The `service` object offers the method `batch` which allows access to the batch-
 Multiple single requests (like `createBusinessPartnerAddress`) can be wrapped into so-called changesets.
 Each changeset is opened with `beginChangeSet` and closed with `endChangeSet`. You can wrap multiple changesets into one batch request.
 
+Non-modification requests can be added outside of changesets with the `addReadOperations` method.
+
 Use `executeRequest` to issue the batch request to the remote system.
 We receive an instance of `BatchResponse` as the result object.
 
 ```java
-final BatchResponse result =
+BusinessPartnerAddress addressToCreate1;
+BusinessPartnerAddress addressToCreate2;
+
+BusinessPartnerFluentHelper requestTenEntities = service.getAllBusinessPartner().top(10);
+BusinessPartnerByKeyFluentHelper requestSingleEntity = service.getBusinessPartnerByKey("bupa9000");
+
+BatchResponse result =
     service
         .batch()
         .beginChangeSet()
-        .createBusinessPartnerAddress(address1)
-        .createBusinessPartnerAddress(address2)
+        .createBusinessPartnerAddress(addressToCreate1)
+        .createBusinessPartnerAddress(addressToCreate2)
         .endChangeSet()
+        .addReadOperations(requestTenEntities)
+        .addReadOperations(requestSingleEntity)
         .executeRequest(destination);
 ```
 
 #### Access Batch Response
 
+In OData Batch the response is structured similar to the request.
+The unordered responses of data modification requests are accessible with a given changeset index.
+The ordered responses of data retrieval requests are accessible with the reference of the original request object.
+
+##### Changeset Response
 Use the method `get` to access the individual changeset responses by index.
 
 ```java
-final Try<BatchResponseChangeSet> changeSetTry = result.get(0);
+Try<BatchResponseChangeSet> changeSetTry = result.get(0);
 ```
 
 The returned `Try` allows checking if the respective changeset was processed successfully by the remote server.
@@ -423,6 +438,19 @@ if (changeSetTry.isSuccess()) {
 :::note
 You have to cast the entity representations from the generic type `VdmEntity` to the respective subclasses.
 :::
+
+##### Read Response
+
+Use the method `getReadResult` to extract the deserialized response of a given read operation:
+
+```java
+List<BusinessPartner> entities = result.getReadResult(requestTenEntities);
+BusinessPartner entity = result.getReadResult(requestSingleEntity);
+```
+
+Instead of an index to indicate the batch position, the API expects the original request reference.
+The request-response mapping and deserialization is happening internally.
+
 
 ## Entity Update Strategies
 

--- a/docs/java/features/odata/type-safe-client-odata-v2.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v2.mdx
@@ -449,7 +449,7 @@ BusinessPartner entity = result.getReadResult(requestSingleEntity);
 ```
 
 Instead of an index to indicate the batch position, the API expects the original request reference.
-The request-response mapping and deserialization is happening internally.
+The request-response mapping and deserialization are happening internally.
 
 
 ## Entity Update Strategies

--- a/docs/java/features/odata/type-safe-client-odata-v2.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v2.mdx
@@ -385,7 +385,7 @@ The `service` object offers the method `batch` which allows access to the batch-
 Multiple single requests (like `createBusinessPartnerAddress`) can be wrapped into so-called changesets.
 Each changeset is opened with `beginChangeSet` and closed with `endChangeSet`. You can wrap multiple changesets into one batch request.
 
-Non-modification requests can be added outside of changesets with the `addReadOperations` method.
+Non-modification or in other words Read requests can be added outside of changesets with the `addReadOperations` method.
 
 Use `executeRequest` to issue the batch request to the remote system.
 We receive an instance of `BatchResponse` as the result object.

--- a/docs/java/features/odata/type-safe-client-odata-v2.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v2.mdx
@@ -411,7 +411,7 @@ BatchResponse result =
 
 #### Access Batch Response
 
-In OData Batch the response is structured similar to the request.
+In OData Batch, the response is structured similarly to the request.
 The unordered responses of data modification requests are accessible with a given changeset index.
 The ordered responses of data retrieval requests are accessible with the reference of the original request object.
 


### PR DESCRIPTION
## What Has Changed?

In the upcoming release additional API is being introduced for OData V2 batch.

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [ ] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [ ] You formatted all changed files with prettier (`npm run prettier`)
- [ ] You tested if the documentation still builds (`npm run build`)
- [ ] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [ ] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
