### PR TITLE
fix: api reference links

### DIFF
--- a/src/theme/NavbarItem/DropdownNavbarItem.js
+++ b/src/theme/NavbarItem/DropdownNavbarItem.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { shouldShow } from './helper';
 import DropdownNavbarItem from '@theme-original/NavbarItem/DropdownNavbarItem';
 import sdkVersions from '@site/static/api/versions';
-import useBaseUrl from '@docusaurus/useBaseUrl';
 import { useActiveVersion } from '@docusaurus/plugin-content-docs/client';
 
 /**
@@ -23,7 +22,7 @@ export default function DropdownNavbarItemWrapper(props) {
         .map(version => {
           return {
             label: version,
-            href: useBaseUrl(`api/${version}/`)
+            href: `https://sap.github.io/cloud-sdk/api/${version}/`
           };
         })
     };


### PR DESCRIPTION
## What Has Changed?

For some reason the exact same path doesn't resolve unless you hit refresh (for example, click on an API Reference Link -> Page not found -> simply refresh the page), I assume this has something to do with the router of Docusaurus. Either way, the hotfix for this is simply using an absolute path.

Note that this is not optimal for local testing, as the reference won't be dynamic enough anymore to point at the local reference.

On the plus side though, with the absolute path, a new window is opened when clicking on an API reference, which is better UX I believe.