### PR TITLE
Fix typo in Java release policy

### DIFF
--- a/docs/java/release-policy.mdx
+++ b/docs/java/release-policy.mdx
@@ -121,7 +121,7 @@ We recommend upgrading to the latest major version immediately or at least not l
 This guarantees:
 
 - easy upgrade path
-- comparability to latest features of SAP Business Technology Platform at all times
+- compatibility to latest features of SAP Business Technology Platform at all times
 - protection of your development process from disruptions in the future.
   Upgrading gets more complex if you have to migrate between more than one major version.
 


### PR DESCRIPTION
I assume this should read "compatibility".