### PR TITLE
Improve generic http client doc

### DIFF
--- a/docs/js/features/connectivity/generic-http-client.mdx
+++ b/docs/js/features/connectivity/generic-http-client.mdx
@@ -62,7 +62,8 @@ executeHttpRequest(destination, requestConfig, httpRequestOptions);
 ```
 
 The `destination` argument is either a full <LinkToLatestJsApiDocs slug="interfaces/sap_cloud_sdk_core.Destination" name="destination object" />, that you have already fetched or an <LinkToLatestJsApiDocs slug="interfaces/sap_cloud_sdk_core.DestinationNameAndJwt" name="object containing a destination name and an optional JWT" />.
-In the latter case the SAP Cloud SDK fetches the destination for you. You should read the [destination document]((../connectivity/destination.mdx)) for details, and it also explains about the JWT parameter.
+In the latter case the SAP Cloud SDK fetches the destination for you.
+You should read the [destination document]((../connectivity/destination.mdx)) for details, and it also explains about the JWT parameter.
 The <LinkToLatestJsApiDocs slug="interfaces/sap_cloud_sdk_core.HttpRequestConfig" name="request configuration" /> argument contains the request configuration.
 A minimal configuration would look like this:
 

--- a/docs/js/features/connectivity/generic-http-client.mdx
+++ b/docs/js/features/connectivity/generic-http-client.mdx
@@ -62,8 +62,8 @@ executeHttpRequest(destination, requestConfig, httpRequestOptions);
 ```
 
 The `destination` argument is either a full <LinkToLatestJsApiDocs slug="interfaces/sap_cloud_sdk_core.Destination" name="destination object" />, that you have already fetched or an <LinkToLatestJsApiDocs slug="interfaces/sap_cloud_sdk_core.DestinationNameAndJwt" name="object containing a destination name and an optional JWT" />.
-In the latter case the SAP Cloud SDK fetches the destination for you.
-You should read the [destination document]((../connectivity/destination.mdx)) for details, and it also explains about the JWT parameter.
+In the latter case, the SAP Cloud SDK fetches the destination for you.
+To learn more check the [destination documentation]((../connectivity/destination.mdx)) . It provides more details about the `JWT` parameter.
 The <LinkToLatestJsApiDocs slug="interfaces/sap_cloud_sdk_core.HttpRequestConfig" name="request configuration" /> argument contains the request configuration.
 A minimal configuration would look like this:
 

--- a/docs/js/features/connectivity/generic-http-client.mdx
+++ b/docs/js/features/connectivity/generic-http-client.mdx
@@ -63,7 +63,7 @@ executeHttpRequest(destination, requestConfig, httpRequestOptions);
 
 The `destination` argument is either a full <LinkToLatestJsApiDocs slug="interfaces/sap_cloud_sdk_core.Destination" name="destination object" />, that you have already fetched or an <LinkToLatestJsApiDocs slug="interfaces/sap_cloud_sdk_core.DestinationNameAndJwt" name="object containing a destination name and an optional JWT" />.
 In the latter case, the SAP Cloud SDK fetches the destination for you.
-To learn more check the [destination documentation]((../connectivity/destination.mdx)) . It provides more details about the `JWT` parameter.
+To learn more, check the [destination documentation]((../connectivity/destination.mdx)). It provides more details about the `JWT` parameter.
 The <LinkToLatestJsApiDocs slug="interfaces/sap_cloud_sdk_core.HttpRequestConfig" name="request configuration" /> argument contains the request configuration.
 A minimal configuration would look like this:
 

