### PR TITLE
Deprecate CLI

### DIFF
--- a/docs/js/features/cli/generator.mdx
+++ b/docs/js/features/cli/generator.mdx
@@ -15,6 +15,13 @@ keywords:
   - TypeScript
 ---
 
+:::caution CLI is deprecated
+
+The SAP Cloud SDK CLI is deprecated. We'll provide replacement for key value adds of the CLI like project scaffolding, etc.
+
+:::
+
+
 The SAP Cloud SDK CLI wraps the generator available in the SAP Cloud SDK.
 Right now the generator needs to be installed globally to be called through the CLI.
 We are working to fully integrate the OData generator, the OpenAPI generator and the CLI.

--- a/docs/js/features/cli/generator.mdx
+++ b/docs/js/features/cli/generator.mdx
@@ -17,7 +17,8 @@ keywords:
 
 :::caution CLI is deprecated
 
-The SAP Cloud SDK CLI is deprecated. We'll provide replacement for key value adds of the CLI like project scaffolding, etc.
+The SAP Cloud SDK CLI is deprecated.
+We'll provide replacement for key value adds of the CLI like project scaffolding, etc.
 
 :::
 

--- a/docs/js/features/cli/init.mdx
+++ b/docs/js/features/cli/init.mdx
@@ -15,6 +15,13 @@ keywords:
   - TypeScript
 ---
 
+:::caution CLI is deprecated
+
+The SAP Cloud SDK CLI is deprecated. We'll provide replacement for key value adds of the CLI like project scaffolding, etc.
+
+:::
+
+
 The SAP Cloud SDK CLI adds necessary dependencies and configurations to use the SAP Cloud SDK and deploy your app to SAP Business Technology Platform with one command.
 This is possible for any existing project that uses `npm`.
 

--- a/docs/js/features/cli/init.mdx
+++ b/docs/js/features/cli/init.mdx
@@ -17,7 +17,8 @@ keywords:
 
 :::caution CLI is deprecated
 
-The SAP Cloud SDK CLI is deprecated. We'll provide replacement for key value adds of the CLI like project scaffolding, etc.
+The SAP Cloud SDK CLI is deprecated.
+We'll provide replacement for key value adds of the CLI like project scaffolding, etc.
 
 :::
 

--- a/docs/js/features/cli/overview.mdx
+++ b/docs/js/features/cli/overview.mdx
@@ -15,6 +15,12 @@ keywords:
   - TypeScript
 ---
 
+:::caution CLI is deprecated
+
+The SAP Cloud SDK CLI is deprecated. We'll provide replacement for key value adds of the CLI like project scaffolding, etc.
+
+:::
+
 The SAP Cloud SDK CLI is a command-line interface (CLI) to simplify common tasks you may encounter when working with the SAP Cloud SDK:
 
 - [Adding the SAP Cloud SDK to an existing project](./init.mdx)

--- a/docs/js/features/cli/overview.mdx
+++ b/docs/js/features/cli/overview.mdx
@@ -17,7 +17,8 @@ keywords:
 
 :::caution CLI is deprecated
 
-The SAP Cloud SDK CLI is deprecated. We'll provide replacement for key value adds of the CLI like project scaffolding, etc.
+The SAP Cloud SDK CLI is deprecated.
+We'll provide replacement for key value adds of the CLI like project scaffolding, etc.
 
 :::
 

--- a/docs/js/features/cli/package.mdx
+++ b/docs/js/features/cli/package.mdx
@@ -15,6 +15,13 @@ keywords:
   - TypeScript
 ---
 
+:::caution CLI is deprecated
+
+The SAP Cloud SDK CLI is deprecated. We'll provide replacement for key value adds of the CLI like project scaffolding, etc.
+
+:::
+
+
 ## Benefits of Using the SAP Cloud SDK CLI in Continuous Delivery
 
 A project initialized with the SAP Cloud SDK CLI provides all the necessary configuration to be used with [Project "Piper"](../../../related-projects/project-piper).

--- a/docs/js/features/cli/package.mdx
+++ b/docs/js/features/cli/package.mdx
@@ -17,7 +17,8 @@ keywords:
 
 :::caution CLI is deprecated
 
-The SAP Cloud SDK CLI is deprecated. We'll provide replacement for key value adds of the CLI like project scaffolding, etc.
+The SAP Cloud SDK CLI is deprecated.
+We'll provide replacement for key value adds of the CLI like project scaffolding, etc.
 
 :::
 


### PR DESCRIPTION
## What Has Changed?

The announcement in docs to deprecate the CLI

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [x] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
