### PR TITLE
Mention `scope=uaa.user` case for `Unauthorized` XSUAA response

### DIFF
--- a/docs/java/guides/cf-xsuaa.mdx
+++ b/docs/java/guides/cf-xsuaa.mdx
@@ -78,7 +78,8 @@ You will likely need to run the following HTTP request in your browser and check
    ```
 
    :::tip
-   Optional values can be set for "scope" and "login_hint"
+   Optional values can be set for "scope" and "login_hint".
+   Use `scope=uaa.user` here when facing unexpected "Unauthorized" response for the resulting `[code]` in the next request.
    :::
 
 1. Submit login form via a browser or REST API debugging tools like POSTMAN or Insomnia.


### PR DESCRIPTION
## What Has Changed?

When reiterating the document, I noticed that for XSUAA in our test subaccount on Cloud Foundry, I had to add `uaa.user` scope to my authorization flow.

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [ ] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [ ] You formatted all changed files with prettier (`npm run prettier`)
- [ ] You tested if the documentation still builds (`npm run build`)
- [ ] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [ ] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
