### PR TITLE
Update link to Javadoc in release notes

### DIFF
--- a/docs/java/release-notes.mdx
+++ b/docs/java/release-notes.mdx
@@ -57,7 +57,7 @@ To continue using the latest features outlined in the release notes for version 
 
 ## 3.50.0 - July 29, 2021
 
-[Maven Central](https://search.maven.org/search?q=g:com.sap.cloud.sdk*%20AND%20v:3.50.0) | [Javadoc](https://help.sap.com/doc/55bb1642ea614bf582d514ed34401136/1.0/en-US/index.html)
+[Maven Central](https://search.maven.org/search?q=g:com.sap.cloud.sdk*%20AND%20v:3.50.0) | [Javadoc](https://help.sap.com/doc/69f4a2d15d9b404fac06e968f0633d98/1.0/en-US/index.html)
 
 ### Known issues
 
@@ -93,7 +93,7 @@ Check more examples on how to leverage`CacheFilter` in the [detailed feature doc
 
 ## 3.49.0 - July 15, 2021
 
-[Maven Central](https://search.maven.org/search?q=g:com.sap.cloud.sdk*%20AND%20v:3.49.0) | [Javadoc](https://help.sap.com/doc/55bb1642ea614bf582d514ed34401136/1.0/en-US/index.html)
+[Maven Central](https://search.maven.org/search?q=g:com.sap.cloud.sdk*%20AND%20v:3.49.0) | [Javadoc](https://help.sap.com/doc/69f4a2d15d9b404fac06e968f0633d98/1.0/en-US/index.html)
 
 ### Known issues
 


### PR DESCRIPTION
## What Has Changed?

Update the link to our Javadoc in our release notes.

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [x] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
