### PR TITLE
DestinationAccess changed to DestinationAccessor

### DIFF
--- a/docs/java/features/connectivity/http-client.mdx
+++ b/docs/java/features/connectivity/http-client.mdx
@@ -32,7 +32,7 @@ HttpClient client = HttpClientAccessor.getHttpClient();
 If On-premise the goal is to create a client with properties according to a specific destination, it can be provided as argument:
 
 ```java
-HttpDestination destination = DestinationAccess.getDestination("my-destination").asHttp();
+HttpDestination destination = DestinationAccessor.getDestination("my-destination").asHttp();
 HttpClient client = HttpClientAccessor.getHttpClient(destination);
 ```
 


### PR DESCRIPTION
## What Has Changed?
There is no class called DestinationAccess, it should be DestinationAccessor

Explain what you have changed.
When i was trying to use the sample code, i found the issue, i think it is a typo error
There is no class called DestinationAccess, it should be DestinationAccessor

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [x] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
