### PR TITLE
accept SDK

### DIFF
--- a/styles/Vocab/SAP/accept.txt
+++ b/styles/Vocab/SAP/accept.txt
@@ -1,5 +1,6 @@
 SAP S/4HANA
 SAP Cloud SDK
+SDK
 Cloud Foundry
 Fieldglass
 Ariba


### PR DESCRIPTION
## What Has Changed?

I think the SDK should be accepted as a shorter form of referring to the SAP Cloud SDK.
In many situations using "SAP Cloud SDK" gets annoyingly verbose and out of style with good writing principles.