### PR TITLE
chore: align tutorials

### DIFF
--- a/docs/js/tutorials/address-manager/change-addresses.mdx
+++ b/docs/js/tutorials/address-manager/change-addresses.mdx
@@ -201,9 +201,9 @@ The result of this and the [previous tutorial](./read-addresses.mdx) is an API t
 
 You can find the complete code below:
 
-<Tabs groupId="code-files" defaultValue="business-partner.service" values={[{ label: 'business-partner.service.ts', value: 'business-partner.service' }, { label: 'business-partner.controller.ts', value: 'business-partner.controller' }]}>
+<Tabs groupId="code-files" defaultValue="business-partner.service.ts" values={[{ label: 'business-partner.service.ts', value: 'business-partner.service.ts' }, { label: 'business-partner.controller.ts', value: 'business-partner.controller.ts' }]}>
 
-<TabItem value="business-partner.service" className="code-block-height-js thin-scrollbar">
+<TabItem value="business-partner.service.ts" className="code-block-height-js thin-scrollbar">
 
 ```ts
 import { Injectable } from '@nestjs/common';
@@ -327,7 +327,7 @@ export class BusinessPartnerService {
 ```
 
 </TabItem>
-<TabItem value="business-partner.controller" className="code-block-height-js thin-scrollbar">
+<TabItem value="business-partner.controller.ts" className="code-block-height-js thin-scrollbar">
 
 ```ts
 import {

--- a/docs/js/tutorials/address-manager/change-addresses.mdx
+++ b/docs/js/tutorials/address-manager/change-addresses.mdx
@@ -14,6 +14,9 @@ keywords:
   - address manager
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## Overview
 
 In the [first part](./read-addresses.mdx) of the tutorial, you implemented the read operation on business partners and the related address information.
@@ -189,7 +192,7 @@ Then execute `DELETE http://localhost:8080/business-partners/1003764/address/282
 This should return 204 if existing IDs are passed.
 To verify you can execute `GET http://localhost:8080/business-partners/1003764` afterwards and the selected address should be removed.
 
-## Summary
+## Final Code Review
 
 In this tutorial, you learned how to create, update and delete addresses using the SAP Cloud SDK.
 First an implementation is added in the service class.
@@ -198,8 +201,9 @@ The result of this and the [previous tutorial](./read-addresses.mdx) is an API t
 
 You can find the complete code below:
 
-<details><summary>business-partner.service.ts</summary>
-<p>
+<Tabs groupId="code-files" defaultValue="business-partner.service" values={[{ label: 'business-partner.service.ts', value: 'business-partner.service' }, { label: 'business-partner.controller.ts', value: 'business-partner.controller' }]}>
+
+<TabItem value="business-partner.service" className="code-block-height-js thin-scrollbar">
 
 ```ts
 import { Injectable } from '@nestjs/common';
@@ -322,11 +326,8 @@ export class BusinessPartnerService {
 }
 ```
 
-</p>
-</details>
-
-<details><summary>business-partner.controller.ts</summary>
-<p>
+</TabItem>
+<TabItem value="business-partner.controller" className="code-block-height-js thin-scrollbar">
 
 ```ts
 import {
@@ -397,5 +398,5 @@ export class BusinessPartnerController {
 }
 ```
 
-</p>
-</details>
+</TabItem>
+</Tabs>

--- a/docs/js/tutorials/address-manager/read-addresses.mdx
+++ b/docs/js/tutorials/address-manager/read-addresses.mdx
@@ -14,6 +14,9 @@ keywords:
   - address manager
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## Overview
 
 In the SAP S/4HANA data model, addresses are related to the business partner entity.
@@ -270,7 +273,7 @@ If you call the URL `http://localhost:8080/business-partners/<yourId>`, the serv
 }
 ```
 
-## Summary
+## Final Code Review
 
 In this tutorial you have created an API to read business partners.
 You created endpoints to read a list of business partners as well as a specific business partner by ID.
@@ -279,8 +282,9 @@ In the [next part](./change-addresses.mdx) you will extend the API to change dat
 
 You can find the complete code below:
 
-<details><summary>business-partner.service.ts</summary>
-<p>
+<Tabs groupId="code-files" defaultValue="business-partner.service" values={[{ label: 'business-partner.service.ts', value: 'business-partner.service'}, { label: 'business-partner.controller.ts', value: 'business-partner.controller'}]}>
+
+<TabItem value="business-partner.service" className="code-block-height-js thin-scrollbar">
 
 ```ts
 import { Injectable } from '@nestjs/common';
