### PR TITLE
[Java V4] Remove `RequestScopedHttpClientCache`

### DIFF
--- a/docs/java/features/connectivity/destinations.mdx
+++ b/docs/java/features/connectivity/destinations.mdx
@@ -100,30 +100,6 @@ DestinationAccessor.getLoader().tryGetDestination(destinationName, options);
 
 See the section on [destination options](#building-destination-options) below.
 
-### Using the SAMLAssertion Authentication Type
-
-Using the [`SAMLAssertion`](https://help.sap.com/viewer/cca91383641e40ffbe03bdc78f00f681/Cloud/en-US/d81e1683bd434823abf3ceefc4ff157f.html) authentication types requires a different caching strategy for `HttpClient`s.
-This is because upon authentication at the target system, a session cookie is returned, which is stored within the used `HttpClient` instance.
-For subsequent calls, the service then expects authenticated clients to include their session cookie.
-
-By default, the SAP Cloud SDK uses the `RequestScopedHttpClientCache` to store `HttpClient` instances for the duration of a specific (incoming) request.
-Using this default strategy results into deleting the `HttpClient` (together with the session cookie) that was used to authorize at the target system, once the initial request has been handled.
-To avoid authorizing over and over again, the SAP Cloud SDK offers the `TimeScopedHttpClientCache`, which keeps existing `HttpClient`s for a certain period of time.
-These instances are then automatically reused for consecutive (incoming) requests, so that the session is retained.
-
-Switching the cache can be done as follows:
-
-```java
-// run this code once in a setup step, afterwards HttpClient instances are kept for 5 minutes
-HttpClientAccessor.setHttpClientCache(new TimeScopedHttpClientCache(5, TimeUnit.MINUTES));
-```
-
-:::note Hint
-
-The cached `HttpClient` instances are also isolated based on the tenant and principal.
-
-:::
-
 ## Supported Proxy Types
 
 | Proxy Type                                                                                                                    | Parameter Name           |

--- a/docs/java/features/multi-tenancy/thread-context.mdx
+++ b/docs/java/features/multi-tenancy/thread-context.mdx
@@ -51,9 +51,8 @@ Additionally, if the `Authorization` header contains a `JWT` from the [`AppRoute
 - Pull the _Tenant_ and _Principal_ information from it
 
 :::tip Integration with CAP
-In case you are using CAP (with the `cds-integration-cloud-sdk` dependency) the Tenant,Principal information and Headers will **instead** be derived from the [CAP Request Context](https://cap.cloud.sap/docs/java/request-contexts).
+In case you are using CAP (with the `cds-integration-cloud-sdk` dependency) the Tenant, Principal, and Headers will **instead** be derived from the [CAP Request Context](https://cap.cloud.sap/docs/java/request-contexts).
 That also means that the `ThreadContext` will not be used when accessing this information.
-Please note that the `RequestScopedHttpClientCache` which is the default being used by the SAP Cloud SDK cannot work with this approach.
 :::
 
 ## Running Asynchronous Operations


### PR DESCRIPTION
## What Has Changed?

This PR removes all mentions of the `RequestScopedHttpClientCache`, which will be removed from the Cloud SDK for Java in version 4.

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [x] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
