### PR TITLE
Troubleshooting for the missing `execute` in some function/action imports.

### DIFF
--- a/docs/java/features/odata/type-safe-client-odata-v2.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v2.mdx
@@ -376,7 +376,7 @@ Refer to the [official OData V2 spec](https://www.odata.org/documentation/odata-
 The `service` object offers the method `batch` which allows access to the batch-related methods that help build the batch request.
 
 Multiple single requests (like `createBusinessPartnerAddress`) can be wrapped into so-called changesets.
-Each changeset is opened with `beginChangeSet` and closed with `endChangeSet`. 
+Each changeset is opened with `beginChangeSet` and closed with `endChangeSet`.
 You can wrap multiple changesets into one batch request.
 
 Non-modification or in other words Read requests can be added outside of changesets with the `addReadOperations` method.

--- a/docs/java/release-notes.mdx
+++ b/docs/java/release-notes.mdx
@@ -64,6 +64,7 @@ To continue using the latest features outlined in the release notes for version 
   As a natural outcome, this new API also supports custom headers on a per-request basis.
 
   Example usage:
+
   ```java
   // define modification requests including custom headers per request
   MyEntityCreate createRequest = new MyEntityCreate(myNewEntityInstance).withHeader("custom-header", "value");
@@ -79,16 +80,16 @@ To continue using the latest features outlined in the release notes for version 
 ### Improvements
 
 - Dependency Updates:
-    - Minor version updates:
-      - Update Netty from `4.1.60.Final` to `4.1.63.Final`
-      - Update Lombok from `1.18.18` to `1.18.20`
-      - Update Jetty from `9.4.38.v20210224` to `9.4.39.v20210325`
-      - Update Bouncycastle from `1.64` to `1.68`
-      - Update Error Prone from `2.5.1` to `2.6.0`
-      - Update Java JWT from `3.14.0` to `3.15.0`
-      - Update Protobuf from `3.15.6` to `3.15.7`
-      - Update Apache CXF from `3.3.8` to `3.3.10`
-      - Update Mockito from `3.8.0` to `3.9.0`
+  - Minor version updates:
+    - Update Netty from `4.1.60.Final` to `4.1.63.Final`
+    - Update Lombok from `1.18.18` to `1.18.20`
+    - Update Jetty from `9.4.38.v20210224` to `9.4.39.v20210325`
+    - Update Bouncycastle from `1.64` to `1.68`
+    - Update Error Prone from `2.5.1` to `2.6.0`
+    - Update Java JWT from `3.14.0` to `3.15.0`
+    - Update Protobuf from `3.15.6` to `3.15.7`
+    - Update Apache CXF from `3.3.8` to `3.3.10`
+    - Update Mockito from `3.8.0` to `3.9.0`
 
 ## 3.42.0 - April 8, 2021
 

--- a/docs/java/troubleshooting.mdx
+++ b/docs/java/troubleshooting.mdx
@@ -139,7 +139,6 @@ In your application log you find the HTTP error code 407 and the request targets
   To solve this issue, retrieve the `HttpDestination` for each request again with the `DestinationAccessor` API.
   There is no need to worry about performance, because the SAP Cloud SDK uses an optimized built-in cache for Destinations.
 
-
 ## java.lang.NoSuchMethodError caused by GSON API
 
 :::info **Symptoms**
@@ -148,6 +147,6 @@ In your application log you find exception `java.lang.NoSuchMethodError: com.goo
 
 **Possible causes:**
 
-- Your project uses the [GSON library](https://github.com/google/gson) in version `2.8.5` or earlier. 
+- Your project uses the [GSON library](https://github.com/google/gson) in version `2.8.5` or earlier.
   This could happen if you do not use the SAP Cloud SDK Bill-of-Material.
   To solve this issue, update GSON to at least version `2.8.6`.

--- a/docs/js/features/odata/common/function-imports/entity-return-type.mdx
+++ b/docs/js/features/odata/common/function-imports/entity-return-type.mdx
@@ -1,5 +1,5 @@
 :::note Troubleshooting
-For some function/action-imports, the `execute()` method might be missing as intended.
+For some OData function or action imports, the `execute()` method might be missing as intended.
 Typically, this might happen when an entity type is shared by multiple entity sets and is used as the return type of function/action imports.
 You can then use `executeRaw` for getting the raw response and deserialize by your own.
 :::

--- a/docs/js/features/odata/common/function-imports/entity-return-type.mdx
+++ b/docs/js/features/odata/common/function-imports/entity-return-type.mdx
@@ -1,5 +1,5 @@
 :::note Troubleshooting
 For some OData function or action imports, the `execute()` method might be missing as intended.
-Typically, this might happen when an entity type is shared by multiple entity sets and is used as the return type of function/action imports.
+Typically, this might happen when an entity type is shared by multiple entity sets and is used as the return type of OData function or action imports.
 You can then use `executeRaw` for getting the raw response and deserialize by your own.
 :::

--- a/docs/js/features/odata/common/function-imports/entity-return-type.mdx
+++ b/docs/js/features/odata/common/function-imports/entity-return-type.mdx
@@ -1,5 +1,5 @@
 :::note Troubleshooting
 For some OData function or action imports, the `execute()` method might be missing as intended.
 Typically, this might happen when an entity type is shared by multiple entity sets and is used as the return type of OData function or action imports.
-You can then use `executeRaw` for getting the raw response and deserialize by your own.
+In such a case you can use `executeRaw` method for getting the raw response returned after invoking the OData function or action via type-safe API and deserialize it on your own.
 :::

--- a/docs/js/features/odata/common/function-imports/entity-return-type.mdx
+++ b/docs/js/features/odata/common/function-imports/entity-return-type.mdx
@@ -1,0 +1,5 @@
+:::note Troubleshooting
+For some function/action-imports, the `execute()` method might be missing as intended.
+Typically, this might happen when an entity type is shared by multiple entity sets and is used as the return type of function/action imports.
+You can then use `executeRaw` for getting the raw response and deserialize by your own.
+:::

--- a/docs/js/features/odata/common/function-imports/index.jsx
+++ b/docs/js/features/odata/common/function-imports/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import RequestBuilderContent from './request-builder.mdx';
 import EtagFunctionImportContent from './etag-function-import.mdx';
+import EntityReturnTypeContent from './entity-return-type.mdx';
 
 export function RequestBuilder() {
   return <RequestBuilderContent />;
@@ -8,4 +9,8 @@ export function RequestBuilder() {
 
 export function EtagFunctionImport() {
   return <EtagFunctionImportContent />;
+}
+
+export function EntityReturnType() {
+  return <EntityReturnTypeContent />;
 }

--- a/docs/js/features/odata/common/query-parameter/filter-functions.mdx
+++ b/docs/js/features/odata/common/query-parameter/filter-functions.mdx
@@ -12,6 +12,7 @@ BusinessPartner.requestBuilder()
 
 For filter functions with `boolean` as a return types, the filter function can be used directly as a filter without `.equal(true)`.
 Logically, the two following examples are equivalent to each other:
+
 ```ts
   /*
     $filter=startswith(FirstName, 'Bob') eq true
@@ -20,7 +21,9 @@ Logically, the two following examples are equivalent to each other:
     startsWith(BusinessPartner.FIRST_NAME, 'Bob').equal(true)
   )
 ```
+
 The filter expression can be shortened:
+
 ```ts
   /*
     $filter=startswith(FirstName, 'Bob')
@@ -29,4 +32,5 @@ The filter expression can be shortened:
     startsWith(BusinessPartner.FIRST_NAME, 'Bob')
   )
 ```
+
 However, as some services might not support both versions shown above, you might have to choose one of them to fit the target system.

--- a/docs/js/features/odata/common/query-parameter/filter.mdx
+++ b/docs/js/features/odata/common/query-parameter/filter.mdx
@@ -31,8 +31,8 @@ $filter=(((FirstName eq 'Alice') and (LastName ne 'Bob')) or (FirstName eq 'Mall
 Take note of the order of `and` and `or`.
 As `or` is invoked on the result of `and` it will form the outer expression while `and` is an inner expression in the first branch of `or`.
 
-
 In addition, the negation operator `not` can also be used for wrapping any filter expressions.
+
 ```
 /*
   Get all business partners that do not match any of the cases:
@@ -48,6 +48,7 @@ In addition, the negation operator `not` can also be used for wrapping any filte
   )
 )
 ```
+
 The `$filter` parameter will then be generated like below:
 
 ```sql

--- a/docs/js/features/odata/odata-v2-client.mdx
+++ b/docs/js/features/odata/odata-v2-client.mdx
@@ -39,7 +39,11 @@ import {
   FilterOneToOne,
   FilterFunctions
 } from './common/query-parameter';
-import { RequestBuilder, EtagFunctionImport } from './common/function-imports';
+import {
+  RequestBuilder,
+  EtagFunctionImport,
+  EntityReturnType
+} from './common/function-imports';
 import {
   BatchIntro,
   RetrieveRequests,
@@ -153,6 +157,8 @@ More advanced filter expressions can be found [here](#available-filter-expressio
 ### Request Builder
 
 <RequestBuilder />
+
+<EntityReturnType />
 
 ### Setting ETag
 

--- a/docs/js/features/odata/odata-v4-client.mdx
+++ b/docs/js/features/odata/odata-v4-client.mdx
@@ -37,7 +37,11 @@ import {
   FilterOneToOne,
   FilterFunctions
 } from './common/query-parameter';
-import { RequestBuilder, EtagFunctionImport } from './common/function-imports';
+import {
+  RequestBuilder,
+  EtagFunctionImport,
+  EntityReturnType
+} from './common/function-imports';
 import {
   BatchIntro,
   RetrieveRequests,
@@ -202,6 +206,8 @@ Note that we currently do not support the usage of count within a filter conditi
 
 <EtagFunctionImport />
 
+<EntityReturnType />
+
 ### Known Issues
 
 <FunctionImportKnownIssues />
@@ -209,6 +215,8 @@ Note that we currently do not support the usage of count within a filter conditi
 ## Action Imports
 
 <ActionImport />
+
+<EntityReturnType />
 
 ### Known Issues
 


### PR DESCRIPTION
## What Has Changed?

Add a troubleshooting section for explaining the missing `execute` method for some function/action imports and suggest to use `executeRaw` instead.

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [ ] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [ ] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
