### PR TITLE
Rename SAP Cloud Platform to SAP Business Technology Platform

### DIFF
--- a/docs/community/community-call.mdx
+++ b/docs/community/community-call.mdx
@@ -17,7 +17,7 @@ image:
 
 ## Community Call
 
-In this series of calls for SAP Community, we will give you regular updates on the latest releases of the SAP Cloud SDK, its roadmap, and topics around extensibility of SAP Business Suite, SAP S/4HANA, and other SAP offerings using SAP Cloud Platform.
+In this series of calls for SAP Community, we will give you regular updates on the latest releases of the SAP Cloud SDK, its roadmap, and topics around extensibility of SAP Business Suite, SAP S/4HANA, and other SAP offerings using SAP Business Technology Platform.
 The call series will be conducted by the SAP Cloud SDK development and product management team.
 We will introduce the SAP Cloud SDK and cover its latest updates.
 
@@ -60,5 +60,5 @@ We consider holding a session in the future about these topics:
 - Nov 5 - [What’s New in SAP Cloud SDK for JavaScript](https://www.youtube.com/watch?v=jv-bS9lK8zk)
 - Oct 1 - [Continuous Delivery](https://www.youtube.com/watch?v=M2chjvlrsF8)
 - Sep 3 - [SAP Cloud SDK for Java version 3](https://www.youtube.com/watch?v=l3P9-wqIhYA)
-- Aug 6 - [SAP Cloud Platform Extension Factory](https://www.youtube.com/watch?v=aTuNXF-Alp4)
+- Aug 6 - [SAP Business Technology Platform Extension Factory](https://www.youtube.com/watch?v=aTuNXF-Alp4)
 - Jul 2 - [SAP Cloud SDK Introduction](https://www.youtube.com/watch?v=jNovhlGzg78)

--- a/docs/community/tech-ed.mdx
+++ b/docs/community/tech-ed.mdx
@@ -38,6 +38,6 @@ Then put your knowledge into practice by following our [exercise](#exercise) hos
 ### Exercise
 
 The exercise for this workshop is hosted in this [GitHub repository](https://github.com/SAP-samples/teched2020-DT261).
-You can run all the code locally or deploy it to the SAP Cloud Platform and test it there.
+You can run all the code locally or deploy it to the SAP Business Technology Platform and test it there.
 For that, we recommend creating a free trial account and activating Business Application Studio.
 You'll find detailed instructions on how to do it in the [`README.md`](https://github.com/SAP/cloud-sdk/blob/main/README.md) of the repository.

--- a/docs/java/faq.mdx
+++ b/docs/java/faq.mdx
@@ -39,8 +39,8 @@ Be cautious about using features annotated as _Beta_ because their API can chang
 
 The SAP Cloud SDK itself is compatible with Java 8 and 11.
 Other Java versions may work as well, depending on your setup, but are not yet tested by us.
-Note that the SAP Cloud Platform Cloud Foundry environment only supports Java 8 out of the box, but can be configured to also run with Java 11.
-SAP Cloud Platform Neo only supports Java 8.
+Note that the SAP Business Technology Platform Cloud Foundry environment only supports Java 8 out of the box, but can be configured to also run with Java 11.
+SAP Business Technology Platform Neo only supports Java 8.
 
 ### Can I Use Features Annotated as Beta in Production?
 
@@ -90,16 +90,16 @@ We also release pre-generated libraries in collaboration with service providers 
 For details check an [overview](features/rest/overview).
 For feedback or questions about our Open API offering, please, create an issue [here](https://github.com/SAP/cloud-sdk/issues).
 
-## Questions About SAP Cloud Platform
+## Questions About SAP Business Technology Platform
 
-### Do You Support SAP Cloud Platform - Cloud Foundry?
+### Do You Support SAP Business Technology Platform - Cloud Foundry?
 
 SAP Cloud SDK for Java has first-class support for [SCP Cloud Foundry](https://www.sap.com/products/cloud-platform.html).
 We provide plenty of helpful abstractions for [connectivity](features/connectivity/sdk-connectivity-destination-service) and authentication that make developing apps a pleasant and rewarding experience.
 Let us know if you're missing any features about SCP Cloud Foundry support from the SAP Cloud SDK for Java.
 
-### Do You Support SAP Cloud Platform - Neo?
+### Do You Support SAP Business Technology Platform - Neo?
 
-We still provide full support for SAP Cloud Platform Neo.
-However, we do not recommend starting new projects with SAP Cloud Platform Neo as Cloud Foundry is better suited for apps and SAP S/4HANA extension development.
+We still provide full support for SAP Business Technology Platform Neo.
+However, we do not recommend starting new projects with SAP Business Technology Platform Neo as Cloud Foundry is better suited for apps and SAP S/4HANA extension development.
 Also, for Neo we provide out-of-the-box support with only servlet based applications and not spring based applications.

--- a/docs/java/faq.mdx
+++ b/docs/java/faq.mdx
@@ -94,7 +94,7 @@ For feedback or questions about our Open API offering, please, create an issue [
 
 ### Do You Support SAP Business Technology Platform - Cloud Foundry?
 
-SAP Cloud SDK for Java has first-class support for [SCP Cloud Foundry](https://www.sap.com/products/cloud-platform.html).
+SAP Cloud SDK for Java has first-class support for [BTP Cloud Foundry](https://www.sap.com/germany/products/business-technology-platform.html).
 We provide plenty of helpful abstractions for [connectivity](features/connectivity/sdk-connectivity-destination-service) and authentication that make developing apps a pleasant and rewarding experience.
 Let us know if you're missing any features about SCP Cloud Foundry support from the SAP Cloud SDK for Java.
 

--- a/docs/java/features/bapi-and-rfc/overview.mdx
+++ b/docs/java/features/bapi-and-rfc/overview.mdx
@@ -254,11 +254,11 @@ The difference is to use alternative classes:
 - `RfmRequest` instead of `BapiRequest`
 - `RfmRequestResult` instead of `BapiRequestResult`
 
-### Deploy to SAP Cloud Platform - Cloud Foundry
+### Deploy to SAP Business Technology Platform - Cloud Foundry
 
 Invoke `cf push` from the directory root to deploy the app to your SAP Cloud Foundry space.
 
-### Configure SAP Cloud Platform - Cloud Foundry
+### Configure SAP Business Technology Platform - Cloud Foundry
 
 #### Prerequisites
 

--- a/docs/java/features/connectivity/destinations.mdx
+++ b/docs/java/features/connectivity/destinations.mdx
@@ -4,7 +4,7 @@ title: Use Destinations To Connect To Other Systems and Services
 hide_title: false
 hide_table_of_contents: false
 sidebar_label: Destinations
-description: This article describes how the SAP Cloud SDK for Java can be used to establish connections to other systems and services like SAP S/4HANA or SAP Cloud Platform services.
+description: This article describes how the SAP Cloud SDK for Java can be used to establish connections to other systems and services like SAP S/4HANA or SAP Business Technology Platform services.
 keywords:
   - sap
   - cloud
@@ -21,7 +21,7 @@ The SAP Cloud SDK offers some basic functionality that helps with connecting to 
 The SAP Cloud SDK introduces the general concept of a `Destination` which holds basic information about how to connect to such a system.
 That could for instance be a `url`, a user name, and password for basic authentication or some custom headers.
 
-This concept is integrated with the [Destination Service](https://help.sap.com/viewer/cca91383641e40ffbe03bdc78f00f681/Cloud/en-US/7e306250e08340f89d6c103e28840f30.html) that is available on the SAP Cloud Platform.
+This concept is integrated with the [Destination Service](https://help.sap.com/viewer/cca91383641e40ffbe03bdc78f00f681/Cloud/en-US/7e306250e08340f89d6c103e28840f30.html) that is available on the SAP Business Technology Platform.
 If the application has a service binding to this service in place the SAP Cloud SDK will provide access to these destinations.
 
 ## Accessing Destinations
@@ -32,7 +32,7 @@ In general destinations are accessed through the `DestinationAccessor`:
 DestinationAccessor.getDestination("my-destination");
 ```
 
-This will look up the destination in the destination service if the application is running on SAP Cloud Platform.
+This will look up the destination in the destination service if the application is running on SAP Business Technology Platform.
 Other sources like the environment variables are also considered.
 
 ## Supported Authentication Flows
@@ -300,7 +300,7 @@ It does not matter that the app does not run on your own machine.
 To better understand the configuration steps, we'll outline shortly how destination retrieval works when running your app on SCP.
 Thereafter we'll outline the configuration procedures in detail.
 
-### Background: Destination Retrieval on SAP Cloud Platform
+### Background: Destination Retrieval on SAP Business Technology Platform
 
 By default the SAP Cloud SDK uses a set of so-called destination loaders in a given order when searching for a destination via the `DestinationAccessor` API:
 
@@ -333,12 +333,12 @@ You can configure multiple destinations with that approach.
 Note that the value of the environment variable is a JSON array, so you can add further entries into it.
 :::
 
-#### SAP Cloud Platform Destination Service
+#### SAP Business Technology Platform Destination Service
 
 If the previous lookup was not successful, the next destination loaders examine the environment variable `VCAP_SERVICES` to see if the SCP destination service is bound.
 If so, the SAP Cloud SDK queries the SCP destination service for the destination configuration per the requested destination name.
 
-#### SAP Cloud Platform Connectivity Service
+#### SAP Business Technology Platform Connectivity Service
 
 In case the destination is of proxy type `OnPremise`, the SAP Cloud SDK performs an additional query to the SCP connectivity service to obtain further proxy information and an authorization token.
 
@@ -467,7 +467,7 @@ final HttpDestination destination =
         "my-workflow");
 ```
 
-##### Enable Access to SAP Cloud Platform Connectivity Service
+##### Enable Access to SAP Business Technology Platform Connectivity Service
 
 The SCP connectivity service builds the connection between SCP and the on-premise network.
 That is why it has strong built-in restrictions to allow it only to be called from within SCP.

--- a/docs/java/features/connectivity/http-client.mdx
+++ b/docs/java/features/connectivity/http-client.mdx
@@ -4,7 +4,7 @@ title: Use the HttpClient Accessor To Configure Requests To Remote Services
 hide_title: false
 hide_table_of_contents: false
 sidebar_label: HttpClient
-description: This article describes how the SAP Cloud SDK for Java can be used to prepare instances of HttpClient. This class enables connections to other systems and services like SAP S/4HANA or SAP Cloud Platform services.
+description: This article describes how the SAP Cloud SDK for Java can be used to prepare instances of HttpClient. This class enables connections to other systems and services like SAP S/4HANA or SAP Business Technology Platform services.
 keywords:
   - sap
   - cloud

--- a/docs/java/features/rest/clients/scp-workflow-rest-api.mdx
+++ b/docs/java/features/rest/clients/scp-workflow-rest-api.mdx
@@ -3,7 +3,7 @@ id: scp-workflow-rest-api
 title: Type-Safe Client for SAP Business Technology Platform Workflow REST API
 hide_title: false
 hide_table_of_contents: false
-sidebar_label: SCP Workflow API
+sidebar_label: SAP Workflow service
 description: Learn how to access the SCP Workflow REST API with the type-safe client from the SAP Cloud SDK for Java
 keywords:
   - sap

--- a/docs/java/features/rest/clients/scp-workflow-rest-api.mdx
+++ b/docs/java/features/rest/clients/scp-workflow-rest-api.mdx
@@ -250,7 +250,7 @@ The Java client library for SCP Workflow enables the developer to:
 
 - We support SCP Workflow API only on SCP Cloud Foundry.
   The SAP Business Technology Platform Neo environment is **Not supported!**
-- In the current state, it is required to create a destination manually instead of letting the library resolve it for you via VCAP_SERVICES binding available on SCP Cloud Foundry.
+- In the current state, it is required to create a destination manually instead of letting the library resolve it for you via VCAP_SERVICES binding available on the BTP Cloud Foundry environment.
 
 ## Additional Information
 

--- a/docs/java/features/rest/clients/scp-workflow-rest-api.mdx
+++ b/docs/java/features/rest/clients/scp-workflow-rest-api.mdx
@@ -249,7 +249,7 @@ The Java client library for SCP Workflow enables the developer to:
 ### Known Limitations
 
 - We support SCP Workflow API only on SCP Cloud Foundry.
-  The SAP Business Technology Platform Neo landscape in **Not supported!**
+  The SAP Business Technology Platform Neo environment is **Not supported!**
 - In the current state, it is required to create a destination manually instead of letting the library resolve it for you via VCAP_SERVICES binding available on SCP Cloud Foundry.
 
 ## Additional Information

--- a/docs/java/features/rest/clients/scp-workflow-rest-api.mdx
+++ b/docs/java/features/rest/clients/scp-workflow-rest-api.mdx
@@ -1,6 +1,6 @@
 ---
 id: scp-workflow-rest-api
-title: Type-Safe Client for SAP Business Technology Platform Workflow REST API
+title: Type-Safe Client for SAP Workflow service
 hide_title: false
 hide_table_of_contents: false
 sidebar_label: SAP Workflow service

--- a/docs/java/features/rest/clients/scp-workflow-rest-api.mdx
+++ b/docs/java/features/rest/clients/scp-workflow-rest-api.mdx
@@ -248,7 +248,7 @@ The Java client library for SCP Workflow enables the developer to:
 
 ### Known Limitations
 
-- We support SCP Workflow API only on SCP Cloud Foundry.
+- We support SAP Workflow service API only on the SAP BTP Cloud Foundry environment.
   The SAP Business Technology Platform Neo environment is **Not supported!**
 - In the current state, it is required to create a destination manually instead of letting the library resolve it for you via VCAP_SERVICES binding available on the BTP Cloud Foundry environment.
 

--- a/docs/java/features/rest/clients/scp-workflow-rest-api.mdx
+++ b/docs/java/features/rest/clients/scp-workflow-rest-api.mdx
@@ -167,7 +167,7 @@ Current version is: <MvnBadge />
 </dependencyManagement>
 ```
 
-#### Add SAP Business Technology Platform Workflow Library Dependency To Your Project
+#### Add SAP Workflow Service Dependency To Your Project
 
 You can refer to the Java client library for the SCP Workflow service with the following Maven dependency:
 

--- a/docs/java/features/rest/clients/scp-workflow-rest-api.mdx
+++ b/docs/java/features/rest/clients/scp-workflow-rest-api.mdx
@@ -45,7 +45,7 @@ Use SAP Business Technology Platform Workflow service and its REST API.
 You can do workflow modeling using a convenient visual editor and call SCP Workflow REST API via type-safe client library module provided by the SAP Cloud SDK for Java.
 Additionally, you'll get other benefits from the SAP Cloud SDK like destinations and authentication handling, complete type-safety, multi-tenancy, easy resilience, and caching configuration.
 
-## Consume the SAP Business Technology Platform Workflow REST API
+## Consume the SAP Workflow REST API in BTP Cloud Foundry environment
 
 ### Prerequisites
 

--- a/docs/java/features/rest/clients/scp-workflow-rest-api.mdx
+++ b/docs/java/features/rest/clients/scp-workflow-rest-api.mdx
@@ -1,6 +1,6 @@
 ---
 id: scp-workflow-rest-api
-title: Type-Safe Client for SAP Cloud Platform Workflow REST API
+title: Type-Safe Client for SAP Business Technology Platform Workflow REST API
 hide_title: false
 hide_table_of_contents: false
 sidebar_label: SCP Workflow API
@@ -20,7 +20,7 @@ import MvnBadge from '../../../../../src/sap/sdk-java/MvnBadge';
 
 ## Overview
 
-The [SAP Cloud Platform (SCP) Workflow service](https://help.sap.com/viewer/product/WORKFLOW_SERVICE/Cloud/en-US) is available on the Cloud Foundry environment [since April 2019](https://blogs.sap.com/2019/04/03/workflow-and-business-rules-now-available-in-cloud-foundry-environment-of-sap-cloud-platform/).
+The [SAP Business Technology Platform (SCP) Workflow service](https://help.sap.com/viewer/product/WORKFLOW_SERVICE/Cloud/en-US) is available on the Cloud Foundry environment [since April 2019](https://blogs.sap.com/2019/04/03/workflow-and-business-rules-now-available-in-cloud-foundry-environment-of-sap-cloud-platform/).
 It helps you build, run, and manage workflows to model processes that span from simple approval steps to complex business scenarios with several involved parties.
 
 Imagine a business scenario involving multiple parties, complex validation logic, and parallel execution flows.
@@ -37,15 +37,15 @@ This library is released for **productive usage** as of November 19, 2020.
 
 ### Problem
 
-We need to model a business workflow involving multiple parties, complex validation logic, and parallel flows execution together with other business logic in your app hosted on the SAP Cloud Platform.
+We need to model a business workflow involving multiple parties, complex validation logic, and parallel flows execution together with other business logic in your app hosted on the SAP Business Technology Platform.
 
 ### Solution
 
-Use SAP Cloud Platform Workflow service and its REST API.
+Use SAP Business Technology Platform Workflow service and its REST API.
 You can do workflow modeling using a convenient visual editor and call SCP Workflow REST API via type-safe client library module provided by the SAP Cloud SDK for Java.
 Additionally, you'll get other benefits from the SAP Cloud SDK like destinations and authentication handling, complete type-safety, multi-tenancy, easy resilience, and caching configuration.
 
-## Consume the SAP Cloud Platform Workflow REST API
+## Consume the SAP Business Technology Platform Workflow REST API
 
 ### Prerequisites
 
@@ -59,7 +59,7 @@ You can find it under the section `Workflow Definitions` on the left-hand side o
 
 Let's look in detail at all necessary steps of Cloud Foundry configuration to run this scenario.
 
-#### Bind App to SAP Cloud Platform Workflow Service instance
+#### Bind App to SAP Business Technology Platform Workflow Service instance
 
 Refer to the documentation on [help.sap.com](https://help.sap.com/viewer/e157c391253b4ecd93647bf232d18a83/Cloud/en-US/e8d88dd056f14c75af59e68d6b20345f.html) for the full picture.
 We'll outline the essentials with the assumption that you understand or have all of the following:
@@ -167,7 +167,7 @@ Current version is: <MvnBadge />
 </dependencyManagement>
 ```
 
-#### Add SAP Cloud Platform Workflow Library Dependency To Your Project
+#### Add SAP Business Technology Platform Workflow Library Dependency To Your Project
 
 You can refer to the Java client library for the SCP Workflow service with the following Maven dependency:
 
@@ -249,7 +249,7 @@ The Java client library for SCP Workflow enables the developer to:
 ### Known Limitations
 
 - We support SCP Workflow API only on SCP Cloud Foundry.
-  The SAP Cloud Platform Neo landscape in **Not supported!**
+  The SAP Business Technology Platform Neo landscape in **Not supported!**
 - In the current state, it is required to create a destination manually instead of letting the library resolve it for you via VCAP_SERVICES binding available on SCP Cloud Foundry.
 
 ## Additional Information
@@ -345,7 +345,7 @@ That's it, the invocation to the java client library would remain the [same](scp
 
 ## Video Tutorial
 
-This video tutorial by the developer advocate team of SAP Cloud Platform will help you get up to speed with SAP Cloud SDK for Java and Workflow API in 60 minutes.
+This video tutorial by the developer advocate team of SAP Business Technology Platform will help you get up to speed with SAP Cloud SDK for Java and Workflow API in 60 minutes.
 
 <div class="sdk-video-container">
   <iframe

--- a/docs/java/features/rest/clients/scp-workflow-rest-api.mdx
+++ b/docs/java/features/rest/clients/scp-workflow-rest-api.mdx
@@ -345,7 +345,7 @@ That's it, the invocation to the java client library would remain the [same](scp
 
 ## Video Tutorial
 
-This video tutorial by the developer advocate team of SAP Business Technology Platform will help you get up to speed with SAP Cloud SDK for Java and Workflow API in 60 minutes.
+This video tutorial by the developer advocate team of SAP Business Technology Platform will help you get up to speed with SAP Cloud SDK for Java and Workflow service API in 60 minutes.
 
 <div class="sdk-video-container">
   <iframe

--- a/docs/java/features/rest/clients/scp-workflow-rest-api.mdx
+++ b/docs/java/features/rest/clients/scp-workflow-rest-api.mdx
@@ -20,7 +20,7 @@ import MvnBadge from '../../../../../src/sap/sdk-java/MvnBadge';
 
 ## Overview
 
-The [SAP Business Technology Platform (SCP) Workflow service](https://help.sap.com/viewer/product/WORKFLOW_SERVICE/Cloud/en-US) is available on the Cloud Foundry environment [since April 2019](https://blogs.sap.com/2019/04/03/workflow-and-business-rules-now-available-in-cloud-foundry-environment-of-sap-cloud-platform/).
+The [SAP Workflow service](https://help.sap.com/viewer/product/WORKFLOW_SERVICE/Cloud/en-US) is available on the Cloud Foundry environment [since April 2019](https://blogs.sap.com/2019/04/03/workflow-and-business-rules-now-available-in-cloud-foundry-environment-of-sap-cloud-platform/).
 It helps you build, run, and manage workflows to model processes that span from simple approval steps to complex business scenarios with several involved parties.
 
 Imagine a business scenario involving multiple parties, complex validation logic, and parallel execution flows.

--- a/docs/java/features/rest/clients/scp-workflow-rest-api.mdx
+++ b/docs/java/features/rest/clients/scp-workflow-rest-api.mdx
@@ -41,7 +41,7 @@ We need to model a business workflow involving multiple parties, complex validat
 
 ### Solution
 
-Use SAP Business Technology Platform Workflow service and its REST API.
+Use SAP Workflow service and its REST API.
 You can do workflow modeling using a convenient visual editor and call SCP Workflow REST API via type-safe client library module provided by the SAP Cloud SDK for Java.
 Additionally, you'll get other benefits from the SAP Cloud SDK like destinations and authentication handling, complete type-safety, multi-tenancy, easy resilience, and caching configuration.
 

--- a/docs/java/features/rest/overview.mdx
+++ b/docs/java/features/rest/overview.mdx
@@ -28,7 +28,7 @@ If you're interested in a typed REST API client for a specific SAP application o
 We ship pre-generated type-safe REST API clients as modules in collaboration with popular SAP services available on SAP Business Technology Platform and beyond.
 
 Depending on the scope modules could be available only internally within SAP or publicly released.
-The [SAP Business Technology Platform Workflow API](clients/scp-workflow-rest-api) is an example of a publicly released API module.
+The [SAP Workflow service API](clients/scp-workflow-rest-api) is an example of a publicly released API module.
 
 In case you need information on REST or other services shipped only internally, please, approach us directly via standard communication channels.
 

--- a/docs/java/features/rest/overview.mdx
+++ b/docs/java/features/rest/overview.mdx
@@ -25,10 +25,10 @@ If you're interested in a typed REST API client for a specific SAP application o
 
 ### Pregenerated Type-Safe REST API Client
 
-We ship pre-generated type-safe REST API clients as modules in collaboration with popular SAP services available on SAP Cloud Platform and beyond.
+We ship pre-generated type-safe REST API clients as modules in collaboration with popular SAP services available on SAP Business Technology Platform and beyond.
 
 Depending on the scope modules could be available only internally within SAP or publicly released.
-The [SAP Cloud Platform Workflow API](clients/scp-workflow-rest-api) is an example of a publicly released API module.
+The [SAP Business Technology Platform Workflow API](clients/scp-workflow-rest-api) is an example of a publicly released API module.
 
 In case you need information on REST or other services shipped only internally, please, approach us directly via standard communication channels.
 
@@ -36,13 +36,13 @@ In case you need information on REST or other services shipped only internally, 
 
 - You'll benefit from a type-safe client when accessing a service of your choice
 - We take care of various complexities around developing extensions for SAP services
-- You'll get convenience abstractions over SAP Cloud Platform services.
+- You'll get convenience abstractions over SAP Business Technology Platform services.
   To name a few: XSUAA, Destination service, Service bindings, and more.
 - We hide complexities of cloud development making many tasks ridiculously easy
 - You're getting best in class support for your application or extensions directly from the SAP Cloud SDK development team
 - We take care of change management by continuously updating, integrating, and shipping the latest version of services that we release.
 
-## I'm Providing a Service on SAP Cloud Platform. How Can I Ship It With SAP Cloud SDK?
+## I'm Providing a Service on SAP Business Technology Platform. How Can I Ship It With SAP Cloud SDK?
 
 Reach out to us via internal communication channels and we'll provide you with information on our contribution models.
 

--- a/docs/java/getting-started.mdx
+++ b/docs/java/getting-started.mdx
@@ -29,8 +29,8 @@ You will need an installation of Java and Maven.
 :::note Java version compatibility
 The SAP Cloud SDK itself is compatible with Java 8 and 11.
 Other Java versions may work as well depending on your setup but are not yet tested by us.
-Note that the SAP Cloud Platform Cloud Foundry environment only supports Java 8 out of the box but can be configured to also run with Java 11.
-SAP Cloud Platform Neo only supports Java 8.
+Note that the SAP Business Technology Platform Cloud Foundry environment only supports Java 8 out of the box but can be configured to also run with Java 11.
+SAP Business Technology Platform Neo only supports Java 8.
 :::
 
 To start with a clean, new project you can select [one of our archetypes](https://search.maven.org/search?q=com.sap.cloud.sdk.archetypes) and build upon it.
@@ -169,7 +169,7 @@ To get started with an existing project include the _SAP Cloud SDK BOM_ in the _
 </dependencyManagement>
 ```
 
-If your application is running on **SAP Cloud Platform** please add the appropriate dependency:
+If your application is running on **SAP Business Technology Platform** please add the appropriate dependency:
 
 <Tabs groupId="scp" defaultValue="cf" values={[
 { label: 'Cloud Foundry', value: 'cf', },

--- a/docs/java/guides/cf-cli.mdx
+++ b/docs/java/guides/cf-cli.mdx
@@ -4,7 +4,7 @@ title: SAP Cloud Foundry
 hide_title: false
 hide_table_of_contents: false
 sidebar_label: Cloud Foundry CLI
-description: Configure you Cloud Foundry CLI and bind it to SAP Cloud Platform
+description: Configure you Cloud Foundry CLI and bind it to SAP Business Technology Platform
 keywords:
   - sap
   - cloud
@@ -17,7 +17,7 @@ image:
 
 ## Cloud Foundry Command-Line Interface
 
-To deploy your app developed with SAP Cloud SDK to [SAP Cloud Platform](https://www.sap.com/products/cloud-platform.html) you'll need Cloud Foundry command-line interface (CLI).
+To deploy your app developed with SAP Cloud SDK to [SAP Business Technology Platform](https://www.sap.com/products/cloud-platform.html) you'll need Cloud Foundry command-line interface (CLI).
 You can download latest release of DEB package [from the official CF GitHub repository](https://github.com/cloudfoundry/cli/releases) or follow [instructions](https://github.com/cloudfoundry/cli#installing-using-a-package-manager) to install it with you package manager: `apt-get`, `yum` and `homebrew` are supported.
 
 After installing the CLI you might need to reload you shell before it becomes available.
@@ -51,6 +51,6 @@ cf login
 
 For more details on `SAP Cloud Foundry CLI` follow this [official tutorial](https://developers.sap.com/tutorials/cp-cf-download-cli.html).
 
-## SAP Cloud Platform
+## SAP Business Technology Platform
 
-Find out more about `SAP Cloud Platform` and `Cloud Foundry Environment` from [official documentation](https://help.sap.com/viewer/65de2977205c403bbc107264b8eccf4b/Cloud/en-US/73beb06e127f4e47b849aa95344aabe1.html).
+Find out more about `SAP Business Technology Platform` and `Cloud Foundry Environment` from [official documentation](https://help.sap.com/viewer/65de2977205c403bbc107264b8eccf4b/Cloud/en-US/73beb06e127f4e47b849aa95344aabe1.html).

--- a/docs/java/guides/cf-xsuaa.mdx
+++ b/docs/java/guides/cf-xsuaa.mdx
@@ -1,6 +1,6 @@
 ---
 id: cloud-foundry-xsuaa-service
-title: SAP Cloud Platform Cloud Foundry XSUAA Explained
+title: SAP Business Technology Platform Cloud Foundry XSUAA Explained
 hide_title: false
 hide_table_of_contents: false
 sidebar_label: CF XSUAA Service
@@ -30,7 +30,7 @@ We do not provide in-depth support on XSUAA topics beyond SAP Cloud SDK use case
 Mind, if some information seems outdated - get in touch with us and refer to [official XSUAA docs](https://docs.cloudfoundry.org/api/uaa/).
 :::
 
-## SAP Cloud Platform Cloud Foundry XSUAA Key Use-Cases
+## SAP Business Technology Platform Cloud Foundry XSUAA Key Use-Cases
 
 - User Login: `Authorization Code Grant`
 - SCP Service Usage on behalf of a User: `JWT Bearer Token Grant`

--- a/docs/java/guides/linux-how-to.mdx
+++ b/docs/java/guides/linux-how-to.mdx
@@ -126,7 +126,7 @@ To find out more about Apache Maven, how to get it for your Linux distribution, 
 
 ### Cloud Foundry Command Line Interface
 
-To deploy your app developed with SAP Cloud SDK to [SAP Cloud Platform](https://www.sap.com/products/cloud-platform.html) you'll need the Cloud Foundry command-line interface (CLI).
+To deploy your app developed with SAP Cloud SDK to [SAP Business Technology Platform](https://www.sap.com/products/cloud-platform.html) you'll need the Cloud Foundry command-line interface (CLI).
 You can download the latest release of the DEB package [from the official CF GitHub repository](https://github.com/cloudfoundry/cli/releases) or follow [instructions](https://github.com/cloudfoundry/cli#installing-using-a-package-manager) to install it with you package manager: `apt-get`, `yum` and `homebrew` are supported.
 
 After installing the CLI you might need to reload your shell before it becomes available.

--- a/docs/java/guides/tutorial-overview-sdk-java.mdx
+++ b/docs/java/guides/tutorial-overview-sdk-java.mdx
@@ -31,7 +31,7 @@ Groups are a collection of topic-based tutorials.
 
 - [Create a Simple Cloud Foundry App Using SAP Cloud SDK](https://developers.sap.com/group.s4sdk-cloud-foundry.html)
 
-  Using the SAP Cloud SDK, create a simple SAP Cloud Platform, Cloud Foundry app that calls an SAP S/4HANA OData service.
+  Using the SAP Cloud SDK, create a simple SAP Business Technology Platform, Cloud Foundry app that calls an SAP S/4HANA OData service.
 
 - [Add Security and More to Your SAP Cloud SDK App](https://developers.sap.com/group.cloudsdk-more-features.html)
   Introduce resilience and caching to your application using the SAP Cloud SDK and protect your Java-based Hello World microservice with authenticated and authorized users.
@@ -39,7 +39,7 @@ Groups are a collection of topic-based tutorials.
 ### Groups for Neo
 
 - [Create a Neo App Using SAP Cloud SDK](https://developers.sap.com/group.s4sdk-neo.html)
-  Using the SAP Cloud SDK, create a simple SAP Cloud Platform, Neo app that calls an SAP S/4HANA OData service.
+  Using the SAP Cloud SDK, create a simple SAP Business Technology Platform, Neo app that calls an SAP S/4HANA OData service.
 
 ### Tutorials Quick Links
 
@@ -47,7 +47,7 @@ Use the links below to directly access your favorite tutorial and refresh your k
 
 1. [Set Up Your Local Infrastructure to Develop with SAP Cloud SDK](https://developers.sap.com/tutorials/s4sdk-setup.html)
 
-   Set up your system to create an SAP Cloud Platform application with the SAP Cloud SDK.
+   Set up your system to create an SAP Business Technology Platform application with the SAP Cloud SDK.
 
 2. [Create a Sample Application on Cloud Foundry Using SAP Cloud SDK](https://developers.sap.com/tutorials/s4sdk-cloud-foundry-sample-application.html)
 
@@ -65,7 +65,7 @@ Use the links below to directly access your favorite tutorial and refresh your k
 
    Introduce caching to your application using the SAP Cloud SDK.
 
-6. [Secure Your Application on SAP Cloud Platform Cloud Foundry](https://developers.sap.com/tutorials/s4sdk-secure-cloudfoundry.html)
+6. [Secure Your Application on SAP Business Technology Platform Cloud Foundry](https://developers.sap.com/tutorials/s4sdk-secure-cloudfoundry.html)
 
    Protect your Java-based Hello World microservice with authenticated and authorized users.
 
@@ -94,11 +94,11 @@ If you are interested to use the SAP Cloud SDK for Neo.
 
 1. [Set Up Your Local Infrastructure to Develop with SAP Cloud SDK](https://developers.sap.com/tutorials/s4sdk-setup.html)
 
-   Set up your system to create an SAP Cloud Platform application with the SAP Cloud SDK.
+   Set up your system to create an SAP Business Technology Platform application with the SAP Cloud SDK.
 
 2. [Create a Sample Application on SCP Neo Using SAP Cloud SDK](https://developers.sap.com/tutorials/s4sdk-scp-neo-sample-application.html)
 
-   Create your very first Hello World sample application on SAP Cloud Platform Neo using the SAP Cloud SDK.
+   Create your very first Hello World sample application on SAP Business Technology Platform Neo using the SAP Cloud SDK.
 
 3. [Connect to OData service on Neo using SAP Cloud SDK](https://developers.sap.com/tutorials/s4sdk-odata-service-neo.html)
    Create a basic Java project to call OData services using the SAP Cloud SDK on Neo.

--- a/docs/java/overview.mdx
+++ b/docs/java/overview.mdx
@@ -4,7 +4,7 @@ title: Java SDK Overview
 hide_title: false
 hide_table_of_contents: false
 sidebar_label: Overview
-description: The SAP Cloud SDK for Java significantly simplifies extending and developing an application with SAP Cloud Platform
+description: The SAP Cloud SDK for Java significantly simplifies extending and developing an application with SAP Business Technology Platform
 keywords:
   - sap
   - cloud

--- a/docs/java/release-notes.mdx
+++ b/docs/java/release-notes.mdx
@@ -23,8 +23,8 @@ import MvnBadge from '../../src/sap/sdk-java/MvnBadge';
 We highly recommend regularly updating to the latest SAP Cloud SDK version. It will help you:
 
 - Ensure access to the latest Cloud SDK features
-- Keep up with the latest changes in SAP Cloud Platform
-- Update client libraries giving access to latest SAP services on SAP Cloud Platform and SAP S/4HANA
+- Keep up with the latest changes in SAP Business Technology Platform
+- Update client libraries giving access to latest SAP services on SAP Business Technology Platform and SAP S/4HANA
 - Protect yourself from bugs and breaking changes in the future
 
 ### The SAP Cloud SDK v2 for Java is Deprecated
@@ -584,7 +584,7 @@ Iterable<List<EntityT>> lazyPages = request.iteratingPages().execute( destinatio
 
 The following changes apply to experimental functionality of the SAP Cloud SDK:
 
-- The SCP service "Hyperledger Fabric on SAP Cloud Platform" is deprecated, the corresponding Maven dependency `com.sap.cloud.sdk.services:scp-blockchain` gets deprecated too. Use the dependency [`com.sap.cloud.sdk.serices:blockchain-client-fabric`](https://mvnrepository.com/artifact/com.sap.cloud.sdk.services/blockchain-client-fabric) instead.
+- The SCP service "Hyperledger Fabric on SAP Business Technology Platform" is deprecated, the corresponding Maven dependency `com.sap.cloud.sdk.services:scp-blockchain` gets deprecated too. Use the dependency [`com.sap.cloud.sdk.serices:blockchain-client-fabric`](https://mvnrepository.com/artifact/com.sap.cloud.sdk.services/blockchain-client-fabric) instead.
 - The method `setResponseFormat()` in the class [`ODataRequestGeneric`](https://help.sap.com/doc/f08906c8d31640d583a106325f6a8184/1.0/en-US/index.html?com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestGeneric.html) is no longer available. You can still configure the `Accept` header via the method [`addHeaderIfAbsent()`](https://help.sap.com/doc/f08906c8d31640d583a106325f6a8184/1.0/en-US/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestGeneric.html#addHeaderIfAbsent-java.lang.String-java.lang.String-).
   Example: `request.addHeaderIfAbsent(HttpHeaders.ACCEPT, "application/xml")`.
 - The enum `com.sap.cloud.sdk.datamodel.odata.client.request.ODataFormat` is no longer public.
@@ -629,7 +629,7 @@ The following changes apply to experimental functionality of the SAP Cloud SDK:
 
 - The Workflow API client library in module `scp-workflow-cf` got enhanced to reflect the latest Workflow API features.
 - Update Dependencies
-  - Spring dependency for the SAP Cloud Platform multitenancy implementation module to version `4.3.29.RELEASE` to overcome the security vulnerability [CVE-2020-5421](https://nvd.nist.gov/vuln/detail/CVE-2020-5421).
+  - Spring dependency for the SAP Business Technology Platform multitenancy implementation module to version `4.3.29.RELEASE` to overcome the security vulnerability [CVE-2020-5421](https://nvd.nist.gov/vuln/detail/CVE-2020-5421).
   - Apache HttpComponents from version `4.5.12` to `4.5.13`
   - Jackson from `2.11.2` to `2.11.3`
   - Java JWT from `3.10.3` to `3.11.0`
@@ -880,9 +880,9 @@ final DefaultHttpDestination defaultHttpDestination =
   new WorkflowDefinitionsApi(apiClient).queryDefinitions();
   ```
 
-#### SAP Cloud Platform - Clound Foundry
+#### SAP Business Technology Platform - Clound Foundry
 
-- We added support for new authentication types recently introduced on SAP Cloud Platform - Cloud Foundry. It further improves handling of `Destinations` and keeps SDK up to date with SCP features:
+- We added support for new authentication types recently introduced on SAP Business Technology Platform - Cloud Foundry. It further improves handling of `Destinations` and keeps SDK up to date with SCP features:
   - `SAP_ASSERTION_SSO`
   - `OAuth2JWTBearer`
   - `OAuth2Password`
@@ -911,7 +911,7 @@ final DefaultHttpDestination defaultHttpDestination =
 - OData 4.0: Extract version identifiers from the `ETag` header in case of create and update operations. Now result entities obtained via `ModificationRespnse#getResponseEntity()` will contain a version identifier. It will be sent as `IF-MATCH` header in subsequent update and delete operations.
 
 - New experimental method `ScpCfDestinationLoader#tryGetDestination`.
-  It allows for custom request handling to resources on _SAP Cloud Platform Destination Service_.
+  It allows for custom request handling to resources on _SAP Business Technology Platform Destination Service_.
   With the handler acting as functional interface, you can conveniently manage your own HTTP interaction. E.g.
 
   ```java
@@ -1037,7 +1037,7 @@ Release date: July 16, 2020
 
 ### Fixed Issues
 
-- Fix an issue where subscriber tenant and principal information would not be available in asynchronous threads when running on SAP Cloud Platform Neo.
+- Fix an issue where subscriber tenant and principal information would not be available in asynchronous threads when running on SAP Business Technology Platform Neo.
 
 ## 3.21.0
 
@@ -1070,7 +1070,7 @@ Release date: July 16, 2020
 
 ### Fixed Issues
 
-- Fix an issue in the realm of HTTP destinations created through the SAP Cloud Platform Extension Factory where a `DestinationAccessException` occurs
+- Fix an issue in the realm of HTTP destinations created through the SAP Business Technology Platform Extension Factory where a `DestinationAccessException` occurs
 
 ## 3.20.0
 
@@ -1130,7 +1130,7 @@ Release date: July 16, 2020
 
 ### New Functionality
 
-- Introducing the client library for the Workflow API on SAP Cloud Platform, Cloud Foundry
+- Introducing the client library for the Workflow API on SAP Business Technology Platform, Cloud Foundry
 
   - Example usage:
 
@@ -1404,7 +1404,7 @@ Release date: July 16, 2020
 ### Improvements
 
 - Introduce snakeyaml version `1.26` as direct dependency and exclude the one used by the jackson library to overcome the security vulnerability [CVE-2017-18640](https://bitbucket.org/asomov/snakeyaml/issues/377/allow-configuration-for-preventing-billion).
-- Replace the SAP Cloud SDK implementation for handling authentication and authorization within the SAP Cloud Platform landscape by the library [XSUAA Token Client and Token Flow API](https://github.com/SAP/cloud-security-xsuaa-integration/tree/master/token-client) version `2.5.1`. See the compatibility notes for details.
+- Replace the SAP Cloud SDK implementation for handling authentication and authorization within the SAP Business Technology Platform landscape by the library [XSUAA Token Client and Token Flow API](https://github.com/SAP/cloud-security-xsuaa-integration/tree/master/token-client) version `2.5.1`. See the compatibility notes for details.
 - Update Dependencies
   - [SAP Cloud Application Programming Model](https://help.sap.com/viewer/65de2977205c403bbc107264b8eccf4b/Cloud/en-US/00823f91779d4d42aa29a498e0535cdf.html) from version `1.37.1` to `1.38.0`
   - Lombok from version `1.18.10` to `1.18.12`
@@ -1423,7 +1423,7 @@ Release date: July 16, 2020
   - AssertJ from version `3.14.0` to `3.15.0`
   - Mockito from version `3.2.4` to `3.3.0`
   - Wiremock from version `2.20.0` to `2.26.1`
-  - SAP Cloud Platform SDK For Neo Environment (Java EE 7 Web Profile TomEE 7) to version `1.69.18`
+  - SAP Business Technology Platform SDK For Neo Environment (Java EE 7 Web Profile TomEE 7) to version `1.69.18`
 
 ### Fixed Issues
 
@@ -1468,7 +1468,7 @@ Release date: July 16, 2020
 
 ### Improvements
 
-- Update the Spring dependency for the SAP Cloud Platform multitenancy implementation module to version `4.3.26.RELEASE` to overcome the security vulnerability [CVE-2020-5397](https://bugs.chromium.org/p/chromium/issues/detail?id=775438).
+- Update the Spring dependency for the SAP Business Technology Platform multitenancy implementation module to version `4.3.26.RELEASE` to overcome the security vulnerability [CVE-2020-5397](https://bugs.chromium.org/p/chromium/issues/detail?id=775438).
 
 ## 3.12.0
 
@@ -1479,7 +1479,7 @@ Release date: July 16, 2020
 ### New Functionality
 
 - _SCP Blockchain Module_: Allow the usage of custom HTTP clients by adding support for a custom HTTP request factory for the rest template in [`MultichainRequest`](https://help.sap.com/doc/3ef4616701f642658f0a7be6b2aaf587/1.0/en-US/index.html?com/sap/cloud/sdk/services/blockchain/multichain/service/MultichainRequest.html).
-- When creating a [`MultichainService`](https://help.sap.com/doc/3ef4616701f642658f0a7be6b2aaf587/1.0/en-US/index.html?com/sap/cloud/sdk/services/blockchain/multichain/service/MultichainService.html) instance using a SAP Cloud Platform destination, the destination's HTTP client will now be used as a pre-configured `HttpClient` instance with authentication, HTTP connection pooling, etc. for each [`MultichainRequest`](https://help.sap.com/doc/3ef4616701f642658f0a7be6b2aaf587/1.0/en-US/index.html?com/sap/cloud/sdk/services/blockchain/multichain/service/MultichainRequest.html).
+- When creating a [`MultichainService`](https://help.sap.com/doc/3ef4616701f642658f0a7be6b2aaf587/1.0/en-US/index.html?com/sap/cloud/sdk/services/blockchain/multichain/service/MultichainService.html) instance using a SAP Business Technology Platform destination, the destination's HTTP client will now be used as a pre-configured `HttpClient` instance with authentication, HTTP connection pooling, etc. for each [`MultichainRequest`](https://help.sap.com/doc/3ef4616701f642658f0a7be6b2aaf587/1.0/en-US/index.html?com/sap/cloud/sdk/services/blockchain/multichain/service/MultichainRequest.html).
 
 ### Improvements
 
@@ -1564,7 +1564,7 @@ Release date: July 16, 2020
   - Java JWT from version `3.8.3` to `3.9.0`
   - JUnit from version `4.12` to `4.13`
   - Jetty from version `9.4.19.v20190610` to `9.4.25.v20191220`
-  - [SAP Cloud Platform Neo Environment SDK for Java EE 7 Web Profile TomEE 7](https://tools.hana.ondemand.com/#cloud) from version `1.44.12` to `1.65.15`
+  - [SAP Business Technology Platform Neo Environment SDK for Java EE 7 Web Profile TomEE 7](https://tools.hana.ondemand.com/#cloud) from version `1.44.12` to `1.65.15`
 
 ### Fixed Issues
 
@@ -1849,7 +1849,7 @@ Release date: July 16, 2020
 ### Fixed Issues
 
 - Fix an issue where [`DefaultHttpDestination`](https://help.sap.com/doc/0c49e20a27384c3abfcd8fdec643406b/1.0/en-US/index.html?com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestination.html) failed to load the authentication type, so that authentication was not correctly applied when loading destinations from an environment variable or instantiating `DefaultHttpDestination` manually.
-- Fix issues with HTTP destinations in the SAP Cloud Platform Neo environment when using EJBs to run code on server startup.
+- Fix issues with HTTP destinations in the SAP Business Technology Platform Neo environment when using EJBs to run code on server startup.
 
 ## 3.0.0
 
@@ -2168,7 +2168,7 @@ When defining destinations via the environment variable destinations, version 3.
   - At the example of TenantAccessor.executeWithTenant, the given callable/executable will be executed in a context where the given tenant is set as the current tenant.
   - In addition to overriding, provide the option to set a fallback for a single execution (for example, with TenantAccessor.executeWithFallbackTenant) or globally (for example, with TenantAccessor.setFallbackTenant). Whenever, for example, a tenant is requested but not available, the SDK will retrieve a fallback tenant from the given supplier.
 - Offer access to the current request, if available, via the new RequestAccessor and allow overriding the request and providing a fallback request when executing code.
-- Make XsuaaService public for communicating with a given XSUAA service on SAP Cloud Platform, Cloud Foundry.
+- Make XsuaaService public for communicating with a given XSUAA service on SAP Business Technology Platform, Cloud Foundry.
 
 ### Improvements
 

--- a/docs/java/troubleshooting.mdx
+++ b/docs/java/troubleshooting.mdx
@@ -106,12 +106,12 @@ Compilation fails due to missing _Getters_ and _Setters_ on entity objects.
 - Conflicting dependency versions may cause such issues.
   See the section on [Managing Dependencies](guides/dependencies.mdx#dealing-with-dependency-conflicts).
 
-## The Java App Has Good Performance on Your Local Machine but Utilizes 100% CPU on SAP Cloud Platform Cloud Foundry
+## The Java App Has Good Performance on Your Local Machine but Utilizes 100% CPU on SAP Business Technology Platform Cloud Foundry
 
 :::info **Symptoms:**
 
 - The Java app executes multiple threads and runs with good performance on a powerful local machine.
-- The performance significantly drops after the app is deployed to SAP Cloud Platform - Cloud Foundry and CPU utilization is always around 100%.
+- The performance significantly drops after the app is deployed to SAP Business Technology Platform - Cloud Foundry and CPU utilization is always around 100%.
 
 :::
 

--- a/docs/java/video/connectivity-service.mdx
+++ b/docs/java/video/connectivity-service.mdx
@@ -2,7 +2,7 @@
 id: video-tutorial-about-connectivity--for-odata-with-sap-cloud-sdk-for-java
 title: 'Video Tutorial: Generate Your Type-Safe OData Client'
 sidebar_label: Destinations and Cloud Connector
-description: You will learn how to generate type-safe OData client with SAP Cloud SDK for Java and learn about consuming Workflow service via its REST API on SAP Cloud Platform
+description: You will learn how to generate type-safe OData client with SAP Cloud SDK for Java and learn about consuming Workflow service via its REST API on SAP Business Technology Platform
 keywords:
   - sap
   - cloud

--- a/docs/java/video/getting-started-video.mdx
+++ b/docs/java/video/getting-started-video.mdx
@@ -2,7 +2,7 @@
 id: video-tutorial-about-getting-started-with-sap-cloud-sdk-for-java
 title: 'Video Tutorial: Getting Started'
 sidebar_label: Getting Started
-description: You will learn how to bootstrap your project with SAP Cloud SDK for Java and learn about consuming Workflow service via its REST API on SAP Cloud Platform
+description: You will learn how to bootstrap your project with SAP Cloud SDK for Java and learn about consuming Workflow service via its REST API on SAP Business Technology Platform
 keywords:
   - sap
   - cloud
@@ -12,7 +12,7 @@ keywords:
   - sap cloud sdk
 ---
 
-This great **Getting Started** video-guide by [Max Streifeneder](https://www.youtube.com/channel/UCkzNZP9fzLxRyhnGT2ziSRw) will help you to familiarize yourself with the SAP Cloud SDK development model and give an example of consuming Workflow service via its REST API on SAP Cloud Platform.
+This great **Getting Started** video-guide by [Max Streifeneder](https://www.youtube.com/channel/UCkzNZP9fzLxRyhnGT2ziSRw) will help you to familiarize yourself with the SAP Cloud SDK development model and give an example of consuming Workflow service via its REST API on SAP Business Technology Platform.
 
 <div class="sdk-video-container">
 

--- a/docs/java/video/odata-generator.mdx
+++ b/docs/java/video/odata-generator.mdx
@@ -2,7 +2,7 @@
 id: video-tutorial-about-type-safe-client-generator-for-odata-with-sap-cloud-sdk-for-java
 title: 'Video Tutorial: Generate Your Type-Safe OData Client'
 sidebar_label: Generate OData Client
-description: You will learn how to generate a type-safe OData client with SAP Cloud SDK for Java and learn about consuming Workflow service via its REST API on SAP Cloud Platform
+description: You will learn how to generate a type-safe OData client with SAP Cloud SDK for Java and learn about consuming Workflow service via its REST API on SAP Business Technology Platform
 keywords:
   - sap
   - cloud
@@ -13,7 +13,7 @@ keywords:
 ---
 
 Imagine you need to develop an app that integrates with an OData service.
-Maybe you also want to host it on SAP Cloud Platform?
+Maybe you also want to host it on SAP Business Technology Platform?
 This might be a painstaking task.
 This video tutorial shows how to minimize your efforts and simplify everything to the limit.
 All you have to do is use SAP Cloud SDK for Java and have your hands on an API definition which is usually the `EDMX` file.

--- a/docs/java/video/use-odata-v4-client.mdx
+++ b/docs/java/video/use-odata-v4-client.mdx
@@ -12,7 +12,7 @@ keywords:
   - sap cloud sdk
 ---
 
-Let's imaging you're building an app in the SAP Cloud Platform.
+Let's imaging you're building an app in the SAP Business Technology Platform.
 Your app calls OData v4 APIs from one or many SAP services exposed by SAP S/4HANA, SAP SuccessFactors, SAP Cloud for Customer, and others.
 OData v4 is a complex protocol based on REST that has a pretty steep learning curve.
 Every service is unique and can choose what API features to expose.

--- a/docs/js/faq.mdx
+++ b/docs/js/faq.mdx
@@ -112,9 +112,9 @@ If you can't solve your issue via debugging and experimenting, please, report yo
 We're working on it.
 The current support is experimental and not ready for production use.
 
-## Questions About SAP Cloud Platform
+## Questions About SAP Business Technology Platform
 
-### Do You Support SAP Cloud Platform - Cloud Foundry?
+### Do You Support SAP Business Technology Platform - Cloud Foundry?
 
 SAP Cloud SDK for JavaScript has first-class support for [SCP Cloud Foundry](https://www.sap.com/products/cloud-platform.html).
 We provide plenty of helpful abstractions for [connectivity](features/connectivity/destination) and authentication that make developing apps a pleasant and rewarding experience.

--- a/docs/js/features/cli/init.mdx
+++ b/docs/js/features/cli/init.mdx
@@ -15,7 +15,7 @@ keywords:
   - TypeScript
 ---
 
-The SAP Cloud SDK CLI adds necessary dependencies and configurations to use the SAP Cloud SDK and deploy your app to SAP Cloud Platform with one command.
+The SAP Cloud SDK CLI adds necessary dependencies and configurations to use the SAP Cloud SDK and deploy your app to SAP Business Technology Platform with one command.
 This is possible for any existing project that uses `npm`.
 
 If you are starting from scratch, the SAP Cloud SDK CLI can also generate a fully-loaded new project to get you started quickly.
@@ -92,7 +92,7 @@ $ sap-cloud-sdk init --frontendScripts
 #### Enter Project Name
 
 The project name is relevant for the Cloud Foundry repository.
-Your application will use this name to appear in the SAP Cloud Platform Cockpit.
+Your application will use this name to appear in the SAP Business Technology Platform Cockpit.
 By default, it will suggest the name of the project folder.
 
 #### Enter the Command to Start Your Application

--- a/docs/js/features/cli/overview.mdx
+++ b/docs/js/features/cli/overview.mdx
@@ -20,7 +20,7 @@ The SAP Cloud SDK CLI is a command-line interface (CLI) to simplify common tasks
 - [Adding the SAP Cloud SDK to an existing project](./init.mdx)
 - [Creating a new project using the SAP Cloud SDK and other recommended dependencies](./init.mdx)
 - [Generate an OData client](./generator.mdx)
-- [Prepare your project for deployment to SAP Cloud Platform](./package.mdx)
+- [Prepare your project for deployment to SAP Business Technology Platform](./package.mdx)
 
 ## Installing the SAP Cloud SDK CLI
 

--- a/docs/js/features/cli/package.mdx
+++ b/docs/js/features/cli/package.mdx
@@ -1,8 +1,8 @@
 ---
-title: Deploy to SAP Cloud Platform
+title: Deploy to SAP Business Technology Platform
 hide_title: false
 hide_table_of_contents: false
-sidebar_label: Deploy to SAP Cloud Platform
+sidebar_label: Deploy to SAP Business Technology Platform
 description: ???
 keywords:
   - sap

--- a/docs/js/features/connectivity/destination.mdx
+++ b/docs/js/features/connectivity/destination.mdx
@@ -16,7 +16,7 @@ keywords:
 
 ## Introduction
 
-Most applications developed on SAP Cloud Platform (SCP) will integrate in some way with other LoB solutions and systems.
+Most applications developed on SAP Business Technology Platform (SCP) will integrate in some way with other LoB solutions and systems.
 Integration means the exchange of data and it is necessary to abstract the details on the data exchange from your codebase.
 The reasons for this abstraction are manifold: URLs defining a resource may change, authentication information should not be part of code, in case of a multi-customer application the locations depends on the customer, etc.
 

--- a/docs/js/features/openapi/generate-openapi-client.mdx
+++ b/docs/js/features/openapi/generate-openapi-client.mdx
@@ -21,7 +21,7 @@ The OpenAPI generator is in beta state.
 
 ## Generate a Client via the Command-Line Interface
 
-Many SAP systems like SAP S/4HANA, SAP Concur and SAP Cloud Platform provide REST APIs to the user.
+Many SAP systems like SAP S/4HANA, SAP Concur and SAP Business Technology Platform provide REST APIs to the user.
 A common way to specify these services is via [OpenAPI](./overview) specification files.
 You can generate type-safe OpenAPI clients using these specification files with the SAP Cloud SDK.
 An example how such a file looks like can be found [here](https://github.com/SAP/cloud-sdk-js/blob/main/test-resources/openapi-service-specs/test-service.json) and is discussed in detail in the guide on [how to execute an OpenAPI request](./execute-openapi-request).

--- a/docs/js/getting-started.mdx
+++ b/docs/js/getting-started.mdx
@@ -166,7 +166,7 @@ If you don't have an [SAP Business Technology Platform](https://account.hana.ond
 To deploy our application, we first need to login to Cloud Foundry in SAP Business Technology Platform using the `cf` CLI.
 First, we need to set an `API endpoint`.
 The exact URL of this API endpoint depends on the region your subaccount is in.
-Open the [SAP Business Technology Platform Cockpit](https://account.hana.ondemand.com/) and navigate to the subaccount you are planning to deploy your application to.
+Open the [SAP BTP cockpit](https://account.hana.ondemand.com/) and navigate to the subaccount you are planning to deploy your application to.
 Click on “Overview” on the left and you can see the URL of the API endpoint.
 
 Copy the URL and paste it into the following command in your command-line:

--- a/docs/js/getting-started.mdx
+++ b/docs/js/getting-started.mdx
@@ -26,14 +26,14 @@ import LicenseBadge from '../../src/sap/sdk-js/LicenseBadge';
 
 The SAP Cloud SDK supports you end-to-end when developing applications that communicate with SAP solutions and services such as SAP S/4HANA Cloud, SAP SuccessFactors, and many others.
 
-Using the SAP Cloud SDK, you can reduce your effort when developing an application on SAP Cloud Platform by building on best practices delivered by the SAP Cloud SDK.
+Using the SAP Cloud SDK, you can reduce your effort when developing an application on SAP Business Technology Platform by building on best practices delivered by the SAP Cloud SDK.
 The SAP Cloud SDK can provide JavaScript libraries and project templates.
 
 To create such an application we provide a command-line interface, that allows you to scaffold or enhance an application with the missing parts to use the SAP Cloud SDK.
 
 ### What Is the Command-Line Interface?
 
-The command-line interface (CLI) can initialize a Nest-based project or (the more common case) add everything you need to develop for SAP Cloud Platform to an existing project no matter what backend framework you use.
+The command-line interface (CLI) can initialize a Nest-based project or (the more common case) add everything you need to develop for SAP Business Technology Platform to an existing project no matter what backend framework you use.
 If there are any incompatibilities, please let us know in the [issues](https://github.com/SAP/cloud-sdk-cli/issues/new/choose)!
 
 ## Installation
@@ -125,7 +125,7 @@ The project contains the following files and folders, among others, to get you s
 
 #### Cloud Foundry
 
-- **`manifest.yml`**: The deployment descriptor file for `Cloud Foundry in SAP Cloud Platform`.
+- **`manifest.yml`**: The deployment descriptor file for `Cloud Foundry in SAP Business Technology Platform`.
 
 #### Local Development
 
@@ -152,7 +152,7 @@ Go to `http://localhost:3000` and you should get a `Hello, World!` in response.
 
 ### Prerequisites
 
-The Cloud Foundry CLI comes in handy when you want to deploy your application to the SAP Cloud Platform.
+The Cloud Foundry CLI comes in handy when you want to deploy your application to the SAP Business Technology Platform.
 You can find installation instructions for all common platforms in the [`Cloud Foundry documentation`](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html).
 We recommend using a package manager for that.
 If you are using `chocolatey` on Windows, please find the instructions [here](https://chocolatey.org/packages/cloudfoundry-cli).
@@ -160,13 +160,13 @@ If you are using `chocolatey` on Windows, please find the instructions [here](ht
 ### Login
 
 :::note
-If you don't have an [SAP Cloud Platform](https://account.hana.ondemand.com/) account you need to create one.
+If you don't have an [SAP Business Technology Platform](https://account.hana.ondemand.com/) account you need to create one.
 :::
 
-To deploy our application, we first need to login to Cloud Foundry in SAP Cloud Platform using the `cf` CLI.
+To deploy our application, we first need to login to Cloud Foundry in SAP Business Technology Platform using the `cf` CLI.
 First, we need to set an `API endpoint`.
 The exact URL of this API endpoint depends on the region your subaccount is in.
-Open the [SAP Cloud Platform Cockpit](https://account.hana.ondemand.com/) and navigate to the subaccount you are planning to deploy your application to.
+Open the [SAP Business Technology Platform Cockpit](https://account.hana.ondemand.com/) and navigate to the subaccount you are planning to deploy your application to.
 Click on “Overview” on the left and you can see the URL of the API endpoint.
 
 Copy the URL and paste it into the following command in your command-line:
@@ -264,7 +264,7 @@ To create an instance of the destination service, execute the following command 
 cf create-service destination lite my-destination
 ```
 
-This tells `Cloud Foundry in SAP Cloud Platform` to create an instance of the destination service with service plan `lite` and make it accessible under the name `my-destination`.
+This tells `Cloud Foundry in SAP Business Technology Platform` to create an instance of the destination service with service plan `lite` and make it accessible under the name `my-destination`.
 We can now use the name to bind this service to our application.
 To do this, open your `manifest.yml` and add a section called `services`, under which you can then add the name of the just created service.
 
@@ -297,7 +297,7 @@ Create a file called `xs-security.json` with the following content:
 }
 ```
 
-The value for `xsappname` again has to be unique across the whole of `Cloud Foundry in SAP Cloud Platform`, so make sure to choose a unique name or prefix.
+The value for `xsappname` again has to be unique across the whole of `Cloud Foundry in SAP Business Technology Platform`, so make sure to choose a unique name or prefix.
 
 Now, execute the following command:
 

--- a/docs/js/getting-started.mdx
+++ b/docs/js/getting-started.mdx
@@ -26,7 +26,7 @@ import LicenseBadge from '../../src/sap/sdk-js/LicenseBadge';
 
 The SAP Cloud SDK supports you end-to-end when developing applications that communicate with SAP solutions and services such as SAP S/4HANA Cloud, SAP SuccessFactors, and many others.
 
-Using the SAP Cloud SDK, you can reduce your effort when developing an application on SAP Business Technology Platform by building on best practices delivered by the SAP Cloud SDK.
+Using the SAP Cloud SDK, you can reduce your effort when developing an application on SAP Business Technology Platform (SAP BTP) by building on best practices delivered by the SAP Cloud SDK.
 The SAP Cloud SDK can provide JavaScript libraries and project templates.
 
 To create such an application we provide a command-line interface, that allows you to scaffold or enhance an application with the missing parts to use the SAP Cloud SDK.

--- a/docs/js/getting-started.mdx
+++ b/docs/js/getting-started.mdx
@@ -125,7 +125,7 @@ The project contains the following files and folders, among others, to get you s
 
 #### Cloud Foundry
 
-- **`manifest.yml`**: The deployment descriptor file for `Cloud Foundry in SAP Business Technology Platform`.
+- **`manifest.yml`**: The deployment descriptor file for `SAP BTP, Cloud Foundry environment`.
 
 #### Local Development
 

--- a/docs/js/guides/bas-external-system.mdx
+++ b/docs/js/guides/bas-external-system.mdx
@@ -195,7 +195,7 @@ We will update this section as soon as possible.
 ## Case 2: Connection to Cloud Systems
 
 Cloud systems are reachable via the internet and you do not need any cloud connector to reach them.
-The same is true for the destination service of the SAP Cloud Platform.
+The same is true for the destination service of the SAP Business Technology Platform.
 Hence you can use the same approach locally and in production.
 
 ### Prerequisite: Service Setup

--- a/docs/js/overview.mdx
+++ b/docs/js/overview.mdx
@@ -4,7 +4,7 @@ title: JavaScript & Typescript Overview
 hide_title: false
 hide_table_of_contents: false
 sidebar_label: Overview
-description: The SAP Cloud SDK for JavaScript significantly simplifies extending and developing applications with SAP Cloud Platform
+description: The SAP Cloud SDK for JavaScript significantly simplifies extending and developing applications with SAP Business Technology Platform
 keywords:
   - sap
   - cloud
@@ -28,7 +28,7 @@ For a quick start check out the [getting started](getting-started) section.
 
 The SAP Cloud SDK supports you end-to-end when developing applications that communicate with SAP solutions and services such as SAP S/4HANA Cloud, SAP SuccessFactors, and many others.
 
-Using the SAP Cloud SDK, you can reduce your effort when developing an application on SAP Cloud Platform by building on best practices delivered by the SAP Cloud SDK.
+Using the SAP Cloud SDK, you can reduce your effort when developing an application on SAP Business Technology Platform by building on best practices delivered by the SAP Cloud SDK.
 The SAP Cloud SDK provides Java libraries, JavaScript libraries, project templates, and a continuous delivery toolkit.
 
 ## Feature Matrix

--- a/docs/js/release-notes.mdx
+++ b/docs/js/release-notes.mdx
@@ -24,8 +24,8 @@ We highly recommend to update to the latest SAP Cloud SDK version regularly.
 It will help you:
 
 - Ensure access to the latest SAP Cloud SDK features
-- Keep up with the latest changes on SAP Cloud Platform
-- Update client libraries giving access to the latest SAP services on SAP Cloud Platform and SAP S/4HANA.
+- Keep up with the latest changes on SAP Business Technology Platform
+- Update client libraries giving access to the latest SAP services on SAP Business Technology Platform and SAP S/4HANA.
 - Protect yourself from bugs and breaking changes in the future
 
 <!-- vale SAP.Products = NO -->

--- a/docs/overview/about.mdx
+++ b/docs/overview/about.mdx
@@ -19,14 +19,14 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 ## Introduction
 
-The SAP Cloud SDK is a versatile set of libraries and tools for developers to build applications in a cloud-native way and host them on SAP Cloud Platform or other runtimes.
+The SAP Cloud SDK is a versatile set of libraries and tools for developers to build applications in a cloud-native way and host them on SAP Business Technology Platform or other runtimes.
 
 ### Benefits & Capabilities
 
 The SAP Cloud SDK is available for [Java](../java/getting-started.mdx) and [JavaScript / TypeScript](../js/getting-started.mdx), providing the following benefits and capabilities:
 
 - A set of pre-generated type-safe client libraries for various SAP published OData and REST services for convenient consumption and bullet-proof developer experience.
-- Robust connectivity abstractions for SAP Cloud Platform for convenient management of destinations, authentication, multitenancy, CSRF, e-tags, and more.
+- Robust connectivity abstractions for SAP Business Technology Platform for convenient management of destinations, authentication, multitenancy, CSRF, e-tags, and more.
 - A tailor-made type-safe client code generator for OData services that seamlessly integrate with other SAP Cloud SDK value-adds.
 - A type-safe client code generator for REST services that wraps the open-source generator with custom code templates to make it deeply integrated with other SAP Cloud SDK features.
 - An easy-to-use CLI with code scaffolding capabilities.
@@ -48,7 +48,7 @@ The SAP Cloud SDK is well-integrated with other SAP products and services like:
 - [SAP Fieldglass](https://www.fieldglass.com/)
 - [SAP Concur](https://www.concur.com/)
 - [SAP Ariba](https://www.ariba.com/)
-- [SAP Cloud Platform](https://www.sap.com/products/cloud-platform.html)
+- [SAP Business Technology Platform](https://www.sap.com/products/cloud-platform.html)
 - Deploy with Confidence
 
 In the next chapter, you'll learn how to generate a type-safe client for any SAP service and start using the benefits of the SAP Cloud SDK.

--- a/docs/overview/benefits.mdx
+++ b/docs/overview/benefits.mdx
@@ -31,9 +31,9 @@ After generating client code from your API definition, you can be sure about typ
 
 Discover SAP APIs the same way you would discover your code.
 
-## SAP Cloud Platform Abstractions
+## SAP Business Technology Platform Abstractions
 
-We make sure you can benefit from the vast infrastructure offered by the SAP Cloud Platform.
+We make sure you can benefit from the vast infrastructure offered by the SAP Business Technology Platform.
 The SAP Cloud SDK helps you with destinations, routing, authentication, caching, resilience, and other advanced topics.
 
 ## Best Practices Out of the Box

--- a/docs/overview/faq.mdx
+++ b/docs/overview/faq.mdx
@@ -36,7 +36,7 @@ That's when we decided to wrap that value into a library and make it available f
 
 Cloud Application Programming Model (CAP) and SAP Cloud SDK are complementary tools to publish and consume APIs like OData and REST.
 They play nicely together to cover the full stack of cloud-native application development.
-The SAP CAP plays more on the API and service publishing side, while SAP Cloud SDK deals more with API consumption and deployment of applications to SAP Cloud Platform.
+The SAP CAP plays more on the API and service publishing side, while SAP Cloud SDK deals more with API consumption and deployment of applications to SAP Business Technology Platform.
 
 You can easily use SAP Cloud SDK and CAP together in one project.
 Find more details about CAP [here](../related-projects/cap.mdx) and check out our [tutorial about using SAP Cloud SDK for Java and CAP together](https://developers.sap.com/tutorials/cloudsdk-integrate-cap.html).

--- a/docs/overview/sdk-used-by.mdx
+++ b/docs/overview/sdk-used-by.mdx
@@ -28,7 +28,7 @@ Many of SAP Cloud ALM services benefit from SAP Cloud SDK features and allow for
 The SAP Cloud Application Programming Model (CAP) is a framework of languages, libraries, and tools for building enterprise-grade services and applications.
 It guides developers along a ‘golden path’ of proven best practices and a great wealth of out-of-the-box solutions to recurring tasks.
 
-The SAP CAP and SAP Cloud SDK nicely play together to build and deliver OData services and consume them to build various extensions and applications on top of SAP Cloud Platform.
+The SAP CAP and SAP Cloud SDK nicely play together to build and deliver OData services and consume them to build various extensions and applications on top of SAP Business Technology Platform.
 Internally CAP uses some of SAP Cloud SDK's advanced capabilities to handle complex OData query building, [multitenancy](../java/features/multi-tenancy/thread-context.mdx), [resilience](../java/features/resilience/resilience.mdx) and others.
 
 Collaboration between SAP Cloud SDK and CAP helps both products evolve faster and brings great synergies for developers.
@@ -47,16 +47,16 @@ Optimize resources and get new products and services to market faster with centr
 
 The SAP Cloud SDK provides the necessary convenience and type-safety when consuming different services to speed up development and flatten the learning curve.
 
-## [SAP Cloud Platform Workflow](https://help.sap.com/viewer/product/WORKFLOW_SERVICE/Cloud/en-US)
+## [SAP Business Technology Platform Workflow](https://help.sap.com/viewer/product/WORKFLOW_SERVICE/Cloud/en-US)
 
-SAP Cloud Platform Workflow lets you build, run, and manage workflows, from simple approvals to end-to-end processes that span organizations and apps.
+SAP Business Technology Platform Workflow lets you build, run, and manage workflows, from simple approvals to end-to-end processes that span organizations and apps.
 
-Thanks to the collaboration with the SAP Cloud SDK all the customers of the SAP Cloud Platform Workflow service can leverage its benefits via [type-safe REST client provided by the SD](../java/features/rest/clients/scp-workflow-rest-api.mdx).
+Thanks to the collaboration with the SAP Cloud SDK all the customers of the SAP Business Technology Platform Workflow service can leverage its benefits via [type-safe REST client provided by the SD](../java/features/rest/clients/scp-workflow-rest-api.mdx).
 It's always up to date and shares other convenience and best practices that the SAP Cloud SDK offers for OData client.
 
 ## [SAP RealSpend](https://www.sap.com/germany/products/real-time-budget-spend.html)
 
 Manage budgets in real-time with our business expense tracking software.
 
-RealSpend was one of the first adopters of SAP Cloud SDK to deliver cloud-native expense and cost-center management solutions on SAP Cloud Platform.
+RealSpend was one of the first adopters of SAP Cloud SDK to deliver cloud-native expense and cost-center management solutions on SAP Business Technology Platform.
 It leverages the SAP Cloud SDK for type-safe OData service consumption from the SAP S/4HANA Suite and related products.

--- a/docs/related-projects/piper.mdx
+++ b/docs/related-projects/piper.mdx
@@ -2,7 +2,7 @@
 id: project-piper
 title: 'Project "Piper": Continuous Delivery for the SAP Ecosystem'
 sidebar_label: Project "Piper"
-description: Continuous delivery is a method to develop software with short feedback cycles. It is applicable to projects both for SAP Cloud Platform and SAP on-premise platforms.
+description: Continuous delivery is a method to develop software with short feedback cycles. It is applicable to projects both for SAP Business Technology Platform and SAP on-premise platforms.
 keywords:
   - sap
   - cloud
@@ -15,14 +15,14 @@ keywords:
 ## Best DevOps Practices at SAP
 
 Continuous delivery is a method to develop software with short feedback cycles.
-It applies to projects both for SAP Cloud Platform and SAP on-premise platforms.
+It applies to projects both for SAP Business Technology Platform and SAP on-premise platforms.
 SAP implements tooling for continuous delivery in the project "Piper".
 The goal of the project "Piper" is to substantially ease setting up continuous delivery in your project using SAP technologies.
 
 ### Project "Piper"
 
 The SAP Cloud SDK is shipped with the pre-configured general-purpose pipeline which is a part of the project "Piper" and allows you to start with continuous delivery without writing any pipeline code - only declarative configuration is required.
-It helps you to quickly deliver high-quality applications to the SAP Cloud Platform.
+It helps you to quickly deliver high-quality applications to the SAP Business Technology Platform.
 
 Check out the [documentation of Project "Piper"](https://sap.github.io/jenkins-library/) for more details.
 

--- a/docs/related-projects/xsuaa.mdx
+++ b/docs/related-projects/xsuaa.mdx
@@ -13,13 +13,13 @@ keywords:
 
 ## What is User Account and Authentication for Cloud Foundry?
 
-[Cloud Foundry](https://help.sap.com/viewer/3504ec5ef16548778610c7e89cc0eac3/Cloud/en-US/9c7092c7b7ae4d49bc8ae35fdd0e0b18.html) is one of the key environments of the [SAP Cloud Platform](https://www.sap.com/products/cloud-platform.html).
+[Cloud Foundry](https://help.sap.com/viewer/3504ec5ef16548778610c7e89cc0eac3/Cloud/en-US/9c7092c7b7ae4d49bc8ae35fdd0e0b18.html) is one of the key environments of the [SAP Business Technology Platform](https://www.sap.com/products/cloud-platform.html).
 
 [User Account and Authentication (UAA)](https://docs.cloudfoundry.org/concepts/architecture/uaa.html) is the identity and management service for Cloud Foundry.
 
-## SAP Cloud Platform XSUAA Service
+## SAP Business Technology Platform XSUAA Service
 
-[XSUAA](https://help.sap.com/viewer/65de2977205c403bbc107264b8eccf4b/Cloud/en-US/ea0281368f11472b8d2b145a2a28666c.html) is an implementation of UAA service from SAP to be used with SAP Cloud Platform.
+[XSUAA](https://help.sap.com/viewer/65de2977205c403bbc107264b8eccf4b/Cloud/en-US/ea0281368f11472b8d2b145a2a28666c.html) is an implementation of UAA service from SAP to be used with SAP Business Technology Platform.
 It greatly extends capabilities for Cloud Foundry UAA service by providing:
 
 - Service broker
@@ -38,7 +38,7 @@ The library for JavaScript is delivered via [npm](https://www.npmjs.com/package/
 ## Integration With the SAP Cloud SDK
 
 The SAP Cloud SDK for Java has migrated its authentication flows from our implementation to a stable version of the Java XSUAA library.
-This ensures full coverage of authentication methods available on the SAP Cloud Platform with a high level of security and ongoing updates provided by the underlying library.
+This ensures full coverage of authentication methods available on the SAP Business Technology Platform with a high level of security and ongoing updates provided by the underlying library.
 Initial support is available since version [3.16.1 of the SAP Cloud SDK for Java](../java/release-notes-sap-cloud-sdk-for-java#3161).
 
 The SAP Cloud SDK for JavaScript handles XSUAA service on its own without using an official library.


### PR DESCRIPTION
## What Has Changed?

It gets a bit longer, but should still make sense. SCP -> SBTP

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [-] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
