### PR TITLE
docs(js): add path templating doc to generate-openapi-client.mdx

### DIFF
--- a/docs/js/features/openapi/generate-openapi-client.mdx
+++ b/docs/js/features/openapi/generate-openapi-client.mdx
@@ -162,6 +162,26 @@ Example:
 | `myFunction`            | `myFunction`             |
 | `other_function`        | `otherFunction`          |
 
+#### Path Templating
+Path templating can be used as:
+
+```yaml
+paths:
+  /entities/{pathParam}:
+    parameters:
+      - in: path
+        name: pathParam
+        required: true
+        type: string
+```
+
+The following path patterns are also syntactically valid: `/path/{param1}:{param2}`, `/path/foo{param1}text{param2}bar`, `/path/{param1}{param2}`, `/path/{{{param}}` (the innermost curly brackets will be matched).
+It is not recommended to have reserved characters included in the rest of the path, e.g., `/path/value?{param}`, since this will cause a misinterpretation of the path parameter.
+It is not allowed to have the slash ("/"), question mark ("?"), and number sign ("#") characters in the placeholder or the value of a path parameter. (RFC3986)
+Therefore, path pattern `/path/{pa/ram}` will be interpreted as having no placeholder. 
+
+The generator checks for mismatches between path parameters and placeholders. If a path parameter cannot be matched with any placeholder (or vice versa), an error will be thrown.
+
 ### Configure Generated Client Structure and Naming
 
 In case you need more flexibility when generating clients, you can use the SAP Cloud SDK's vendor extensions for OpenAPI.

--- a/docs/js/features/openapi/generate-openapi-client.mdx
+++ b/docs/js/features/openapi/generate-openapi-client.mdx
@@ -177,10 +177,11 @@ paths:
 
 The following path patterns are also syntactically valid: `/path/{param1}:{param2}`, `/path/foo{param1}text{param2}bar`, `/path/{param1}{param2}`, `/path/{{{param}}` (the innermost curly brackets will be matched).
 It is not recommended to have reserved characters included in the rest of the path, e.g., `/path/value?{param}`, since this will cause a misinterpretation of the path parameter.
-It is not allowed to have the slash ("/"), question mark ("?"), and number sign ("#") characters in the placeholder or the value of a path parameter. (RFC3986)
+It is not allowed to have the slash ("/"), question mark ("?"), and number sign ("#") characters in the placeholder or the value of a path parameter (RFC3986).
 Therefore, path pattern `/path/{pa/ram}` will be interpreted as having no placeholder. 
 
-The generator checks for mismatches between path parameters and placeholders. If a path parameter cannot be matched with any placeholder (or vice versa), an error will be thrown.
+The generator checks for mismatches between path parameters and placeholders. 
+If a path parameter cannot be matched with any placeholder (or vice versa), an error will be thrown.
 
 ### Configure Generated Client Structure and Naming
 


### PR DESCRIPTION
## What Has Changed?

Ref: SAP/cloud-sdk-js#2358
Closes: SAP/cloud-sdk-backlog#52

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [x] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
