### PR TITLE
chore: Adjust existing release notes

### DIFF
--- a/docs-js/release-notes.mdx
+++ b/docs-js/release-notes.mdx
@@ -36,6 +36,7 @@ import LicenseBadge from '@site/src/sap/sdk-js/LicenseBadge';
 <!-- This line is used for our release notes automation -->
 
 ## 2.8.0 [Core Modules] - September 06, 2022
+
 **API Reference:** [2.8.0](https://sap.github.io/cloud-sdk/api/2.8.0)
 
 ### Compatibility Notes
@@ -60,6 +61,7 @@ import LicenseBadge from '@site/src/sap/sdk-js/LicenseBadge';
 - [connectivity] Fix that unparsable destinations in the subaccount prevent other destinations from beeing fetched. (15e9ef4b)
 
 ## 2.7.1 [Core Modules] - August 12, 2022
+
 **API Reference:** [2.7.1](https://sap.github.io/cloud-sdk/api/2.7.1)
 
 ### Fixed Issues
@@ -67,6 +69,7 @@ import LicenseBadge from '@site/src/sap/sdk-js/LicenseBadge';
 - [mail-client] Fix proxy authorization for sending emails.
 
 ## 2.7.0 [Core Modules] - August 10, 2022
+
 **API Reference:** [2.7.0](https://sap.github.io/cloud-sdk/api/2.7.0)
 
 ### New Functionalities
@@ -82,6 +85,7 @@ import LicenseBadge from '@site/src/sap/sdk-js/LicenseBadge';
 - [connectivity] Fix a breaking change of `serviceToken` introduced in 2.0, so it accepts `XsuaaServiceCredentials` again as an option. (3bff42e1)
 
 ## 2.6.0 [Core Modules] - July 15, 2022
+
 **API Reference:** [2.6.0](https://sap.github.io/cloud-sdk/api/2.6.0)
 
 ### Compatibility Notes
@@ -112,6 +116,7 @@ import LicenseBadge from '@site/src/sap/sdk-js/LicenseBadge';
 - [odata-v2] Support negative epoch timestamps in serialization. (9ffe0824)
 
 # 2.5.0 [Core Modules] - June 13, 2022
+
 **API Reference:** [2.5.0](https://sap.github.io/cloud-sdk/api/2.5.0)
 
 ## Compatibility Notes
@@ -126,6 +131,7 @@ import LicenseBadge from '@site/src/sap/sdk-js/LicenseBadge';
   [New Functionality] Support defining header options and query parameter options with origins. (9481ec69)
 
 ## 2.4.0 [Core Modules] - May 20, 2022
+
 **API Reference:** [2.4.0](https://sap.github.io/cloud-sdk/api/2.4.0)
 
 ### Compatibility Notes
@@ -153,6 +159,7 @@ import LicenseBadge from '@site/src/sap/sdk-js/LicenseBadge';
 - [util] Fix a bug in the implementation of the trim method.
 
 ## 2.3.0 [Core Modules] - Apr 22, 2022
+
 **API Reference:** [2.3.0](https://sap.github.io/cloud-sdk/api/2.3.0)
 
 ## Compatibility Notes
@@ -174,6 +181,7 @@ import LicenseBadge from '@site/src/sap/sdk-js/LicenseBadge';
 - [openapi-generator, openapi] Support path parameters that are not separated by '/', e.g., `/path/{param}:{param}`.
 
 ## 2.2.0 [Core Modules] - Apr 6, 2022
+
 **API Reference:** [2.2.0](https://sap.github.io/cloud-sdk/api/2.2.0)
 
 ### Compatibility Notes
@@ -196,6 +204,7 @@ import LicenseBadge from '@site/src/sap/sdk-js/LicenseBadge';
 - [http-client] Introduce consistent query parameter encoding for all non custom parameters.
 
 ## 2.1.0 [Core Modules] - Feb 18, 2022
+
 **API Reference:** [2.1.0](https://sap.github.io/cloud-sdk/api/2.1.0)
 
 ### Improvements
@@ -212,6 +221,7 @@ import LicenseBadge from '@site/src/sap/sdk-js/LicenseBadge';
 - [odata-common] Fix URL encoding for `getByKey`
 
 ## 2.0.0 [Core Modules] - Feb 03, 2022
+
 **API Reference:** [2.0.0](https://sap.github.io/cloud-sdk/api/2.0.0)
 
 We released version 2 :partying_face:

--- a/docs-js/release-notes.mdx
+++ b/docs-js/release-notes.mdx
@@ -36,6 +36,7 @@ import LicenseBadge from '@site/src/sap/sdk-js/LicenseBadge';
 <!-- This line is used for our release notes automation -->
 
 ## 2.8.0 [Core Modules] - September 06, 2022
+**API Reference:** [2.8.0](https://sap.github.io/cloud-sdk/api/2.8.0)
 
 ### Compatibility Notes
 
@@ -59,12 +60,14 @@ import LicenseBadge from '@site/src/sap/sdk-js/LicenseBadge';
 - [connectivity] Fix that unparsable destinations in the subaccount prevent other destinations from beeing fetched. (15e9ef4b)
 
 ## 2.7.1 [Core Modules] - August 12, 2022
+**API Reference:** [2.7.1](https://sap.github.io/cloud-sdk/api/2.7.1)
 
 ### Fixed Issues
 
 - [mail-client] Fix proxy authorization for sending emails.
 
 ## 2.7.0 [Core Modules] - August 10, 2022
+**API Reference:** [2.7.0](https://sap.github.io/cloud-sdk/api/2.7.0)
 
 ### New Functionalities
 
@@ -79,6 +82,7 @@ import LicenseBadge from '@site/src/sap/sdk-js/LicenseBadge';
 - [connectivity] Fix a breaking change of `serviceToken` introduced in 2.0, so it accepts `XsuaaServiceCredentials` again as an option. (3bff42e1)
 
 ## 2.6.0 [Core Modules] - July 15, 2022
+**API Reference:** [2.6.0](https://sap.github.io/cloud-sdk/api/2.6.0)
 
 ### Compatibility Notes
 
@@ -108,6 +112,7 @@ import LicenseBadge from '@site/src/sap/sdk-js/LicenseBadge';
 - [odata-v2] Support negative epoch timestamps in serialization. (9ffe0824)
 
 # 2.5.0 [Core Modules] - June 13, 2022
+**API Reference:** [2.5.0](https://sap.github.io/cloud-sdk/api/2.5.0)
 
 ## Compatibility Notes
 
@@ -121,6 +126,7 @@ import LicenseBadge from '@site/src/sap/sdk-js/LicenseBadge';
   [New Functionality] Support defining header options and query parameter options with origins. (9481ec69)
 
 ## 2.4.0 [Core Modules] - May 20, 2022
+**API Reference:** [2.4.0](https://sap.github.io/cloud-sdk/api/2.4.0)
 
 ### Compatibility Notes
 
@@ -147,6 +153,7 @@ import LicenseBadge from '@site/src/sap/sdk-js/LicenseBadge';
 - [util] Fix a bug in the implementation of the trim method.
 
 ## 2.3.0 [Core Modules] - Apr 22, 2022
+**API Reference:** [2.3.0](https://sap.github.io/cloud-sdk/api/2.3.0)
 
 ## Compatibility Notes
 
@@ -167,6 +174,7 @@ import LicenseBadge from '@site/src/sap/sdk-js/LicenseBadge';
 - [openapi-generator, openapi] Support path parameters that are not separated by '/', e.g., `/path/{param}:{param}`.
 
 ## 2.2.0 [Core Modules] - Apr 6, 2022
+**API Reference:** [2.2.0](https://sap.github.io/cloud-sdk/api/2.2.0)
 
 ### Compatibility Notes
 
@@ -188,6 +196,7 @@ import LicenseBadge from '@site/src/sap/sdk-js/LicenseBadge';
 - [http-client] Introduce consistent query parameter encoding for all non custom parameters.
 
 ## 2.1.0 [Core Modules] - Feb 18, 2022
+**API Reference:** [2.1.0](https://sap.github.io/cloud-sdk/api/2.1.0)
 
 ### Improvements
 
@@ -203,6 +212,7 @@ import LicenseBadge from '@site/src/sap/sdk-js/LicenseBadge';
 - [odata-common] Fix URL encoding for `getByKey`
 
 ## 2.0.0 [Core Modules] - Feb 03, 2022
+**API Reference:** [2.0.0](https://sap.github.io/cloud-sdk/api/2.0.0)
 
 We released version 2 :partying_face:
 Be mindful of breaking changes when upgrading.


### PR DESCRIPTION
Relates to: https://github.com/SAP/cloud-sdk-backlog/issues/841

Add the link manuall for the already existing released veriosn.
With thie [PR](https://github.com/SAP/cloud-sdk-js/pull/2889) it should be done automatically from now on.