### PR TITLE
[OpenAPIGenerator] Add section about issues during `anyOf/oneOf`

### DIFF
--- a/docs/java/features/rest/generate-rest-client.mdx
+++ b/docs/java/features/rest/generate-rest-client.mdx
@@ -251,7 +251,7 @@ In certain cases although the generation of the client succeeds the subsequent c
 
 If you observe that you notice `Cannot find Symbol for AnyOf{ClassName} Classes` or `Cannot find symbol OneOf{ClassName} Classes` or `Cannot find symbol UNKNOWN_BASE_TYPE` during compilation, check if your specification contains keywords `anyOf` or `oneOf`.
 
-The public open-source [OpenAPI Generator](https://github.com/OpenAPITools/openapi-generator) that is used by the SAP Cloud SDK under the hood generates non compilable code if `anyOf` or `oneOf` are present in certain parts of the input specification.
+The public open-source [OpenAPI Generator](https://github.com/OpenAPITools/openapi-generator) that is used by the SAP Cloud SDK under the hood generates non-compilable code if `anyOf` or `oneOf` are present in certain parts of the input specification.
 
 Compilation fails if:
 

--- a/docs/java/features/rest/generate-rest-client.mdx
+++ b/docs/java/features/rest/generate-rest-client.mdx
@@ -243,7 +243,6 @@ The complete list of available parameters with their description is as follows:
 :::info
 
 From version `3.58` of the SAP Cloud SDK, the OpenAPI generator has been enhanced to fail if the input specification contains keywords `anyOf` or `oneOf` in certain positions.
-(More details on these positions below)
 
 :::
 

--- a/docs/java/features/rest/generate-rest-client.mdx
+++ b/docs/java/features/rest/generate-rest-client.mdx
@@ -237,3 +237,91 @@ The complete list of available parameters with their description is as follows:
 
 </TabItem>
 </Tabs>
+
+## Solving Compilation Issues After Generation
+
+:::info
+
+From version `3.58` of the SAP Cloud SDK, the OpenAPI generator has been enhanced to fail if the input specification contains keywords `anyOf` or `oneOf` in certain positions.
+(More details on these positions below)
+
+:::
+
+In certain cases although the generation of the client succeeds the subsequent compilation fails due to multiple reasons.
+
+If you observe that you notice `Cannot find Symbol for AnyOf{ClassName} Classes` or `Cannot find symbol OneOf{ClassName} Classes` or `Cannot find symbol UNKNOWN_BASE_TYPE` during compilation, check if your specification contains keywords `anyOf` or `oneOf`.
+
+The public open-source [OpenAPI Generator](https://github.com/OpenAPITools/openapi-generator) that is used by the SAP Cloud SDK under the hood generates non compilable code if `anyOf` or `oneOf` are present in certain parts of the input specification.
+
+Compilation fails if:
+
+- These keywords exist under the `paths` part, under any operation while defining either the `requestbody` or `responses`
+
+```YAML
+paths:
+ /APIPath:
+        put:
+          summary: ...
+          requestBody:
+            description: ...
+            content:
+              application/json:
+                schema:
+                  oneOf:
+                    - $ref: '#/components/schemas/SomeSchema'
+                    - $ref: '#/components/schemas/SomeOtherSchema'
+          responses:
+            '200':
+              description: ...
+              content:
+                application/json:
+                  schema:
+                    oneOf:
+                      - $ref: '#/components/schemas/SomeSchema'
+                      - type: array
+                        items:
+                          $ref: '#/components/schemas/SomeOtherSchema'
+```
+- These keywords exist under any of the `schemas` either under any property in `properties` or under `additionalProperties`
+```YAML
+components:
+  schemas:
+    SampleSchema:
+      title: SampleSchema
+      description: ...
+      type: object
+      properties:
+        embeddedData:
+          $ref: '#/components/schemas/EmbeddedData'
+        questions:
+          type: array
+          title: questions
+          items:
+            title: Question
+            oneOf:
+              - $ref: '#/components/schemas/mc'
+              - $ref: '#/components/schemas/te'
+              - $ref: '#/components/schemas/db'
+            discriminator:
+              propertyName: type
+      AnotherSampleSchema:
+        description: ...
+        type: ...
+        anotherProperty:
+            description: ...
+            oneOf:
+              - type: string
+                enum:
+                  - ENDOFBLOCK
+                  - ENDOFSURVEY
+              - $ref: '#/components/schemas/SurveyID'
+        additionalProperties:
+          oneOf:
+            - $ref: '#/components/schemas/SomeSchema'
+            - $ref: '#/components/schemas/SomeOtherSchema'
+```
+To make the compilation to succeed, please remove these keywords (if they exist in the above mentioned positions) from the input specification and generated the client again.
+
+Please note that while removing these keywords, you must also supply a meaningful replacement.
+
+Refer to the [Swagger documentation](https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/) to understand more about the usage of these keywords and to derive their replacement.

--- a/docs/java/features/rest/generate-rest-client.mdx
+++ b/docs/java/features/rest/generate-rest-client.mdx
@@ -330,7 +330,7 @@ components:
 ```
 </details>
 
-To make the compilation to succeed, please remove these keywords (if they exist in the above mentioned positions) from the input specification and generate the client again.
+To make the compilation succeed, please remove these keywords from your specification and generate the client again.
 
 Please note that while removing these keywords from a property, you must also supply a meaningful replacement.
 Sometimes you may also choose to drop the property altogether for e.g, in the case of `additionalProperties`

--- a/docs/java/features/rest/generate-rest-client.mdx
+++ b/docs/java/features/rest/generate-rest-client.mdx
@@ -257,7 +257,10 @@ Compilation fails if:
 
 - These keywords exist under the `paths` part, under any operation while defining either the `requestbody` or `responses`
 
-```YAML
+<details>
+  <summary>Keywords under paths</summary>
+
+```
 paths:
  /APIPath:
         put:
@@ -282,8 +285,14 @@ paths:
                         items:
                           $ref: '#/components/schemas/SomeOtherSchema'
 ```
+</details>
+
 - These keywords exist under any of the `schemas` either under any property in `properties` or under `additionalProperties`
-```YAML
+
+<details>
+  <summary>Keywords under properties of schema</summary>
+
+```
 components:
   schemas:
     SampleSchema:
@@ -320,8 +329,11 @@ components:
             - $ref: '#/components/schemas/SomeSchema'
             - $ref: '#/components/schemas/SomeOtherSchema'
 ```
-To make the compilation to succeed, please remove these keywords (if they exist in the above mentioned positions) from the input specification and generated the client again.
+</details>
 
-Please note that while removing these keywords, you must also supply a meaningful replacement.
+To make the compilation to succeed, please remove these keywords (if they exist in the above mentioned positions) from the input specification and generate the client again.
+
+Please note that while removing these keywords from a property, you must also supply a meaningful replacement.
+Sometimes you may also choose to drop the property altogether for e.g, in the case of `additionalProperties`
 
 Refer to the [Swagger documentation](https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/) to understand more about the usage of these keywords and to derive their replacement.


### PR DESCRIPTION
## What Has Changed?

Added a section explaining when compilation error occurs while input specification contains keywords `anyOf/oneOf`

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] ~You verified all new and changed links still work (changing the `id` or name of a file can break links)~
- [x] ~You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.~
