### PR TITLE
Remove pre-release info on sdk v2

### DIFF
--- a/docs-js/release-policy.mdx
+++ b/docs-js/release-policy.mdx
@@ -30,11 +30,11 @@ It's not relevant for the SAP Cloud SDK for Java!
 
 The SAP Cloud SDK for JavaScript follows [semantic versioning](https://semver.org/).
 
-| Version | Status      | Release Date  | Link to Announcement                    |
-| :------ | ----------- | :------------ | :-------------------------------------- |
-| 1.x     | Deprecated  | March 2019    | N/A                                     |
-| 2.x     | Released GA | February 2022 | [Version 2.x](announcing-version-2.mdx) |
-| 3.x     | Planned     | Q1/Q2 2023    | TBD                                     |
+| Version | Status      | Release Date  | Link to Announcement             |
+| :------ | ----------- | :------------ | :------------------------------- |
+| 1.x     | Deprecated  | March 2019    | N/A                              |
+| 2.x     | Released GA | February 2022 | [Version 2.x](release-notes.mdx) |
+| 3.x     | Planned     | Q1/Q2 2023    | TBD                              |
 
 ## Minor and Major Release Policy
 

--- a/sidebarsDocsJs.js
+++ b/sidebarsDocsJs.js
@@ -95,11 +95,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Releases',
-      items: [
-        'release-policy',
-        'announcing-version-2',
-        'announcing-version-2-beta'
-      ]
+      items: ['release-policy']
     },
     {
       type: 'category',


### PR DESCRIPTION
Those pages are not accurate anymore so they might lead to confusion.
