### PR TITLE
Java/actually v4/mention sjb bom

### DIFF
--- a/docs-java/getting-started.mdx
+++ b/docs-java/getting-started.mdx
@@ -145,7 +145,7 @@ skipUsageAnalytics: false
 To change the Java version modify the `<java.version>` property in the root `pom.xml`.
 :::
 
-### Run App locally
+### Run App Locally
 
 Applications created with our SAP Cloud SDK Archetypes give you the possibility to run locally on your development machine.
 
@@ -172,7 +172,7 @@ cd application/
 mvn tomee:run -Ddeployment=local
 ```
 
-The property `deployment=local` activates a profile that replaces the `sdk-buildpack-bom-tomee` with the `sdk-bom`, the former being a combination of the SAP Java Buildpack BOM and our `sdk-bom`.
+The property `deployment=local` activates a profile that replaces the `sdk-buildpack-bom` with the `sdk-bom`, the former being a combination of the SAP Java Buildpack BOM and our `sdk-bom`.
 That way you replace the scope of the dependencies marked as `provided` from the SAP Java Buildpack with `compile`.
 
 </TabItem>

--- a/docs-java/getting-started.mdx
+++ b/docs-java/getting-started.mdx
@@ -145,6 +145,40 @@ skipUsageAnalytics: false
 To change the Java version modify the `<java.version>` property in the root `pom.xml`.
 :::
 
+### Run App locally
+
+Applications created with our SAP Cloud SDK Archetypes give you the possibility to run locally on your development machine.
+
+<Tabs groupId="frameworks" defaultValue="spring" values={[
+{ label: 'Spring', value: 'spring', },
+{ label: 'TomEE', value: 'tomee', }
+]}>
+
+<TabItem value="spring">
+
+```bash
+mvn clean install
+cd application/
+mvn spring-boot:run
+```
+
+</TabItem>
+
+<TabItem value="tomee">
+
+```bash
+mvn clean install -Ddeployment=local
+cd application/
+mvn tomee:run -Ddeployment=local
+```
+
+The property `deployment=local` activates a profile that replaces the `sdk-buildpack-bom-tomee` with the `sdk-bom`, the former being a combination of the SAP Java Buildpack BOM and our `sdk-bom`.
+That way you replace the scope of the dependencies marked as `provided` from the SAP Java Buildpack with `compile`.
+
+</TabItem>
+
+</Tabs>
+
 ## Integrate the SAP Cloud SDK for Java Into Your Project
 
 ### Adding Dependencies
@@ -233,12 +267,12 @@ The dependencies differ with respect to the type of **SAP S/4HANA** system([**SA
     <artifactId>s4hana-api-odata-v4-onpremise-2020</artifactId>
 </dependency>
 <dependency>
-	<groupId>com.sap.cloud.sdk.s4hana</groupId>
-	<artifactId>s4hana-connectivity</artifactId>
+ <groupId>com.sap.cloud.sdk.s4hana</groupId>
+ <artifactId>s4hana-connectivity</artifactId>
 </dependency>
 <dependency>
-	<groupId>com.sap.cloud.sdk.s4hana</groupId>
-	<artifactId>s4hana-core</artifactId>
+ <groupId>com.sap.cloud.sdk.s4hana</groupId>
+ <artifactId>s4hana-core</artifactId>
 </dependency>
 ```
 
