### PR TITLE
fir: remove reference to executeHttpRequestOrigin

### DIFF
--- a/docs/js/features/connectivity/destination.mdx
+++ b/docs/js/features/connectivity/destination.mdx
@@ -105,7 +105,7 @@ The SAP Cloud SDK searches for the destination by its name in the following loca
 The search stops, once a destination is found.
 Therefore, if a destination with the same name exists in multiple locations, the destination that occurs earliest during the search takes precedence before other destinations with the same name.
 
-:::
+:::note
 The second option `register a destination` was introduced in version 2.0 of the SAP Cloud SDK.
 :::
 
@@ -398,7 +398,7 @@ This does not apply to query **parameter names**`.
 With the `registerDestination` function it is possible to put destinations into the environment variables.
 You can then use these destinations in the same way as those retrieved from the SAP BTP.
 
-Below is an example using the `executeHttpRequestOrigin` function together with a registered destination.
+Below is an example using the `executeHttpRequest` function together with a registered destination.
 
 <Tabs groupId="version" defaultValue="major" values={[
 { label: 'SDK 2.x', value: 'major'}]}>
@@ -410,7 +410,7 @@ import { registerDestination } from '@sap-cloud-sdk/connectivity';
 
 registerDestination({ name: 'MY-DEST', url: 'https://example.com' });
 
-const response = await executeHttpRequestOrigin(
+const response = await executeHttpRequest(
   { destinationName: 'MY-DEST' },
   {
     method: 'get'


### PR DESCRIPTION
## What Has Changed?

Explain what you have changed.

Updated the docs. to remove reference to method executeHttpRequestOrigin 

## Manual Checks?

- [ ] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [ ] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [ ] You formatted all changed files with prettier (`npm run prettier`)
- [ ] You tested if the documentation still builds (`npm run build`)
- [ ] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [ ] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
