### PR TITLE
csrf token updates

### DIFF
--- a/docs/js/features/connectivity/generic-http-client.mdx
+++ b/docs/js/features/connectivity/generic-http-client.mdx
@@ -93,7 +93,7 @@ The values you give in the request configuration [will be merged](https://github
 For keys which exist for both object the value from the custom request configuration will be used.
 For example, a request configuration with `authorization` headers will overwrite the authorization header information from the destination.
 
-You can also pass an optional third parameter `httpRequestOptions`, where you can indicate for example whether the SAP Cloud SDK should fetch `CSRF` token for a non-get request.
+You can also pass an optional third parameter `httpRequestOptions`, where you can indicate for example whether the SAP Cloud SDK should fetch `CSRF` token for a non-GET request.
 For a get request, the `CSRF` token is not fetched and this option is ignored.
 Below is an example of the `httpRequestOptions` to delegate the `CSRF` token fetching to the SAP Cloud SDK.
 ```JSON

--- a/docs/js/features/connectivity/generic-http-client.mdx
+++ b/docs/js/features/connectivity/generic-http-client.mdx
@@ -58,7 +58,7 @@ This client executes the actual HTTP requests in the end.
 To make a request using the Generic HTTP client use the `executeHttpRequest` function.
 
 ```ts
-executeHttpRequest(destination, requestConfig);
+executeHttpRequest(destination, requestConfig, httpRequestOptions);
 ```
 
 The `destination` argument is either a full destination object you have already fetched or an object containing a destination name and JWT.
@@ -93,6 +93,16 @@ The values you give in the request configuration [will be merged](https://github
 For keys which exist for both object the value from the custom request configuration will be used.
 For example, a request configuration with `authorization` headers will overwrite the authorization header information from the destination.
 
+You can also pass an optional third parameter `httpRequestOptions`, where you can indicate for example whether the SAP Cloud SDK should fetch `CSRF` token for a non-get request.
+For a get request, the `CSRF` token is not fetched and this option is ignored.
+Below is an example of the `httpRequestOptions` to delegate the `CSRF` token fetching to the SAP Cloud SDK.
+```JSON
+{
+     fetchCsrfToken: true
+}
+```
+By default, the value of `fetchCsrfToken` is false.
+
 ## When to Use It
 
 You should consider the Generic HTTP client if:
@@ -108,5 +118,5 @@ You should consider the OData client if:
 - You have to build complicated filter, selection, and/or expand conditions.
   Here you will highly benefit from the help of the OData client.
 - You want to update or create new entities.
-  The OData Client has built-in `ETag` versions handling and takes also care of `CSRF` token fetching for you.
-  With the generic client, you have to manage versions and tokens on your own.
+  The OData Client has built-in `ETag` versions handling.
+  With the generic client, you have to manage versions on your own.

--- a/docs/js/features/odata/common/index.jsx
+++ b/docs/js/features/odata/common/index.jsx
@@ -1,9 +1,19 @@
 import React from 'react';
 import CsrfContent from './csrf-token.mdx';
+import SkipCsrfContent from './skip-csrf-token.mdx';
+import SkipCsrfExampleContent from './skip-csrf-token-example.mdx';
 import EtagContent from './etag.mdx';
 
 export function Csrf() {
   return <CsrfContent />;
+}
+
+export function SkipCsrf() {
+  return <SkipCsrfContent />;
+}
+
+export function SkipCsrfExample() {
+  return <SkipCsrfExampleContent />;
 }
 
 export function Etag() {

--- a/docs/js/features/odata/common/skip-csrf-token-example.mdx
+++ b/docs/js/features/odata/common/skip-csrf-token-example.mdx
@@ -1,0 +1,5 @@
+```ts
+BusinessPartner.requestBuilder()
+  .update(businessPartner)
+  .skipCsrfTokenFetching();
+```

--- a/docs/js/features/odata/common/skip-csrf-token.mdx
+++ b/docs/js/features/odata/common/skip-csrf-token.mdx
@@ -1,0 +1,3 @@
+For some services, the `CSRF` token is not required even for non-get requests.
+Therefore, skipping fetching the `CSRF` token makes sense as performance improvement.
+You can disable the `CSRF` token request by using `skipCsrfTokenFetching()` like below:

--- a/docs/js/features/odata/odata-v2-client.mdx
+++ b/docs/js/features/odata/odata-v2-client.mdx
@@ -14,7 +14,7 @@ keywords:
 ---
 
 import { Select } from './v2';
-import { Etag, Csrf } from './common';
+import {Csrf, SkipCsrf, SkipCsrfExample} from './common';
 import {
   CustomFields,
   DeserializeEntity,
@@ -136,6 +136,10 @@ More advanced filter expressions can be found [here](#available-filter-expressio
 ## Handling of Cross-Site Request Forgery Tokens
 
 <Csrf />
+
+## Skip CSRF token handling
+<SkipCsrf />
+<SkipCsrfExample />
 
 ## Available Filter Expressions
 

--- a/docs/js/features/odata/odata-v4-client.mdx
+++ b/docs/js/features/odata/odata-v4-client.mdx
@@ -46,7 +46,7 @@ import {
   ChangeSet,
   ConfigureSerialization
 } from './common/batch';
-import { Csrf, Etag } from './common';
+import { Csrf, SkipCsrf, SkipCsrfExample } from './common';
 import {
   ExpandSelect,
   FilterOneToMany,
@@ -180,6 +180,10 @@ Note that we currently do not support the usage of count within a filter conditi
 ## Handling of Cross-Site Request Forgery Tokens
 
 <Csrf />
+
+## Skip CSRF token handling
+<SkipCsrf />
+<SkipCsrfExample />
 
 ## Available Filter Expressions
 


### PR DESCRIPTION
## What Has Changed?

- [x] a new option in the `executeHttpRequest` to fetch csrf token.
- [x] a new API in the OData request builder to skip the csrf token request

## Manual Checks?

- [ ] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [ ] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [ ] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
