### PR TITLE
chore: Fix spelling

### DIFF
--- a/docs-js/tutorials/address-manager/read-addresses.mdx
+++ b/docs-js/tutorials/address-manager/read-addresses.mdx
@@ -202,7 +202,7 @@ Otherwise, an error message is sent.
 Restart your server and open `http://localhost:8080/business-partners` to get the list of all business partners.
 Copy one ID from the result list and execute `http://localhost:8080/business-partners/<yourId>`.
 You should see the details of the chosen business partner.
-Note that Nest applications have a build-in [exception filter](https://docs.nestjs.com/exception-filters), which maps exceptions to HTTP messages shown to the client.
+Note that Nest applications have a built-in [exception filter](https://docs.nestjs.com/exception-filters), which maps exceptions to HTTP messages shown to the client.
 By default, the exceptions from the SAP Cloud SDK are mapped to a server-side error.
 So if you provide a non-existing ID, you will receive a 500 response and not a 404.
 


### PR DESCRIPTION
"Built-in" is correct for what we want to say here, cf [1](https://www.merriam-webster.com/dictionary/built-in), [2](https://www.merriam-webster.com/dictionary/build%20in)

## What Has Changed?

Fixed spelling of "built-in"
