### PR TITLE
Update overview.mdx

### DIFF
--- a/docs/java/features/bapi-and-rfc/overview.mdx
+++ b/docs/java/features/bapi-and-rfc/overview.mdx
@@ -464,7 +464,7 @@ Some configuration steps differ depending on which Maven archetype (Spring or To
   :::tip
   Before running the command, replace `<sapjco-version>` with the JCo version you downloaded.
   :::
-  `mvn install:install-file -Dfile=sapjco3.jar -DgroupId=com.sap.conn.jco -DartifactId=com.sap.conn.jco.sapjco3 -Dversion=<sapjco-version> -Dpackaging=jar`
+  `mvn install:install-file -Dfile=sapjco3.jar -DgroupId=com.company.sap -DartifactId=com.sap.conn.jco.sapjco3 -Dversion=<sapjco-version> -Dpackaging=jar`
 - Now Maven uses the JCo JAR file when declaring the dependency in your pom file.
 
 #### Add a Dependency To Your `pom.xml`
@@ -477,8 +477,8 @@ Some configuration steps differ depending on which Maven archetype (Spring or To
 
 ```xml
 <dependency>
-    <groupId>com.sap.conn.jco</groupId>
-    <artifactId>com.sap.conn.jco.sapjco3</artifactId>
+    <groupId>com.company.sap</groupId>
+    <artifactId>com.sap.conn.jco.sapjco</artifactId>
     <version>X.Y.Z</version>
 </dependency>
 ```


### PR DESCRIPTION
The settings.xml continues to import the version from the sap mvn repo when trying to use locally.
This way it adds the local jar to a new groupId outside of the com.sap namespace .

## What Has Changed?

Using the directions as is, for local dev mvn continues to try and get the artifact from the sap mvn repo.
using an outside namespace allows us to build locally.

## Manual Checks?

- [X] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)

