### PR TITLE
[V4] Add Warnings about `executeWith...` Limitations

### DIFF
--- a/docs-java/features/multi-tenancy/thread-context.mdx
+++ b/docs-java/features/multi-tenancy/thread-context.mdx
@@ -130,6 +130,14 @@ ThreadContextExecutors.submit(myTask);
 
 ### Modifying the ThreadContext
 
+:::danger Caution
+
+Modifying the `ThreadContext` as depicted below is currently supported only when using the default `Facade` (e.g. `DefaultTenantFacade`) implementations.
+This is an issue especially when using the the CAP integration dependency `cds-integration-cloud-sdk`.
+To still manipulate the request context, please refer to [the CAP documentation](https://cap.cloud.sap/docs/java/request-contexts#defining-requestcontext).
+
+:::
+
 You may want to run an asynchronous operation in a completely new or custom context.
 By default, the executor will transfer any existing context to the new thread.
 
@@ -189,9 +197,11 @@ TenantAccessor.executeWithTenant(customTenant, () -> doStuff());
 ```
 
 :::caution CAP Integration
-The above does not apply for any accessors like `TenantAccessor`, `PrincipalAccessor`, `RequestHeaderAccessor` when using the CAP framework (with the `cds-integration-cloud-sdk` dependency).
-When using CAP the Tenant,Principal information and Headers are derived from the `RequestContext`.
+
+The above does not apply for accessors like `TenantAccessor`, `PrincipalAccessor`, `RequestHeaderAccessor` when using the CAP framework (with the `cds-integration-cloud-sdk` dependency).
+When using CAP the Tenant, Principal, and Headers are derived from the `RequestContext`.
 Please refer to [this section](https://cap.cloud.sap/docs/java/request-contexts#defining-requestcontext) on how to override existing values in the CAP context.
+
 :::
 
 :::caution

--- a/docs-java/features/resilience/caching.mdx
+++ b/docs-java/features/resilience/caching.mdx
@@ -162,6 +162,14 @@ TenantAccessor.executeWithTenant(tenantB, () -> cachedOperation());
 TenantAccessor.executeWithTenant(tenantB, () -> cachedOperation());
 ```
 
+:::danger Caution
+
+The `executeWith...()` methods depicted above are currently supported only when using the default `Facade` (e.g. `DefaultTenantFacade`) implementations.
+This is an issue especially when using the CAP integration dependency `cds-integration-cloud-sdk`.
+To still switch the isolation context, please refer to [the CAP documentation](https://cap.cloud.sap/docs/java/request-contexts#defining-requestcontext).
+
+:::
+
 You can configure this isolation via the isolation mode of the resilience configuration.
 Set the isolation mode to `NO_ISOLATION` to disable tenant aware caching.
 See the section on isolation levels under [Resilience](https://sap.github.io/cloud-sdk/docs/java/features/resilience/resilience#multi-tenancy) for more details.

--- a/docs-java/guides/cap-sdk-integration.mdx
+++ b/docs-java/guides/cap-sdk-integration.mdx
@@ -116,6 +116,13 @@ We'll add a respective integration dependency to the POM file under the `srv` di
 </dependency>
 ```
 
+:::danger Caution
+
+The `executeWith...()` methods offered by the _Accessor_ classes (e.g. `TenantAccessor`) are currently not supported when using the CAP integration.
+To still manipulate the request context, please refer to [the CAP documentation](https://cap.cloud.sap/docs/java/request-contexts#defining-requestcontext).
+
+:::
+
 :::note Multitenancy Integration with CAP
 You can learn more about how the multitenancy of the SAP Cloud SDK integrates with CAP in [this article](../features/multi-tenancy/multi-tenancy-thread-context#how-is-a-thread-context-created).
 :::
@@ -154,12 +161,6 @@ RequestContextRunner cdsContextRunner = context.getCdsRuntime().requestContext()
 
 Callable<Object> task = () -> cdsContextRunner.run(() -> ... ));
 ```
-
-:::caution Caution
-The `executeWith` methods of _Accessor_ classes cannot be currently used to execute asynchronous operations in the CAP context.
-
-Please note that the `RequestScopedHttpClientCache` which is the default being used by the SAP Cloud SDK cannot work with CAP integration, please use [`TimeScopedHttpClientCache`](../features/connectivity/sdk-connectivity-http-client#caching-httpclient) instead for caching `HttpClient`s.
-:::
 
 :::info Info
 In case you are using CAP/CDS versions earlier than `1.23.0`, additional steps are required.


### PR DESCRIPTION
## What Has Changed?

This PR adds "danger boxes" about the current limitations with regard to the `executeWith...` API, especially in combination with the CAP integration.

## Manual Checks?

- [x] Text adheres to the style guide (`vale docs/`)
  - Every sentence is on its own line
  - Headings use [title capitalization](https://capitalizemytitle.com/style/AP/#) (applies also to the sidebar and title of a document)
  - You followed [naming center](https://www.sapbrandtools.com/naming-center/#/dashboard) guidelines when referring to SAP products (e.g. SAP S/4HANA)
- [x] You checked your spelling and grammar (consider using Grammarly, see `CONTRIBUTING.md`)
- [x] You formatted all changed files with prettier (`npm run prettier`)
- [x] You tested if the documentation still builds (`npm run build`)
- [x] You verified all new and changed links still work (changing the `id` or name of a file can break links)
- [x] You have updated the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js) if you add documentation on a new feature or otherwise required.
