### PR TITLE
[JS] manual release note update

### DIFF
--- a/docs-js/release-notes.mdx
+++ b/docs-js/release-notes.mdx
@@ -55,6 +55,35 @@ To easily search for services and get typed client library for them, use our [AP
 <!-- vale off -->
 <!-- This line is used for our release notes automation -->
 
+# 2.6.0 [Core Modules] - July 15, 2022
+
+## Compatibility Notes
+
+- [odata-v4, temporal-de-serializers] Adjust parsing of `Edm.Date`, `Edm.DateTimeOffset`, `Edm.Time`, and `Edm.Duration` to be closer to the OData v4 specification.
+There may be loss of precision if using the default (de-)serializers with high-precision fractional seconds. (de851289)
+- [generator] Deprecate generator option `versionInPackageJson`. If you need to set the version, use the new `include` option to add your own `package.json` file instead. (069aa168)
+- [generator] The hidden generator option `additionalFiles` is renamed to `include`. (069aa168)
+- [connectivity] Rename `transformationFn` into `serviceBindingTransformFn` in `DestinationForServiceBindingsOptions` to avoid ambiguity and make the function async. (8fdfebd6)
+
+## New Functionalities
+
+- [connectivity] Support JWTs without a `JKU` property. (cb598c16)
+- [connectivity] Add interface `DestinationCacheInterface` and method `setDestinationCache` to support implementation of custom destination cache. (09094607)
+- [connectivity] Fetch client credential token for destinations created by service bindings. (93d41281)
+- [generator] New generator option `include` which allows to add files to generated packages. (069aa168)
+
+## Improvements
+
+- [http-client] Make `requestConfig` of `OriginOptions` optional. (e46bb51d)
+
+## Fixed Issues
+
+- [connectivity] Fix `getDestination()` to allow passing an async transform function `serviceBindingTransformFn` in `options`. The transform function can also be passed by `execute()`, `executeHttpRequest()`, `executeRaw()`, etc.
+- [http-client] Fix the `executeHttpRequest`/`executeHttpRequestWithOrigin` function, so the warning is only shown when overwriting headers by using custom headers. (e44c214a)
+- [odata-common, odata-v4, temporal-de-serializers] Fix parsing of `Edm.DateTimeOffset` with high-precision fractional seconds and edge-cases like 5-digit years. (de851289)
+- [odata-common, generator] Allow OData service to contain an entity name 'entity'. (0675ee3b)
+- [odata-v2] Support negative epoch timestamps in serialization. (9ffe0824)
+
 ## 2.1.0 [Client Libraries] - Jul 5, 2022
 
 ### New Functionality


### PR DESCRIPTION
The rautomatic release note update failed: https://github.com/SAP/cloud-sdk-js/runs/7356882863?check_suite_focus=true
Manual copy of the release notes.