--- a/docs/js/features/connectivity/generic-http-client.mdx
+++ b/docs/js/features/connectivity/generic-http-client.mdx
@@ -61,8 +61,8 @@ To make a request using the Generic HTTP client use the `executeHttpRequest` fun
 executeHttpRequest(destination, requestConfig, httpRequestOptions);
 ```
 
-The `destination` argument is either a full <LinkToLatestJsApiDocs slug="interfaces/sap_cloud_sdk_core.Destination" name="destination object" /> you have already fetched or an <LinkToLatestJsApiDocs slug="interfaces/sap_cloud_sdk_core.DestinationNameAndJwt" name="object containing a destination name and JWT" />.
-In the latter case the SAP Cloud SDK fetches the destination for you. You should read the [destination document]((../connectivity/destination.mdx)) for details and it also explains about the optional JWT parameter.
+The `destination` argument is either a full <LinkToLatestJsApiDocs slug="interfaces/sap_cloud_sdk_core.Destination" name="destination object" />, that you have already fetched or an <LinkToLatestJsApiDocs slug="interfaces/sap_cloud_sdk_core.DestinationNameAndJwt" name="object containing a destination name and an optional JWT" />.
+In the latter case the SAP Cloud SDK fetches the destination for you. You should read the [destination document]((../connectivity/destination.mdx)) for details, and it also explains about the JWT parameter.
 The <LinkToLatestJsApiDocs slug="interfaces/sap_cloud_sdk_core.HttpRequestConfig" name="request configuration" /> argument contains the request configuration.
 A minimal configuration would look like this:
 

--- a/docs/js/features/connectivity/generic-http-client.mdx
+++ b/docs/js/features/connectivity/generic-http-client.mdx
@@ -62,7 +62,7 @@ executeHttpRequest(destination, requestConfig, httpRequestOptions);
 ```
 
 The `destination` argument is either a full <LinkToLatestJsApiDocs slug="interfaces/sap_cloud_sdk_core.Destination" name="destination object" /> you have already fetched or an <LinkToLatestJsApiDocs slug="interfaces/sap_cloud_sdk_core.DestinationNameAndJwt" name="object containing a destination name and JWT" />.
-In the latter case the SAP Cloud SDK fetches the destination for you, you should read the [destination document]((../connectivity/destination.mdx)) for details and it also explains about the optional JWT parameter.
+In the latter case the SAP Cloud SDK fetches the destination for you. You should read the [destination document]((../connectivity/destination.mdx)) for details and it also explains about the optional JWT parameter.
 The <LinkToLatestJsApiDocs slug="interfaces/sap_cloud_sdk_core.HttpRequestConfig" name="request configuration" /> argument contains the request configuration.
 A minimal configuration would look like this:
 

--- a/docs/js/features/connectivity/generic-http-client.mdx
+++ b/docs/js/features/connectivity/generic-http-client.mdx
@@ -61,8 +61,8 @@ To make a request using the Generic HTTP client use the `executeHttpRequest` fun
 executeHttpRequest(destination, requestConfig, httpRequestOptions);
 ```
 
-The `destination` argument is either a full destination object you have already fetched or an object containing a destination name and JWT.
-In the latter case the SAP Cloud SDK [fetches the destination](../connectivity/destination.mdx) for you.
+The `destination` argument is either a full <LinkToLatestJsApiDocs slug="interfaces/sap_cloud_sdk_core.Destination" name="destination object" /> you have already fetched or an <LinkToLatestJsApiDocs slug="interfaces/sap_cloud_sdk_core.DestinationNameAndJwt" name="object containing a destination name and JWT" />.
+In the latter case the SAP Cloud SDK fetches the destination for you, you should read the [destination document]((../connectivity/destination.mdx)) for details and it also explains about the optional JWT parameter.
 The <LinkToLatestJsApiDocs slug="interfaces/sap_cloud_sdk_core.HttpRequestConfig" name="request configuration" /> argument contains the request configuration.
 A minimal configuration would look like this:
 


### PR DESCRIPTION
## What Has Changed?

Related to [this issue](https://github.com/SAP/cloud-sdk/issues/454)
- add some links to `destination object` and `DestinationNameAndJwt`
- mention JWT is optional and show the JWT doc

## Manual Checks?

- [ ] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [ ] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [ ] You formatted all changed files with prettier (`npm run prettier`)
- [ ] You tested if the documentation still builds (`npm run build`)
- [ ] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [ ] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
