### PR TITLE
[Java] Add Prerequisites for OData v2/v4 Typed Clients

### DIFF
--- a/docs/java/features/odata/type-safe-client-odata-v2.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v2.mdx
@@ -71,8 +71,9 @@ To leverage the type-safe OData v2 client, you need to add following dependencie
 
 :::tip Tip
 
-If you would like to consume a specific service, try searching for it on the [SAP API Business Hub](https://api.sap.com/).
-You will find detailed instructions on how to use the SAP Cloud SDK to interact with the services of your choice.
+If you would like to consume a specific service, try searching for it on the [SAP API Business Hub](https://api.sap.com/) and visit an **SAP Cloud SDK** tab on the landing page of that service.
+There you will find detailed instructions on how to use the SAP Cloud SDK to get a client library for that specific service.
+Learn more about the integration with the SAP API Business Hub in the [blog](https://blogs.sap.com/2021/09/17/the-sap-cloud-sdk-integrates-with-the-sap-api-business-hub/).
 
 :::
 

--- a/docs/java/features/odata/type-safe-client-odata-v2.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v2.mdx
@@ -19,7 +19,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-## Prerequesites
+## Prerequisites
 
 To leverage the type-safe OData v2 client, you need to add following dependencies to the `dependencies` section of your `pom.xml`:
 

--- a/docs/java/features/odata/type-safe-client-odata-v2.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v2.mdx
@@ -69,7 +69,7 @@ To leverage the type-safe OData v2 client, you need to add following dependencie
 </TabItem>
 </Tabs>
 
-:::tip Tip
+:::tip Discover services on the SAP API Business Hub
 
 If you would like to consume a specific service, try searching for it on the [SAP API Business Hub](https://api.sap.com/) and visit an **SAP Cloud SDK** tab on the landing page of that service.
 There you will find detailed instructions on how to use the SAP Cloud SDK to get a client library for that specific service.

--- a/docs/java/features/odata/type-safe-client-odata-v2.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v2.mdx
@@ -19,6 +19,63 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
+## Prerequesites
+
+To leverage the type-safe OData v2 client, you need to add following dependencies to the `dependencies` section of your `pom.xml`:
+
+<Tabs groupId="odataClientType" defaultValue="PregeneratedCloud" values={[ { label: 'Pregenerated Clients (Cloud)', value: 'PregeneratedCloud' }, { label: 'Pregenerated Clients (On-Premise)', value: 'PregeneratedOnPremise' }, { label: 'Self Generated Clients', value: 'Selfgenerated' } ]}>
+
+<TabItem value="Selfgenerated">
+
+```xml
+<dependency>
+    <groupId>com.sap.cloud.sdk.datamodel</groupId>
+    <artifactId>odata-core</artifactId>
+</dependency>
+<dependency>
+    <groupId>org.projectlombok</groupId>
+    <artifactId>lombok</artifactId>
+    <scope>provided</scope>
+</dependency>
+<dependency>
+    <groupId>javax.inject</groupId>
+    <artifactId>javax.inject</artifactId>
+    <scope>provided</scope>
+</dependency>
+```
+
+</TabItem>
+
+<TabItem value="PregeneratedCloud">
+
+```xml
+<dependency>
+    <groupId>com.sap.cloud.sdk.s4hana</groupId>
+    <artifactId>s4hana-api-odata</artifactId>
+</dependency>
+```
+
+</TabItem>
+
+<TabItem value="PregeneratedOnPremise">
+
+```xml
+<dependency>
+    <groupId>com.sap.cloud.sdk.s4hana</groupId>
+    <artifactId>s4hana-api-odata-onpremise</artifactId>
+</dependency>
+```
+
+</TabItem>
+</Tabs>
+
+:::tip Tip
+
+If you would like to consume a specific service, try searching for it on the [SAP API Business Hub](https://api.sap.com/).
+You will find detailed instructions on how to use the SAP Cloud SDK to interact with the services of your choice.
+
+:::
+
 ## Build and Execute OData Requests With the Typed OData Client
 
 The typed OData v2 client allows building type-safe OData v2 requests for a given service.

--- a/docs/java/features/odata/type-safe-client-odata-v4.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v4.mdx
@@ -70,7 +70,7 @@ To leverage the type-safe OData v4 client, you need to add following dependencie
 </TabItem>
 </Tabs>
 
-:::tip Tip
+:::tip Discover services on the SAP API Business Hub
 
 If you would like to consume a specific service, try searching for it on the [SAP API Business Hub](https://api.sap.com/).
 You will find detailed instructions on how to use the SAP Cloud SDK to interact with the services of your choice.

--- a/docs/java/features/odata/type-safe-client-odata-v4.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v4.mdx
@@ -20,6 +20,63 @@ import TabItem from '@theme/TabItem';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import NotImplemented from '../../../components/NotImplemented.js';
 
+## Prerequesites
+
+To leverage the type-safe OData v4 client, you need to add following dependencies to the `dependencies` section of your `pom.xml`:
+
+<Tabs groupId="odataClientType" defaultValue="PregeneratedCloud" values={[ { label: 'Pregenerated Clients (Cloud)', value: 'PregeneratedCloud' }, { label: 'Pregenerated Clients (On-Premise)', value: 'PregeneratedOnPremise' }, { label: 'Self Generated Clients', value: 'Selfgenerated' } ]}>
+
+<TabItem value="Selfgenerated">
+
+```xml
+<dependency>
+    <groupId>com.sap.cloud.sdk.datamodel</groupId>
+    <artifactId>odata-v4-core</artifactId>
+</dependency>
+<dependency>
+    <groupId>org.projectlombok</groupId>
+    <artifactId>lombok</artifactId>
+    <scope>provided</scope>
+</dependency>
+<dependency>
+    <groupId>javax.inject</groupId>
+    <artifactId>javax.inject</artifactId>
+    <scope>provided</scope>
+</dependency>
+```
+
+</TabItem>
+
+<TabItem value="PregeneratedCloud">
+
+```xml
+<dependency>
+    <groupId>com.sap.cloud.sdk.s4hana</groupId>
+    <artifactId>s4hana-api-odata-v4</artifactId>
+</dependency>
+```
+
+</TabItem>
+
+<TabItem value="PregeneratedOnPremise">
+
+```xml
+<dependency>
+    <groupId>com.sap.cloud.sdk.s4hana</groupId>
+    <artifactId>s4hana-api-odata-v4-onpremise</artifactId>
+</dependency>
+```
+
+</TabItem>
+</Tabs>
+
+:::tip Tip
+
+If you would like to consume a specific service, try searching for it on the [SAP API Business Hub](https://api.sap.com/).
+You will find detailed instructions on how to use the SAP Cloud SDK to interact with the services of your choice.
+
+:::
+
 ## Build and Execute OData Requests With the Typed OData Client
 
 The typed OData v4 client allows building type-safe OData v4 requests for a given service.

--- a/docs/java/features/odata/type-safe-client-odata-v4.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v4.mdx
@@ -72,8 +72,9 @@ To leverage the type-safe OData v4 client, you need to add following dependencie
 
 :::tip Discover services on the SAP API Business Hub
 
-If you would like to consume a specific service, try searching for it on the [SAP API Business Hub](https://api.sap.com/).
-You will find detailed instructions on how to use the SAP Cloud SDK to interact with the services of your choice.
+If you would like to consume a specific service, try searching for it on the [SAP API Business Hub](https://api.sap.com/) and visit an **SAP Cloud SDK** tab on the landing page of that service.
+There you will find detailed instructions on how to use the SAP Cloud SDK to get a client library for that specific service.
+Learn more about the integration with the SAP API Business Hub in the [blog](https://blogs.sap.com/2021/09/17/the-sap-cloud-sdk-integrates-with-the-sap-api-business-hub/).
 
 :::
 

--- a/docs/java/features/odata/type-safe-client-odata-v4.mdx
+++ b/docs/java/features/odata/type-safe-client-odata-v4.mdx
@@ -20,7 +20,7 @@ import TabItem from '@theme/TabItem';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import NotImplemented from '../../../components/NotImplemented.js';
 
-## Prerequesites
+## Prerequisites
 
 To leverage the type-safe OData v4 client, you need to add following dependencies to the `dependencies` section of your `pom.xml`:
 


### PR DESCRIPTION
## What Has Changed?

Add a short section with required dependencies for both the OData v2 and v4 typed clients.

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [x] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
