### PR TITLE
Update overview.mdx

### DIFF
--- a/docs/java/features/bapi-and-rfc/overview.mdx
+++ b/docs/java/features/bapi-and-rfc/overview.mdx
@@ -653,7 +653,7 @@ set destinations=[{name: "destinationName"}]
 You can set the destinations' environment variable by the following command:
 
 ```
-export destinations=[{name: "destinationName"}]
+export destinations="[{name: \"destinationName\"}]" 
 ```
 
 </TabItem>

--- a/docs/java/features/bapi-and-rfc/overview.mdx
+++ b/docs/java/features/bapi-and-rfc/overview.mdx
@@ -653,7 +653,7 @@ set destinations=[{name: "destinationName"}]
 You can set the destinations' environment variable by the following command:
 
 ```
-export destinations="[{name: \"destinationName\"}]" 
+export destinations="[{name: \"destinationName\"}]"
 ```
 
 </TabItem>


### PR DESCRIPTION
To add mac environment variable as a json esc is required.

## What Has Changed?

Explain what you have changed.
The export command using a json for a non-windows machine, eg. mac,
requires esc characters.

## Manual Checks?

- [X] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
