### PR TITLE
Warn that we don't have SDK for the FE

### DIFF
--- a/docs/js/guides/sdk-in-browser.mdx
+++ b/docs/js/guides/sdk-in-browser.mdx
@@ -13,7 +13,7 @@ keywords:
 
 :::warn
 
-The latest Webpack update introed braking changes that make the building part of this guide fail.
+The latest Webpack update introduced braking changes that make the building part of this guide fail.
 You can try to resolve them yourself or wait before we test and release an update to this guide.
 We can't provide a specific ETA for such an update.
 

--- a/docs/js/guides/sdk-in-browser.mdx
+++ b/docs/js/guides/sdk-in-browser.mdx
@@ -11,7 +11,7 @@ keywords:
   - sap cloud sdk
 ---
 
-:::warn
+:::caution
 
 The latest Webpack update introduced braking changes that make the building part of this guide fail.
 You can try to resolve them yourself or wait before we test and release an update to this guide.

--- a/docs/js/guides/sdk-in-browser.mdx
+++ b/docs/js/guides/sdk-in-browser.mdx
@@ -13,7 +13,9 @@ keywords:
 
 :::warn
 
-The latest Webpack update introed braking changes that make the building part of this guide fail. You can try to resolve them yourself or wait before we test and release an update to this guide. We can't provide a specific ETA for such update.
+The latest Webpack update introed braking changes that make the building part of this guide fail.
+You can try to resolve them yourself or wait before we test and release an update to this guide.
+We can't provide a specific ETA for such an update.
 
 :::
 

--- a/docs/js/guides/sdk-in-browser.mdx
+++ b/docs/js/guides/sdk-in-browser.mdx
@@ -11,6 +11,13 @@ keywords:
   - sap cloud sdk
 ---
 
+:::warn
+
+The latest Webpack update introed braking changes that make the building part of this guide fail. You can try to resolve them yourself or wait before we test and release an update to this guide. We can't provide a specific ETA for such update.
+
+:::
+
+
 The SAP Cloud SDK for JavaScript can be used both as a backend and frontend library when used in a browser.
 Because of the specifics of a browser environment, some features might be unavailable.
 To help you get up and running faster in a browser, we'll outline the main steps and caveats of using SAP Cloud SDK on the frontend.

--- a/styles/Vocab/SAP/accept.txt
+++ b/styles/Vocab/SAP/accept.txt
@@ -68,3 +68,4 @@ autogenerate
 [Ww]eb[Ff]lux
 [Dd]ockerfile
 [Mm]iddleware
+[Ww]ebpack

--- a/styles/Vocab/SAP/accept.txt
+++ b/styles/Vocab/SAP/accept.txt
@@ -68,4 +68,3 @@ autogenerate
 [Ww]eb[Ff]lux
 [Dd]ockerfile
 [Mm]iddleware
-[Ww]ebpack


### PR DESCRIPTION
## What Has Changed?

Webpack 5 makes our FE build fail

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
~~- [ ] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.~~
