### PR TITLE
Revert "fix: DocSearch (#773)"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,3 @@ yarn-error.log*
 
 *.iml
 .idea/
-.env

--- a/docs/js/features/odata/generate-odata-client.mdx
+++ b/docs/js/features/odata/generate-odata-client.mdx
@@ -57,8 +57,8 @@ This file is used for generation and contains a mapping from the original file n
 
 - `directoryName` - the name of the subdirectory the client code will be generated into.
 - `servicePath` - the URL path to be prepended before every request.
-  By default, this is read from the EDMX file, if available.
-  Otherwise, the value will be set as `VALUE_IS_UNDEFINED`, and an error will be logged.
+  By default, this is read from the EDMX file, if available. 
+  Otherwise, the value will be set as `VALUE_IS_UNDEFINED`, and an error will be logged. 
   In this case, you can specify `servicePath` in the `serviceMapping.json` manually and re-generate again.
 - `npmPackageName` - the name of the npm package, if a `package.json` is generated.
   This information is optional.

--- a/docs/js/release-notes.mdx
+++ b/docs/js/release-notes.mdx
@@ -52,13 +52,12 @@ To easily search for services and get typed client library for them, use our [AP
 
 ### Fixed Issues
 -->
-
 ## 2.2.0 [Core Modules] - Apr 6, 2022
 
 ### Compatibility Notes
 
 - [eslint-config] Replace `valid-jsdoc` with `eslint-plugin-jsdoc` plugin for checking JSDoc comments, since the `valid-jsdoc` rule is deprecated in ESLint.
-  To stop your project from using a specific rule, turn it off by setting the rule ID to `off` under the `rules` key inside your configuration file.
+To stop your project from using a specific rule, turn it off by setting the rule ID to `off` under the `rules` key inside your configuration file.
 - [generator] Stop exporting service classes (e.g., `BusinessPartnerService`) from generated clients, use `businessPartnerService()` instead.
 - [generator] Stop exporting API classes (e.g., `BusinessPartnerAPI`) from generated clients, use `businessPartnerService().businessPartnerApi` instead.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -33,9 +33,9 @@ module.exports = {
       darkTheme: require('prism-react-renderer/themes/dracula')
     },
     algolia: {
-      apiKey: '441c57554e5a0ca9338cc9f047fb10c8',
+      apiKey: '84d46c71e9f2445436400effad7c4e1b',
       indexName: 'sap_cloud-sdk',
-      appId: 'E4A268JVO0',
+      // appId: 'app-id', // Optional, if you run the DocSearch crawler on your own
       algoliaOptions: {} // Optional, if provided by Algolia
     },
     // ***************************************************************


### PR DESCRIPTION
This reverts commit da0d5c38c9233ef240e4afc456539277d298e05b.

## What Has Changed?

Explain what you have changed.

## Manual Checks?

- [ ] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [ ] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [ ] You formatted all changed files with prettier (`npm run prettier`)
- [ ] You tested if the documentation still builds (`npm run build`)
- [ ] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [ ] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
