### PR TITLE
Add link to the ScpCfDestinationTokenExchangeStrategy Javadoc

### DIFF
--- a/docs/java/features/connectivity/destinations.mdx
+++ b/docs/java/features/connectivity/destinations.mdx
@@ -324,7 +324,7 @@ DestinationOptions options =
 
 ##### Token Exchange Options
 
-Besides the retrieval strategy, the SAP Cloud SDK also offers a _token exchange strategy_ that lets you change the behavior when authentication requires a user token exchange.
+Besides the retrieval strategy, the SAP Cloud SDK also offers a [token exchange strategy](https://help.sap.com/doc/69f4a2d15d9b404fac06e968f0633d98/1.0/en-US/com/sap/cloud/sdk/cloudplatform/connectivity/ScpCfDestinationTokenExchangeStrategy.html) that lets you change the behavior when authentication requires a user token exchange.
 There are three different options available:
 
 - `LOOKUP_THEN_EXCHANGE` (default)


### PR DESCRIPTION
## What Has Changed?

Minor left over from the time when I initially created that documentation.

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [x] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
