### PR TITLE
[js] Pluralize headings release Note

### DIFF
--- a/docs/js/release-notes.mdx
+++ b/docs/js/release-notes.mdx
@@ -70,7 +70,7 @@ To easily search for services and get typed client library for them, use our [AP
 
 # 2.4.0 [Core Modules] - May 20, 2022
 
-## Compatibility Note
+## Compatibility Notes
 
 - [connectivity] Mark the function `noDestinationErrorMessage` as internal API.
 - [odata-v4] Mark the function `uriConverter` as internal API.
@@ -86,11 +86,11 @@ To easily search for services and get typed client library for them, use our [AP
 
 - [connectivity] Support self-signed certificate using the `trustStore` property of the destination object.
 
-## Improvement
+## Improvements
 
 - [connectivity, http-client] Reduce default log output on the `info` level significantly.
 
-## Fixed Issue
+## Fixed Issues
 
 - [util] Fix a bug in the implementation of the trim method.
 


### PR DESCRIPTION
Just added a `s` for some heading in the release notes.