### PR TITLE
Fix the link on the badge to point to JS repo

### DIFF
--- a/src/sap/sdk-js/BuildBadge.js
+++ b/src/sap/sdk-js/BuildBadge.js
@@ -6,7 +6,7 @@ function BuildBadge({ align }) {
       <a
         target="_blank"
         rel="noopener noreferrer"
-        href="https://github.com/SAP/cloud-sdk"
+        href="https://github.com/SAP/cloud-sdk-js"
       >
         <img
           src="https://github.com/SAP/cloud-sdk-js/workflows/build/badge.svg"


### PR DESCRIPTION
## What Has Changed?

Make the link from the badge pointing at JS repo, not the docs. The actual source from the badge is correct.

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
~~- [ ] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.~~
