### PR TITLE
Add section on ThreadContext propagation details

### DIFF
--- a/docs/java/features/multi-tenancy/thread-context.mdx
+++ b/docs/java/features/multi-tenancy/thread-context.mdx
@@ -62,6 +62,33 @@ In that case you can override the current tenant explicitly:
 TenantAccessor.executeWithTenant(customTenant, () -> doStuff());
 ```
 
+:::caution
+Be aware, that the _executeWith_ methods shown above only replaces the given property, but does not update properties derived from it.
+
+Example: You have a special _AuthToken_, that you propagate with _AuthTokenAccessor.executeWithAuthToken_.
+Inside the given code block only the _AuthToken_ will be replaced, while e.g. the _Tenant_ is the same as in the original context.
+
+If you want to start a fresh context based on a given _AuthToken_, for example accessing information of the provider tenant while in a subscriber context, have a look at this code:
+
+```java
+
+Tenant retrieveProviderTenant()
+{
+    // retrieves an access token from the provider context
+    AuthToken providerXsuaaAccessToken = AuthTokenAccessor.getXsuaaServiceToken();
+    return new ThreadContextExecutor()
+        // don't reuse the original context
+        .withoutParentThreadContext()
+        // add the provider token into the new context
+        .withListeners(new AuthTokenThreadContextListener(providerXsuaaAccessToken))
+        // return the actual provider tenant
+        .execute(TenantAccessor::getCurrentTenant);
+}
+
+```
+
+:::
+
 ### Running Asynchronous Operations
 
 As the name suggests the `ThreadContext` is bound to a Thread, more specifically to the one it was created.
@@ -92,31 +119,4 @@ invokeAsynchronously(operationWithContext);
 Be cautious with long-running, asynchronous operations.
 A propagated Thread context will only persist as long as the Thread lives that it was created on.
 So when the parent Thread dies the context will cease to exist and no longer be available in any of the Threads.
-:::
-
-:::note
-Be aware, that the _executeWith_ methods shown above only replaces the given property, but does not update properties derived from it.
-
-Example: You have a special _AuthToken_, that you propagate with _AuthTokenAccessor.executeWithAuthToken_.
-Inside the given code block only the _AuthToken_ will be replaced, while e.g. the _Tenant_ is the same as in the original context.
-
-If you want to start a fresh context based on a given _AuthToken_, for example accessing information of the provider tenant while in a subscriber context, have a look at this code:
-
-```java
-
-Tenant retrieveProviderTenant()
-{
-    // retrieves an access token from the provider context
-    AuthToken providerXsuaaAccessToken = AuthTokenAccessor.getXsuaaServiceToken();
-    return new ThreadContextExecutor()
-        // don't reuse the original context
-        .withoutParentThreadContext()
-        // add the provider token into the new context
-        .withListeners(new AuthTokenThreadContextListener(providerXsuaaAccessToken))
-        // return the actual provider tenant
-        .execute(TenantAccessor::getCurrentTenant);
-}
-
-```
-
 :::

--- a/docs/java/features/multi-tenancy/thread-context.mdx
+++ b/docs/java/features/multi-tenancy/thread-context.mdx
@@ -103,20 +103,20 @@ Inside the given code block only the _AuthToken_ will be replaced, while e.g. th
 If you want to start a fresh context based on a given _AuthToken_, for example accessing information of the provider tenant while in a subscriber context, have a look at this code:
 
 ```java
+
+Tenant retrieveProviderTenant()
 {
-  Tenant retrieveProviderTenant()
-  {
-      // retrieves an access token from the provider context
-      AuthToken providerXsuaaAccessToken = AuthTokenAccessor.getXsuaaServiceToken();
-      return new ThreadContextExecutor()
-          // don't reuse the original context
-          .withoutParentThreadContext()
-          // add the provider token into the new context
-          .withListeners(new AuthTokenThreadContextListener(providerXsuaaAccessToken))
-          // return the actual provider tenant
-          .execute(TenantAccessor::getCurrentTenant);
-  }
+    // retrieves an access token from the provider context
+    AuthToken providerXsuaaAccessToken = AuthTokenAccessor.getXsuaaServiceToken();
+    return new ThreadContextExecutor()
+        // don't reuse the original context
+        .withoutParentThreadContext()
+        // add the provider token into the new context
+        .withListeners(new AuthTokenThreadContextListener(providerXsuaaAccessToken))
+        // return the actual provider tenant
+        .execute(TenantAccessor::getCurrentTenant);
 }
+
 ```
 
 :::

--- a/docs/java/features/multi-tenancy/thread-context.mdx
+++ b/docs/java/features/multi-tenancy/thread-context.mdx
@@ -93,3 +93,30 @@ Be cautious with long-running, asynchronous operations.
 A propagated Thread context will only persist as long as the Thread lives that it was created on.
 So when the parent Thread dies the context will cease to exist and no longer be available in any of the Threads.
 :::
+
+:::note
+Be aware, that the _executeWith_ methods shown above only replaces the given property, but does not update properties derived from it.
+
+Example: You have a special _AuthToken_, that you propagate with _AuthTokenAccessor.executeWithAuthToken_.
+Inside the given code block only the _AuthToken_ will be replaced, while e.g. the _Tenant_ is the same as in the original context.
+
+If you want to start a fresh context based on a given _AuthToken_, for example accessing information of the provider tenant while in a subscriber context, have a look at this code:
+
+```java
+{
+  Tenant retrieveProviderTenant()
+  {
+      // retrieves an access token from the provider context
+      AuthToken providerXsuaaAccessToken = AuthTokenAccessor.getXsuaaServiceToken();
+      return new ThreadContextExecutor()
+          // don't reuse the original context
+          .withoutParentThreadContext()
+          // add the provider token into the new context
+          .withListeners(new AuthTokenThreadContextListener(providerXsuaaAccessToken))
+          // return the actual provider tenant
+          .execute(TenantAccessor::getCurrentTenant);
+  }
+}
+```
+
+:::

--- a/docs/js/extensions/currency-conversion.mdx
+++ b/docs/js/extensions/currency-conversion.mdx
@@ -15,7 +15,6 @@ keywords:
 import sdkVersions from '../../../static/currency-conversion/api/versions';
 import ApiReleaseList from '../../../src/sap/sdk-js/ApiReleaseList';
 
-
 ## Overview
 
 Currency Conversion is an extension library built on SAP Cloud SDK.
@@ -34,7 +33,6 @@ You can use the library for the following functions:
 - Fixed rate conversions, for when you have the exact currency exchange rate that you want to use in your conversion operations.
 - Non-fixed rate conversions, for when you have a set of exchange rates, as opposed to the exact rate.
   The library will pick the "best rate" from the set depending on various factors.
-
 
 ## SAP Cloud SDK Currency Conversion Library Versions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19401,7 +19401,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",


### PR DESCRIPTION
## What Has Changed?

After some investigation (together with @MatKuhr) we found out that the `AuthTokenAccessor.executeWithAuthToken` really only replaces the AuthToken, but not the derived properties, like Tenant and Principal.

Therefore we deemed it necessary to extend the documentation with that information.

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] ~You verified all new and changed links still work (changing the `id` or name of a file can break links)~
- [x] ~You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.~
