### PR TITLE
[ODataV2] Add Docu for new `addChangeSet` Api

### DIFF
--- a/docs/java/features/odata/type-safe-client-odata-v2.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v2.mdx
@@ -411,12 +411,18 @@ BusinessPartnerAddress addressToCreate;
 BusinessPartnerAddress addressToUpdate;
 BusinessPartnerAddress addressToDelete;
 
-BusinessPartnerAddressCreateFluentHelper createRequest = service.createBusinessPartnerAddress(addressToCreate)
-                                                                .withHeader("header-for-create", "create value");
-BusinessPartnerAddressUpdateFluentHelper updateRequest = service.updateBusinessPartnerAddress(addressToUpdate)
-                                                                .withHeader("header-for-update", "update value");
-BusinessPartnerAddressDeleteFluentHelper deleteRequest = service.deleteBusinessPartnerAddress(addressToDelete)
-                                                                .withHeader("header-for-delete", "delete value");
+BusinessPartnerAddressCreateFluentHelper createRequest =
+    service
+        .createBusinessPartnerAddress(addressToCreate)
+        .withHeader("header-for-create", "create value");
+BusinessPartnerAddressUpdateFluentHelper updateRequest =
+    service
+        .updateBusinessPartnerAddress(addressToUpdate)
+        .withHeader("header-for-update", "update value");
+BusinessPartnerAddressDeleteFluentHelper deleteRequest =
+    service
+        .deleteBusinessPartnerAddress(addressToDelete)
+        .withHeader("header-for-delete", "delete value");
 
 BatchResponse result =
     service

--- a/docs/java/features/odata/type-safe-client-odata-v2.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v2.mdx
@@ -376,7 +376,8 @@ Refer to the [official OData V2 spec](https://www.odata.org/documentation/odata-
 The `service` object offers the method `batch` which allows access to the batch-related methods that help build the batch request.
 
 Multiple single requests (like `createBusinessPartnerAddress`) can be wrapped into so-called changesets.
-Each changeset is opened with `beginChangeSet` and closed with `endChangeSet`. You can wrap multiple changesets into one batch request.
+Each changeset is opened with `beginChangeSet` and closed with `endChangeSet`. 
+You can wrap multiple changesets into one batch request.
 
 Non-modification or in other words Read requests can be added outside of changesets with the `addReadOperations` method.
 
@@ -399,6 +400,28 @@ BatchResponse result =
         .endChangeSet()
         .addReadOperations(requestTenEntities)
         .addReadOperations(requestSingleEntity)
+        .executeRequest(destination);
+```
+
+Alternatively, you can also assemble changesets from individual requests with `addChangeSet`.
+This option allows you to further configure your requests by, for example, attaching custom headers to special parts of your changeset like so:
+
+```java
+BusinessPartnerAddress addressToCreate;
+BusinessPartnerAddress addressToUpdate;
+BusinessPartnerAddress addressToDelete;
+
+BusinessPartnerAddressCreateFluentHelper createRequest = service.createBusinessPartnerAddress(addressToCreate)
+                                                                .withHeader("header-for-create", "create value");
+BusinessPartnerAddressUpdateFluentHelper updateRequest = service.updateBusinessPartnerAddress(addressToUpdate)
+                                                                .withHeader("header-for-update", "update value");
+BusinessPartnerAddressDeleteFluentHelper deleteRequest = service.deleteBusinessPartnerAddress(addressToDelete)
+                                                                .withHeader("header-for-delete", "delete value");
+
+BatchResponse result =
+    service
+        .batch()
+        .addChangeSet(createRequest, updateRequest, deleteRequest)
         .executeRequest(destination);
 ```
 

--- a/docs/java/troubleshooting.mdx
+++ b/docs/java/troubleshooting.mdx
@@ -129,7 +129,7 @@ Compilation fails due to missing _Getters_ and _Setters_ on entity objects.
 ## Request via Cloud Connector fails with HTTP 407
 
 :::info **Symptoms**
-In your application log you find the HTTP error code 407 and the request targets an on-premise system via the SAP Cloud Connector.
+In your application log you find the HTTP error code 407 and the request targets an On-Premise system via the SAP Cloud Connector.
 :::
 
 **Possible causes:**


### PR DESCRIPTION
## What Has Changed?

Add usage documentation for the new `addChangeSet` API on ODataV2 Batch services.

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [x] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
