### PR TITLE
docs(js): add `dataAccessor` for function / action import

### DIFF
--- a/docs/js/features/odata/common/function-imports/request-builder.mdx
+++ b/docs/js/features/odata/common/function-imports/request-builder.mdx
@@ -22,7 +22,7 @@ The default transformer expects the following response format:
 }
 ```
 
-But the actual response has an additional layer `Foo` in between
+Assume the actual response has an additional layer `Foo`:
 
 ```json
 {

--- a/docs/js/features/odata/common/function-imports/request-builder.mdx
+++ b/docs/js/features/odata/common/function-imports/request-builder.mdx
@@ -12,7 +12,7 @@ The service operation is defined in the service metadata.
 
 If the response structure does not match the transformation type, the promise from `execute(destination)` will be resolved into `undefined`.
 
-For example, the expected response for the transformer is
+The default transformer expects the following response format:
 
 ```json
 {

--- a/docs/js/features/odata/common/function-imports/request-builder.mdx
+++ b/docs/js/features/odata/common/function-imports/request-builder.mdx
@@ -9,3 +9,36 @@ postGoodsIssue({ outboundDeliveryOrder: 'order' }).execute(destination);
 ```
 
 The service operation is defined in the service metadata.
+
+If the response structure does not match the transformation type, the promise from `execute(destination)` will be resolved into `undefined`.
+
+For example, the expected response for the transformer is
+
+```json
+{
+  "d": {
+    "Count": 0
+  }
+}
+```
+
+But the actual response has an additional layer `Foo` in between
+
+```json
+{
+  "d": {
+    "Foo": {
+      "Count": 0
+    }
+  }
+}
+```
+
+In this case, `dataAccessor` can be used in the following way to modify the response into the desired form for further deserialization.
+
+```ts
+functionImportRequestBuilder.execute(
+    destination,
+    data => data.d.Foo
+);
+```


### PR DESCRIPTION
## What Has Changed?
Ref: SAP/cloud-sdk-js#2395
Closes: SAP/cloud-sdk-backlog#73

Add the documentation for `dataAccessor` used in function / action import.

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [x] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
