### PR TITLE
[Java] Configuration of Service Binding Root Location

### DIFF
--- a/docs/java/features/service-bindings/service-binding-loader.mdx
+++ b/docs/java/features/service-bindings/service-binding-loader.mdx
@@ -91,8 +91,8 @@ This can be customized by providing a `ServiceBindingLoader` with the method `se
 
 ### Configuration & Customization
 
-The service binding loading has been built with both configurability and customizability in mind.
-Therefore, you can easily tweak the default behavior of the SAP Cloud SDK to fit your needs.
+The service binding loading has been built with both easy configuration and customization in mind.
+Therefore, you can tweak the default behavior of the SAP Cloud SDK to fit your needs.
 
 #### Service Binding Root Location
 
@@ -118,15 +118,15 @@ It assumes a file system structure like shown below:
                   <service-name#n>/
 ```
 
-There is a root location (`/etc/secrets/sapcp` by default), which contains an abitrary amount of sub directories, which each represents a specific service type (e.g. `XSUAA` or `Destination`).
-Within each of these service specific directories, there are - again - an abitrary amount of nested folders, each containing one concrete binding for the service type.
-While the general directory structure is what we recommend when [mounting service bindings to the file system](../../environments/sap-btp-kubernetes-environment-with-sap-gardener#bind-sap-btp-services-to-the-application), the root location itself is really just a convention.
-Therefore, the SAP Cloud SDK allows for easy configuration: Simply use `ScpCfCloudPlatform#setServiceBindingRootLocation(Path)` to overwrite the default value.
+There is a root location (`/etc/secrets/sapcp` by default), which contains an arbitrary amount of sub directories, which each represents a specific service type (e.g. `XSUAA` or `Destination`).
+Within each of these service specific directories, there are - again - an arbitrary amount of nested folders, each containing one concrete binding for the service type.
+While the general directory structure is what we recommend when [mounting service bindings to the file system](../../environments/sap-btp-kubernetes-environment-with-sap-gardener#bind-sap-btp-services-to-the-application), the root location itself is more like a convention.
+Therefore, the SAP Cloud SDK allows for easy configuration: Use `ScpCfCloudPlatform#setServiceBindingRootLocation(Path)` to overwrite the default value.
 
 :::caution Caution
 
 Overwriting the default root path for service bindings will only take effect when done **before** accessing any of the service bindings.
-This is, because the SAP Cloud SDK caches the service bindings indetinetly by default.
-So if you would like to change the service binding root path, we recommend doing it **during application startup**.
+This is, because the SAP Cloud SDK caches the service bindings indefinitely by default.
+If you would like to change the service binding root path, we recommend doing it **during application startup**.
 
 :::

--- a/docs/java/features/service-bindings/service-binding-loader.mdx
+++ b/docs/java/features/service-bindings/service-binding-loader.mdx
@@ -16,7 +16,7 @@ keywords:
   - loader
 ---
 
-### Load Service Binding Information
+## Load Service Binding Information
 
 SAP Cloud SDK provides functionality to load service binding information when running the application in any Cloud Foundry and Kubernetes (in particular Gardener) environment.
 Below you can find an architectural overview of the relevant classes.
@@ -30,13 +30,13 @@ Please note that the API is currently in an experimental state.
 
 Let's look at the classes and their use cases individually.
 
-#### ServiceBindingLoader
+### ServiceBindingLoader
 
 This interface offers only one method to load the existing service bindings for the current application.
 The abstract method named `load()` will have different functionality based on the subclass.
 The following four classes implement this interface.
 
-#### FileSystemServiceBindingLoader
+### FileSystemServiceBindingLoader
 
 ![FileSystemServiceBindingLoader](/img/FSSBL.png 'FileSystemServiceBindingLoader')
 
@@ -46,7 +46,7 @@ It has a _Functional Interface_ (`ParsingStrategy`), exposing the `Map<String, J
 `FileSystemServiceBindingLoader` takes the root location path and a `ParsingStrategy`.
 The SAP Cloud SDK offers several implementations for the `ParsingStrategy` as shown in the figure.
 
-#### EnvironmentVariableServiceBindingLoader
+### EnvironmentVariableServiceBindingLoader
 
 ![EnvironmentVariableServiceBindingLoader](/img/EVSBL.png 'EnvironmentVariableServiceBindingLoader')
 
@@ -56,7 +56,7 @@ It has a _Functional Interface_ (`ParsingStrategy`), exposing the `Map<String, J
 `EnvironmentVariableServiceBindingLoader` takes an environment variable reader and a `ParsingStrategy`.
 The SAP Cloud SDK offers an implementation for the `ParsingStrategy` as shown in the figure.
 
-#### ServiceBindingMerger
+### ServiceBindingMerger
 
 ![ServiceBindingMerger](/img/SBM.png 'ServiceBindingMerger')
 
@@ -67,7 +67,7 @@ It has a _Functional Interface_ (`MergingStrategy`), exposing the `Map<String, J
 With that, it is able to combine multiple service bindings for the same service from different sources.
 SAP Cloud SDK offers an implementation for the `MergingStrategy` as shown in the figure.
 
-#### SimpleCachingServiceBindingLoaderWrapper
+### SimpleCachingServiceBindingLoaderWrapper
 
 ![SimpleCachingServiceBindingLoaderWrapper](/img/SCSBLW.png 'SimpleCachingServiceBindingLoaderWrapper')
 
@@ -75,7 +75,7 @@ This class is used for wrapping another instance and caching the result for a ce
 Once the cache duration has been exceeded, the wrapped `ServiceBindingLoader` is evaluated again.
 The cache can also be reset in a manual fashion.
 
-#### Usage
+## Usage
 
 The SAP Cloud SDK features can be used in a Kubernetes environment without additional configuration (specifically `ScpCfCloudPlatform`).
 You can load the service binding information by calling the `Map<String, JsonArray> getVcapServices()` method.
@@ -89,12 +89,12 @@ By default, the service bindings are loaded in the following order:
 
 This can be customized by providing a `ServiceBindingLoader` with the method `setServiceBindingLoader(ServiceBindingLoader serviceBindingLoader)`.
 
-### Configuration & Customization
+## Configuration & Customization
 
 The service binding loading has been built with both easy configuration and customization in mind.
 Therefore, you can tweak the default behavior of the SAP Cloud SDK to fit your needs.
 
-#### Service Binding Root Location
+### Service Binding Root Location
 
 By default, the `DefaultFileSystemStructureParsingStrategy` is used under the hood to read and parse file system based service bindings.
 It assumes a file system structure like shown below:
@@ -121,7 +121,12 @@ It assumes a file system structure like shown below:
 There is a root location (`/etc/secrets/sapcp` by default), which contains an arbitrary amount of sub directories, which each represents a specific service type (e.g. `XSUAA` or `Destination`).
 Within each of these service specific directories, there are - again - an arbitrary amount of nested folders, each containing one concrete binding for the service type.
 While the general directory structure is what we recommend when [mounting service bindings to the file system](../../environments/sap-btp-kubernetes-environment-with-sap-gardener#bind-sap-btp-services-to-the-application), the root location itself is more like a convention.
-Therefore, the SAP Cloud SDK allows for easy configuration: Use `ScpCfCloudPlatform#setServiceBindingRootLocation(Path)` to overwrite the default value.
+Therefore, the SAP Cloud SDK allows for easy configuration: 
+
+```java
+Path myLocation = Paths.get("my", "custom", "location");
+ScpCfCloudPlatform.getInstanceOrThrow().setServiceBindingRootLocation(myLocation);
+``` 
 
 :::caution Caution
 

--- a/docs/java/features/service-bindings/service-binding-loader.mdx
+++ b/docs/java/features/service-bindings/service-binding-loader.mdx
@@ -88,3 +88,45 @@ By default, the service bindings are loaded in the following order:
 - VCAP_SERVICES environment variable
 
 This can be customized by providing a `ServiceBindingLoader` with the method `setServiceBindingLoader(ServiceBindingLoader serviceBindingLoader)`.
+
+### Configuration & Customization
+
+The service binding loading has been built with both configurability and customizability in mind.
+Therefore, you can easily tweak the default behavior of the SAP Cloud SDK to fit your needs.
+
+#### Service Binding Root Location
+
+By default, the `DefaultFileSystemStructureParsingStrategy` is used under the hood to read and parse file system based service bindings.
+It assumes a file system structure like shown below:
+
+```
+/etc/secrets/sapcp/
+                  <service-name#1>/
+                  |               <binding-name#1>/
+                  |               |               - <binding-property#1>
+                  |               |               - <binding-property#2>
+                  |               |               - ...
+                  |               |               - <binding-property#n>
+                  |               <binding-name#2>/
+                  |               |               - ...
+                 ...             ...
+                  |
+                  <service-name#2>/ 
+                  |
+                 ...
+                  |
+                  <service-name#n>/
+```
+
+There is a root location (`/etc/secrets/sapcp` by default), which contains an abitrary amount of sub directories, which each represents a specific service type (e.g. `XSUAA` or `Destination`).
+Within each of these service specific directories, there are - again - an abitrary amount of nested folders, each containing one concrete binding for the service type.
+While the general directory structure is what we recommend when [mounting service bindings to the file system](../../environments/sap-btp-kubernetes-environment-with-sap-gardener#bind-sap-btp-services-to-the-application), the root location itself is really just a convention.
+Therefore, the SAP Cloud SDK allows for easy configuration: Simply use `ScpCfCloudPlatform#setServiceBindingRootLocation(Path)` to overwrite the default value.
+
+:::caution Caution
+
+Overwriting the default root path for service bindings will only take effect when done **before** accessing any of the service bindings.
+This is, because the SAP Cloud SDK caches the service bindings indetinetly by default.
+So if you would like to change the service binding root path, we recommend doing it **during application startup**.
+
+:::


### PR DESCRIPTION
## What Has Changed?

This PR introduces a new section on our feature description of the "Service Binding Loader", which explains how consumers can easily tweak and adjust this feature.
Right now, the only entry focuses on the configuration of the root location from which the service bindings should be read.

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [x] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
