### PR TITLE
Remove old community call links

### DIFF
--- a/docs/community/community-call.mdx
+++ b/docs/community/community-call.mdx
@@ -42,11 +42,9 @@ We consider holding a session in the future about these topics:
 
 - Build an application using SAP Cloud SDK in SAP Business Application Studio
 
-## Upcoming Dates 2020
+<!--## Upcoming Dates 2020--
 
-- June 23 - Easy consumption of OpenAPI services using OpenAPI Client Generator of SAP Cloud SDK for JS
-
-Please register for the [series](https://sap-se.zoom.us/webinar/register/WN_dBtYmF5IR7Gb8TMjHqEvhw) to receive an invite for the upcoming session.
+Please register for the [series](https://sap-se.zoom.us/webinar/register/WN_dBtYmF5IR7Gb8TMjHqEvhw) to receive an invite for the upcoming session.-->
 
 ## Past Sessions
 

--- a/docs/js/features/openapi/generate-openapi-client.mdx
+++ b/docs/js/features/openapi/generate-openapi-client.mdx
@@ -21,13 +21,6 @@ Many SAP systems like SAP S/4HANA, SAP Concur and SAP Business Technology Platfo
 A common way to specify these services are [OpenAPI specifications](https://swagger.io/specification/).
 With the SAP Cloud SDK, you can generate typed clients for those specifications.
 
-:::info
-
-There is an upcoming community call on using the OpenAPI client generator of the SAP Cloud SDK for JS on June 23rd 2020.
-Consider [registering](https://sap-se.zoom.us/webinar/register/WN_dBtYmF5IR7Gb8TMjHqEvhw) to get a hands on demo on this topic.
-
-:::
-
 ## Installation
 
 Run this command to install the OpenAPI generator globally:


### PR DESCRIPTION
## What Has Changed?

I have removed the invite links to our old community call 

## Manual Checks?

- [x] ~Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)~
- [x] ~You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)~
- [x] ~You formatted all changed files with prettier (`npm run prettier`)~
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [x] ~You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.~
