### PR TITLE
Remove Unneeded Constant

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -217,11 +217,3 @@ module.exports = {
   ],
   customFields: {}
 };
-
-const docsOptions = {
-  versions: {
-    current: {
-      banner: 'none'
-    }
-  }
-}


### PR DESCRIPTION
## What Has Changed?

Remove constant that was introduced to disable to the `DocVersionBanner` component on top of our articles. However, it turned out that this was not actually needed.

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [x] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
