### PR TITLE
Remove reference to no longer available video

### DIFF
--- a/docs/related-projects/piper.mdx
+++ b/docs/related-projects/piper.mdx
@@ -25,17 +25,3 @@ The SAP Cloud SDK is shipped with the pre-configured general-purpose pipeline wh
 It helps you to quickly deliver high-quality applications to the SAP Business Technology Platform.
 
 Check out the [documentation of Project "Piper"](https://sap.github.io/jenkins-library/) for more details.
-
-### Video Tutorial
-
-This video tutorial is a good example of SAP Cloud SDK for continuous delivery used with [SAP Cloud Programming Model](https://cap.cloud.sap/docs/).
-
-<div class="sdk-video-container">
-  <iframe
-    class="sdk-video"
-    src="https://www.youtube.com/embed/Ss0mFfaE5t4"
-    frameborder="0"
-    allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-    allowfullscreen
-  ></iframe>
-</div>


### PR DESCRIPTION
Regarding https://sap.github.io/cloud-sdk/docs/related-projects/project-piper

The video is now longer available and probably not needed.