### PR TITLE
Fix typos in WAR deployment guide

### DIFF
--- a/docs/java/guides/spring-boot-war-deployment.mdx
+++ b/docs/java/guides/spring-boot-war-deployment.mdx
@@ -30,7 +30,7 @@ The advantage of that modern deployment form is that the application can be star
 This guide is applicable to all Spring-based Java projects which use the modern deployment of Spring as jar file.
 That comprises in the first place any project using the [new CAP stack](https://cap.cloud.sap/docs/) as well as the [Spring Boot Maven archetype](https://search.maven.org/artifact/com.sap.cloud.sdk.archetypes/scp-cf-spring) of the SAP Cloud SDK.
 
-The problem with the modern deployment is that the [SAP Java Connector](https://support.sap.com/en/product/connectors/jco.html) library cannot be used when the application gets deployed as war file.
+The problem with the modern deployment is that the [SAP Java Connector](https://support.sap.com/en/product/connectors/jco.html) library cannot be used when the application gets deployed as jar file.
 That results in runtime exceptions like `java.lang.NoClassDefFoundError: com/sap/conn/jco/JCoException`.
 
 To overcome this problem, we'll outline how to adjust your project to leverage the traditional Spring deployment instead.
@@ -39,7 +39,7 @@ To overcome this problem, we'll outline how to adjust your project to leverage t
 
 Perform the following steps to switch your project from using the modern to the traditional Spring deployment.
 
-### Change Maven Packacking
+### Change Maven Packaging
 
 In your `pom.xml`, change the packaging setting from `jar` to `war`.
 


### PR DESCRIPTION
## What Has Changed?

Fix two typos in the docu about the WAR deployment.

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [x] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
