### PR TITLE
Mention dependency exclusion

### DIFF
--- a/docs/java/features/bapi-and-rfc/overview.mdx
+++ b/docs/java/features/bapi-and-rfc/overview.mdx
@@ -426,6 +426,12 @@ At the top of your dependency management section, before including any SAP Cloud
     <version>latest-version-here</version>
     <scope>provided</scope>
 </dependency>
+<dependency>
+    <groupId>com.sap.cloud.security</groupId>
+    <artifactId>java-security</artifactId>
+    <version>latest-version-here</version>
+    <scope>provided</scope>
+</dependency>
 ```
 
 ### Decoration of RFC Destinations


### PR DESCRIPTION
## What Has Changed?

As a learning from an [internal issue](https://github.wdf.sap.corp/MA/sdk/issues/5344) we found that the additional exclusion of `java-security` library is necessary.

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [x] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
