### PR TITLE
Annotate only modified lines

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -28,7 +28,7 @@ jobs:
           # The files to lint: "all" or "<some_folder>".
           files: __onlyModified
           # Only post annotations on lines that have changed within a PR.
-          onlyAnnotateModifiedLines: false # optional, default is false
+          onlyAnnotateModifiedLines: true # optional, default is false
           # Log debugging information to stdout
           debug: false # optional, default is false
         env:  


### PR DESCRIPTION
## What Has Changed?

This is a pipeline update to benefit from the official Vale cation instead of a custom step to install it via brew. 
The install of Vale started to intermittently fail via brew due to unknown reasons and I found this action to be a good solution and enhance our use of it.

I tested it manually with a couple of PR and it worked fine. The annotations are added only to changed lines and visible in your "files" PR review screen. No need to switch to the Actions tab.
![image](https://user-images.githubusercontent.com/10460752/114465715-c6cce700-9be7-11eb-8930-0132f17971b0.png)
