### PR TITLE
fix: correct any lambda operation example

### DIFF
--- a/docs-js/features/odata/v4/filter-one-to-many.mdx
+++ b/docs-js/features/odata/v4/filter-one-to-many.mdx
@@ -3,13 +3,13 @@ Below is an example that demonstrates how to use the lambda operator `any`.
 
 ```ts
 /*
-Get all people that have at least one friend that matches all the following conditions:
+Get all people that have at least one friend that matches all of the following conditions:
   - Has first name 'John'
   - Has last name 'Miller'
 */
 .filter(
-  any(
-    peopleApi.schema.FRIENDS.filter(
+  peopleApi.schema.FRIENDS.filter(
+    any(
       peopleApi.schema.FIRST_NAME.equals('John'),
       peopleApi.schema.LAST_NAME.equals('Miller')
     )
@@ -20,5 +20,5 @@ Get all people that have at least one friend that matches all the following cond
 The generated `$filter` parameter of the URL will be:
 
 ```sql
-$filter=(/any(a0:((a0/Friends/FirstName eq 'John' and a0/Friends/LastName eq 'Miller'))))
+$filter=((Friends/any(a0:(a0/FirstName eq 'John' and a0/LastName eq 'Miller'))))
 ```

--- a/docs-js/features/odata/v4/filter-parent-child.mdx
+++ b/docs-js/features/odata/v4/filter-parent-child.mdx
@@ -11,7 +11,7 @@ peopleApi
   .filter(peopleApi.schema.FIRST_NAME.equals('John'));
 ```
 
-If you want to get all people who have at least one friend with first name `John` the query is:
+If you want to get all people who have at least one friend with first name `John`, the query is:
 
 ```ts
 const { peopleApi } = peopleService();


### PR DESCRIPTION
## What Has Changed?

The example shown in the 1-to-N nav properties for `any` and the generated filter url expression is incorrect. This PR corrects that.
## Manual Checks?

- [ ] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [ ] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [ ] You formatted all changed files with prettier (`npm run prettier`)
- [ ] You tested if the documentation still builds (`npm run build`)
- [ ] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [ ] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