@@ -256,12 +290,12 @@ The dependencies differ with respect to the type of **SAP S/4HANA** system([**SA
     <artifactId>s4hana-api-odata-v4-onpremise</artifactId>
 </dependency>
 <dependency>
-	<groupId>com.sap.cloud.sdk.s4hana</groupId>
-	<artifactId>s4hana-connectivity</artifactId>
+ <groupId>com.sap.cloud.sdk.s4hana</groupId>
+ <artifactId>s4hana-connectivity</artifactId>
 </dependency>
 <dependency>
-	<groupId>com.sap.cloud.sdk.s4hana</groupId>
-	<artifactId>s4hana-core</artifactId>
+ <groupId>com.sap.cloud.sdk.s4hana</groupId>
+ <artifactId>s4hana-core</artifactId>
 </dependency>
 ```
 

--- a/docs-java/guides/dependencies.mdx
+++ b/docs-java/guides/dependencies.mdx
@@ -210,7 +210,7 @@ Depending on the [target runtime](https://help.sap.com/docs/BTP/65de2977205c403b
 
 You can verify the behavior by searching for the scope of, for example, the `com.sap.cloud.security.xsuaa:token-client` dependency in your application.
 
-When you use the BOM of the SAP Java Buildpack, it should have the scope `provided`.
+When you use the BOM of the SAP Java Buildpack the `token-client`  should have the scope `provided`.
 If you are not using the BOM, it should have the scope `compile` or `test`.
 
 :::tip

--- a/docs-java/guides/dependencies.mdx
+++ b/docs-java/guides/dependencies.mdx
@@ -200,6 +200,7 @@ Still, the same strategy is also valid and useful for the community Buildpack.
 ### Avoiding Scope Conflicts
 
 We recommend using the [BOMs provided by the SAP Java Buildpack](https://help.sap.com/docs/BTP/65de2977205c403bbc107264b8eccf4b/6c6936e8e4ea40c9a9a69f6783b1e978.html).
+In our `scp-cf-tomee` Archetype we are using the `sdk-buildpack-bom` which itself depends on the SAP Java Buildpack BOM.
 
 This will set the version and the scope of the dependencies the SAP Java Buildpack adds to your application at runtime.
 The scope of the those dependencies is set to `provided`.

--- a/docs-java/guides/dependencies.mdx
+++ b/docs-java/guides/dependencies.mdx
@@ -30,7 +30,7 @@ For general information on how to deal with dependencies refer to the resources 
 
 ### The SAP Cloud SDK Bill-of-Material
 
-The SAP Cloud SDK provides a [Bill-of-Material](https://dzone.com/articles/the-bill-of-materials-in-maven).
+The SAP Cloud SDK provides a [Bill-of-Material](https://dzone.com/articles/the-bill-of-materials-in-maven) (BOM).
 It comprises all dependencies and their specific version that the SAP Cloud SDK relies upon.
 
 It can be used in the dependency management as follows:
@@ -280,10 +280,11 @@ The above dependencies should only be listed with scope `provided`.
 :::note
 
 Dependencies with the scope `provided` are not part of your `.war` file.
-This means you will need to adapt the scopes if you want to run your applications without the SAP Java Buildpack
+This means you need to adapt the scopes if you want to run your applications without the SAP Java Buildpack
 One common example for this is running your application locally.
 
-In our `scp-cf-tomee` archetype we provide a maven profile activated by the parameter `-Ddeployment=local`, which replaces our `sdk-buildpack-bom-tomee` (a convenience combination of the SAP Java Buildpack and our SAP Cloud SDK BOMs) with our `sdk-bom`.
-This basically removes the SAP Java Buildpack BOM from the `dependencyManagement` and adapts the scopes of your dependencies accordingly.
+In our `scp-cf-tomee` archetype we provide a maven profile activated by the parameter `-Ddeployment=local`.
+This replaces our `sdk-buildpack-bom-tomee` (a convenience combination of the SAP Java Buildpack and our SAP Cloud SDK BOMs) with our `sdk-bom`.
+As a result the SAP Java Buildpack BOM is removed from the `dependencyManagement`, which adapts the scopes of your dependencies for local deployment.
 
 :::

--- a/docs-java/guides/dependencies.mdx
+++ b/docs-java/guides/dependencies.mdx
@@ -17,6 +17,9 @@ keywords:
   - how-to
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ## General Information
 
 The SAP Cloud SDK for Java is a set of libraries that itself depends on other libraries.
@@ -109,7 +112,7 @@ Update the SAP Cloud SDK version frequently.
 ### Overriding Dependency Versions of the SAP Cloud SDK Bill-of-Material
 
 Sometimes you may want to override the version of a specific dependency the SAP Cloud SDK is using.
-You can achieve this by listing it in the dependency management _before the SAP Cloud SDK BOM_.
+You can achieve this by listing it in the dependency management.
 
 For example to override the version of SLF4J:
 
@@ -117,23 +120,23 @@ For example to override the version of SLF4J:
 <dependencyManagement>
     <dependencies>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>your-slf4j-version</version>
-        </dependency>
-        <dependency>
             <groupId>com.sap.cloud.sdk</groupId>
             <artifactId>sdk-bom</artifactId>
             <version>latest-sdk-version</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>your-slf4j-version</version>
+        </dependency>
     </dependencies>
 </dependencyManagement>
 ```
 
 :::note
-Remember that including a dependency in the `<dependencyManagement>` section only enforces its version.
+Remember that including a dependency in the `<dependencyManagement>` section only enforces its version and scope.
 It does not yet include it as a dependency in your project.
 :::
 
@@ -196,42 +199,91 @@ Still, the same strategy is also valid and useful for the community Buildpack.
 
 ### Avoiding Scope Conflicts
 
-We recommend overriding the scope for selected dependencies when using the SAP Java Buildpack.
+We recommend using the BOMs provided by the SAP Java Buildpack.
 
-The respective dependencies are:
+This will set the version and the scope of the dependencies the SAP Java Buildpack adds to your application at runtime.
+The scope of the those dependencies is set to `provided`.
 
-- `com.sap.cloud.security:java-api`
-- `com.sap.cloud.security:java-security`
-- `com.sap.cloud.security.xsuaa:token-client`
+Depending on the target runtime defined in your `manifest.yml` you should import one of the following dependencies in your `<dependencyManagement>` section:
 
-You can override the scope by setting including these dependencies explicitly in your `pom.xml` with scope `provided`.
+<Tabs defaultValue="tomcat" values={[
+{ label: 'Tomcat', value: 'tomcat', },
+{ label: 'TomEE', value: 'tomee', },
+{ label: 'TomEE7', value: 'tomee7', }
+]}>
 
-At the top of your `<dependencyManagement>` section, **_before_** including any SAP Cloud SDK dependencies in your project, insert the following:
+<TabItem value="tomcat">
 
 ```xml
-<dependency>
-    <groupId>com.sap.cloud.security</groupId>
-    <artifactId>java-api</artifactId>
-    <version>latest-version-here</version>
-    <scope>provided</scope>
-</dependency>
-<dependency>
-    <groupId>com.sap.cloud.security</groupId>
-    <artifactId>java-security</artifactId>
-    <version>latest-version-here</version>
-    <scope>provided</scope>
-</dependency>
-<dependency>
-    <groupId>com.sap.cloud.security.xsuaa</groupId>
-    <artifactId>token-client</artifactId>
-    <version>latest-version-here</version>
-    <scope>provided</scope>
-</dependency>
+<dependencyManagement>
+    <dependency>
+        <groupId>com.sap.cloud.sjb.cf</groupId>
+        <artifactId>cf-tomcat-bom</artifactId>
+        <version>your-buildpack-version</version>
+        <type>pom</type>
+        <scope>import</scope>
+    </dependency>
+    ...
+</dependencyManagement>
 ```
+
+</TabItem>
+
+<TabItem value="tomee">
+
+```xml
+<dependencyManagement>
+    <dependency>
+        <groupId>com.sap.cloud.sjb.cf</groupId>
+        <artifactId>cf-tomee-bom</artifactId>
+        <version>your-buildpack-version</version>
+        <type>pom</type>
+        <scope>import</scope>
+    </dependency>
+    ...
+</dependencyManagement>
+```
+
+</TabItem>
+
+<TabItem value="tomee7">
+
+```xml
+<dependencyManagement>
+    <dependency>
+        <groupId>com.sap.cloud.sjb.cf</groupId>
+        <artifactId>cf-tomee7-bom</artifactId>
+        <version>your-buildpack-version</version>
+        <type>pom</type>
+        <scope>import</scope>
+    </dependency>
+    ...
+</dependencyManagement>
+```
+
+</TabItem>
+
+</Tabs>
+
+You can verify this behavior by searching for the scope of, for example, the `com.sap.cloud.security.xsuaa:token-client` dependency in your application.
+
+When you use the BOM of the SAP Java Buildpack, it should have the scope `provided`.
+If you are not using the BOM, it should have the scope `compile` or `test`.
 
 :::tip
 
 Verify your dependency tree via `mvn dependency:tree`.
 The above dependencies should only be listed with scope `provided`.
+
+:::
+
+:::note
+
+Dependencies with the scope `provided` are not part of your `.war` file.
+This means you will need to adapt the scopes if you want to run your applications without the SAP Java Buildpack
+One common example for this is running your application locally.
+
+In our `scp-cf-tomee` archetype we provide a maven profile activated by the parameter `-Ddeployment=local`, which replaces our `sdk-buildpack-bom-tomee` (a convenience combination of the SAP Java Buildpack and our SAP Cloud SDK BOMs) with our `sdk-bom`.
+This basically removes the SAP Java Buildpack BOM from the `dependencyManagement` and adapts the scopes of your dependencies accordingly.
 
 :::

--- a/docs-java/guides/dependencies.mdx
+++ b/docs-java/guides/dependencies.mdx
@@ -199,73 +199,14 @@ Still, the same strategy is also valid and useful for the community Buildpack.
 
 ### Avoiding Scope Conflicts
 
-We recommend using the BOMs provided by the SAP Java Buildpack.
+We recommend using the [BOMs provided by the SAP Java Buildpack](https://help.sap.com/docs/BTP/65de2977205c403bbc107264b8eccf4b/6c6936e8e4ea40c9a9a69f6783b1e978.html).
 
 This will set the version and the scope of the dependencies the SAP Java Buildpack adds to your application at runtime.
 The scope of the those dependencies is set to `provided`.
 
-Depending on the target runtime defined in your `manifest.yml` you should import one of the following dependencies in your `<dependencyManagement>` section:
+Depending on the [target runtime](https://help.sap.com/docs/BTP/65de2977205c403bbc107264b8eccf4b/83d241613dcd41c99ccc308ed0d26399.html) defined in your `manifest.yml` you should import the respective BOM in your `<dependencyManagement>` section.
 
-<Tabs defaultValue="tomcat" values={[
-{ label: 'Tomcat', value: 'tomcat', },
-{ label: 'TomEE', value: 'tomee', },
-{ label: 'TomEE7', value: 'tomee7', }
-]}>
-
-<TabItem value="tomcat">
-
-```xml
-<dependencyManagement>
-    <dependency>
-        <groupId>com.sap.cloud.sjb.cf</groupId>
-        <artifactId>cf-tomcat-bom</artifactId>
-        <version>your-buildpack-version</version>
-        <type>pom</type>
-        <scope>import</scope>
-    </dependency>
-    ...
-</dependencyManagement>
-```
-
-</TabItem>
-
-<TabItem value="tomee">
-
-```xml
-<dependencyManagement>
-    <dependency>
-        <groupId>com.sap.cloud.sjb.cf</groupId>
-        <artifactId>cf-tomee-bom</artifactId>
-        <version>your-buildpack-version</version>
-        <type>pom</type>
-        <scope>import</scope>
-    </dependency>
-    ...
-</dependencyManagement>
-```
-
-</TabItem>
-
-<TabItem value="tomee7">
-
-```xml
-<dependencyManagement>
-    <dependency>
-        <groupId>com.sap.cloud.sjb.cf</groupId>
-        <artifactId>cf-tomee7-bom</artifactId>
-        <version>your-buildpack-version</version>
-        <type>pom</type>
-        <scope>import</scope>
-    </dependency>
-    ...
-</dependencyManagement>
-```
-
-</TabItem>
-
-</Tabs>
-
-You can verify this behavior by searching for the scope of, for example, the `com.sap.cloud.security.xsuaa:token-client` dependency in your application.
+You can verify the behavior by searching for the scope of, for example, the `com.sap.cloud.security.xsuaa:token-client` dependency in your application.
 
 When you use the BOM of the SAP Java Buildpack, it should have the scope `provided`.
 If you are not using the BOM, it should have the scope `compile` or `test`.
@@ -280,11 +221,11 @@ The above dependencies should only be listed with scope `provided`.
 :::note
 
 Dependencies with the scope `provided` are not part of your `.war` file.
-This means you need to adapt the scopes if you want to run your applications without the SAP Java Buildpack
+This means you need to adapt the scopes if you want to run your applications without the SAP Java Buildpack.
 One common example for this is running your application locally.
 
 In our `scp-cf-tomee` archetype we provide a maven profile activated by the parameter `-Ddeployment=local`.
-This replaces our `sdk-buildpack-bom-tomee` (a convenience combination of the SAP Java Buildpack and our SAP Cloud SDK BOMs) with our `sdk-bom`.
+This replaces our `sdk-buildpack-bom` (a convenience combination of the SAP Java Buildpack and our SAP Cloud SDK BOMs) with our `sdk-bom`.
 As a result the SAP Java Buildpack BOM is removed from the `dependencyManagement`, which adapts the scopes of your dependencies for local deployment.
 
 :::

--- a/docs-java/guides/dependencies.mdx
+++ b/docs-java/guides/dependencies.mdx
@@ -204,7 +204,7 @@ We recommend using the [BOMs provided by the SAP Java Buildpack](https://help.sa
 This will set the version and the scope of the dependencies the SAP Java Buildpack adds to your application at runtime.
 The scope of the those dependencies is set to `provided`.
 
-Depending on the [target runtime](https://help.sap.com/docs/BTP/65de2977205c403bbc107264b8eccf4b/83d241613dcd41c99ccc308ed0d26399.html) defined in your `manifest.yml` you should import the respective BOM in your `<dependencyManagement>` section.
+Depending on the [target runtime](https://help.sap.com/docs/BTP/65de2977205c403bbc107264b8eccf4b/83d241613dcd41c99ccc308ed0d26399.html) defined in your `manifest.yml` you should import the [respective BOM](https://search.maven.org/search?q=com.sap.cloud.sjb.cf) in your `<dependencyManagement>` section.
 
 You can verify the behavior by searching for the scope of, for example, the `com.sap.cloud.security.xsuaa:token-client` dependency in your application.
 

--- a/docs-java/guides/dependencies.mdx
+++ b/docs-java/guides/dependencies.mdx
@@ -200,9 +200,10 @@ Still, the same strategy is also valid and useful for the community Buildpack.
 ### Avoiding Scope Conflicts
 
 We recommend using the [BOMs provided by the SAP Java Buildpack](https://help.sap.com/docs/BTP/65de2977205c403bbc107264b8eccf4b/6c6936e8e4ea40c9a9a69f6783b1e978.html).
-In our `scp-cf-tomee` Archetype we are using the `sdk-buildpack-bom` which itself depends on the SAP Java Buildpack BOM.
+In our `scp-cf-tomee` Archetype we are using the `sdk-buildpack-bom` which itself brings in the SAP Java Buildpack BOM.
+This combined BOM ensures that the SAP Cloud SDK and SAP Java Buildpack versions are compatible and that you only need to manage one BOM.
 
-This will set the version and the scope of the dependencies the SAP Java Buildpack adds to your application at runtime.
+Any of the BOMs above will set the version and the scope of the dependencies the SAP Java Buildpack adds to your application at runtime.
 The scope of the those dependencies is set to `provided`.
 
 Depending on the [target runtime](https://help.sap.com/docs/BTP/65de2977205c403bbc107264b8eccf4b/83d241613dcd41c99ccc308ed0d26399.html) defined in your `manifest.yml` you should import the [respective BOM](https://search.maven.org/search?q=com.sap.cloud.sjb.cf) in your `<dependencyManagement>` section.

--- a/styles/Vocab/SAP/accept.txt
+++ b/styles/Vocab/SAP/accept.txt
@@ -24,6 +24,7 @@ runtimes?
 allowlist(ed)?
 onboard(ed)?
 [Bb]uildpack
+BOM
 
 changesets?
 subrequests?


### PR DESCRIPTION
## What Has Changed?

In V4 we introduced a new BOM that combines the SAP Java Buildpack BOM for TomEE, as well as our `sdk-bom`.
This allows consumers to easily consume a tested combination of dependency versions and scopes.

Especially in the archetypes that requires some changes to be able to run the application locally.
This required now some changes on our documentation.

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] ~You verified all new and changed links still work (changing the `id` or name of a file can break links)~
- [x] ~You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.~