@@ -348,11 +352,9 @@ export class BusinessPartnerService {
 }
 ```
 
-</p>
-</details>
+</TabItem>
 
-<details><summary>business-partner.controller.ts</summary>
-<p>
+<TabItem value="business-partner.controller" className="code-block-height-js thin-scrollbar">
 
 ```ts
 import {
@@ -423,5 +425,5 @@ export class BusinessPartnerController {
 }
 ```
 
-</p>
-</details>
+</TabItem>
+</Tabs>

--- a/docs/js/tutorials/address-manager/read-addresses.mdx
+++ b/docs/js/tutorials/address-manager/read-addresses.mdx
@@ -282,9 +282,9 @@ In the [next part](./change-addresses.mdx) you will extend the API to change dat
 
 You can find the complete code below:
 
-<Tabs groupId="code-files" defaultValue="business-partner.service" values={[{ label: 'business-partner.service.ts', value: 'business-partner.service'}, { label: 'business-partner.controller.ts', value: 'business-partner.controller'}]}>
+<Tabs groupId="code-files" defaultValue="business-partner.service.ts" values={[{ label: 'business-partner.service.ts', value: 'business-partner.service.ts'}, { label: 'business-partner.controller.ts', value: 'business-partner.controller.ts'}]}>
 
-<TabItem value="business-partner.service" className="code-block-height-js thin-scrollbar">
+<TabItem value="business-partner.service.ts" className="code-block-height-js thin-scrollbar">
 
 ```ts
 import { Injectable } from '@nestjs/common';
@@ -354,7 +354,7 @@ export class BusinessPartnerService {
 
 </TabItem>
 
-<TabItem value="business-partner.controller" className="code-block-height-js thin-scrollbar">
+<TabItem value="business-partner.controller.ts" className="code-block-height-js thin-scrollbar">
 
 ```ts
 import {

--- a/docs/js/tutorials/getting-started/1-set-up-dev-environment.mdx
+++ b/docs/js/tutorials/getting-started/1-set-up-dev-environment.mdx
@@ -16,6 +16,8 @@ keywords:
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+## Overview
+
 You will start with installing the tools necessary to getting started.
 Once your development enviroment is setup, you can begin with scaffolding an initial application with the NestJS CLI.
 Throughout this tutorial, you'll modify and extend this starter application to use the SAP Cloud SDK for JavaScript.
@@ -126,6 +128,8 @@ await app.listen(process.env.PORT || 8080);
 ```
 
 ## Final Code Review
+
+In this tutorial, you installed the CLI tools necessary for creating and deploying your application, and scaffolded an initial NestJS application.
 
 Here are the code files discussed on this page:
 

--- a/docs/js/tutorials/getting-started/2-execute-odata-request.mdx
+++ b/docs/js/tutorials/getting-started/2-execute-odata-request.mdx
@@ -16,6 +16,8 @@ keywords:
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+## Overview
+
 In this part of the tutorial, you will do the following:
 
 - Extend your starter NestJS application by adding a custom route.
@@ -296,6 +298,10 @@ async getAllBusinessPartners(): Promise<BusinessPartner[]> {
 ```
 
 ## Final Code Review
+
+In this tutorial, you added a new custom route to your application.
+Using the SAP Cloud SDK, you executed an OData request to fetch a list of business partners.
+You configured the destinations environment variable using a `.env` file.
 
 Here are the code files discussed on this page, if you are using the mock server:
 

--- a/docs/js/tutorials/getting-started/3-deploy-app-to-cf.mdx
+++ b/docs/js/tutorials/getting-started/3-deploy-app-to-cf.mdx
@@ -17,6 +17,8 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+## Overview
+
 In this part of the tutorial, you will do the following:
 
 - Deploy your application to Cloud Foundry in SAP Business Technology Platform
@@ -227,6 +229,10 @@ Now you can recompile and redeploy the application.
 When you now call the `/business-partners` route of your app, the Business Partners will be retrieved from the defined destination.
 
 ## Final Code Review
+
+In this tutorial, you deployed your application to Cloud Foundry.
+You configured a new destination in the Cloud Cockpit.
+You created instances of destination and XSUAA services to consume the configured destination.
 
 Here are the code files discussed on this page:
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -92,3 +92,8 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
     display: block;
   }
 }
+
+.code-block-height-js {
+  max-height: 30em;
+  overflow-y: scroll;
+}

--- a/styles/Vocab/SAP/accept.txt
+++ b/styles/Vocab/SAP/accept.txt
@@ -84,3 +84,4 @@ uncheck
 [tT]ruststore
 [Aa]pprouter
 [Kk]ubeconfig
+[Ss]caffolded


### PR DESCRIPTION
## What Has Changed?

- Aligned the sections between both tutorials
- Added css class for max-height+scroll for code files tabs

PS: A better way to handle styling would be to add below in `custom.css` instead

```
[class*='codeBlock'] {
  max-height: 30em
}
```
But this also affects java code snippets.


## Manual Checks?

- [ ] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [ ] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [ ] You formatted all changed files with prettier (`npm run prettier`)
- [ ] You tested if the documentation still builds (`npm run build`)
- [ ] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [ ] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
