### PR TITLE
[Java] Release Notes for `3.75.0`

### DIFF
--- a/docs-java/release-notes.mdx
+++ b/docs-java/release-notes.mdx
@@ -97,7 +97,7 @@ To continue using the latest features outlined in the release notes for version 
 ### Fixed Issues
 
 - Fix an issue with OData request payloads containing incomplete entity type indicators.
-
+- Fix an issue with JWT payload parsing from incoming requests: `aud` claim can be an atomic string or an array of strings.
 
 ## 3.74.0 - August 11, 2022
 

--- a/docs-java/release-notes.mdx
+++ b/docs-java/release-notes.mdx
@@ -55,6 +55,44 @@ To continue using the latest features outlined in the release notes for version 
 ### Fixed Issues
 -->
 
+## 3.75.0 - September 21, 2022
+
+[Maven Central](https://search.maven.org/search?q=g:com.sap.cloud.sdk*%20AND%20v:3.75.0) | [Javadoc](https://help.sap.com/doc/d36e6a93f11b48bd920453bed2149bd3/1.0/en-US/index.html)
+
+### Compatibility Notes
+
+
+- The `RequestAccessor` API (along all the related classes - e.g. the `RequestThreadContextListener` and `RequestFacade`) has been deprecated. For a replacement, please refer to the `RequestHeaderAccessor`.
+  - Before:
+    ```
+    HttpServletRequest request;
+    
+    RequestAccessor.executeWithRequest(request, () -> { ... });
+    ```
+  - After:
+    ```
+    HttpServletRequest request;
+    Map<String, Collection<String>> headers = Collections.list(request.getHeaderNames())
+      .stream()
+      .collect(Collectors.toMap(Function.identity(), key -> Collections.list(request.getHeaders(key))));
+      
+    RequestHeaderAccessor.executeWithHeaderContainer(headers, () -> { ... });
+    ```
+
+### New Functionality
+
+- Add public method `getAllDestinations()` to `EnvVarDestinationLoader` to resolve all destinations from the configured system environment variable (default: `destinations`).
+
+### Improvements
+
+- Dependency Updates:
+  - SAP dependency updates:
+    - Update XSUAA Library from `2.12.2` to `2.12.3`
+  - Other dependency updates:
+    - Minor version updates:
+        - Update Spring from `5.3.21` to `5.3.22`
+        - Update Spring Security from `5.7.2` to `5.7.3`
+
 ## 3.74.0 - August 11, 2022
 
 [Maven Central](https://search.maven.org/search?q=g:com.sap.cloud.sdk*%20AND%20v:3.74.0) | [Javadoc](https://help.sap.com/doc/d36e6a93f11b48bd920453bed2149bd3/1.0/en-US/index.html)

--- a/docs-java/release-notes.mdx
+++ b/docs-java/release-notes.mdx
@@ -94,6 +94,11 @@ To continue using the latest features outlined in the release notes for version 
       - Update Spring from `5.3.21` to `5.3.22`
       - Update Spring Security from `5.7.2` to `5.7.3`
 
+### Fixed Issues
+
+- Fix an issue with OData request payloads containing incomplete entity type indicators.
+
+
 ## 3.74.0 - August 11, 2022
 
 [Maven Central](https://search.maven.org/search?q=g:com.sap.cloud.sdk*%20AND%20v:3.74.0) | [Javadoc](https://help.sap.com/doc/d36e6a93f11b48bd920453bed2149bd3/1.0/en-US/index.html)

--- a/docs-java/release-notes.mdx
+++ b/docs-java/release-notes.mdx
@@ -61,21 +61,22 @@ To continue using the latest features outlined in the release notes for version 
 
 ### Compatibility Notes
 
-
 - The `RequestAccessor` API (along all the related classes - e.g. the `RequestThreadContextListener` and `RequestFacade`) has been deprecated. For a replacement, please refer to the `RequestHeaderAccessor`.
   - Before:
+
     ```
     HttpServletRequest request;
-    
+
     RequestAccessor.executeWithRequest(request, () -> { ... });
     ```
+
   - After:
     ```
     HttpServletRequest request;
     Map<String, Collection<String>> headers = Collections.list(request.getHeaderNames())
       .stream()
       .collect(Collectors.toMap(Function.identity(), key -> Collections.list(request.getHeaders(key))));
-      
+
     RequestHeaderAccessor.executeWithHeaderContainer(headers, () -> { ... });
     ```
 
@@ -90,8 +91,8 @@ To continue using the latest features outlined in the release notes for version 
     - Update XSUAA Library from `2.12.2` to `2.12.3`
   - Other dependency updates:
     - Minor version updates:
-        - Update Spring from `5.3.21` to `5.3.22`
-        - Update Spring Security from `5.7.2` to `5.7.3`
+      - Update Spring from `5.3.21` to `5.3.22`
+      - Update Spring Security from `5.7.2` to `5.7.3`
 
 ## 3.74.0 - August 11, 2022
 
@@ -130,10 +131,10 @@ To continue using the latest features outlined in the release notes for version 
     - Update NEO Web API from `4.29.8` to `4.32.0`
   - Other dependency updates:
     - Minor version updates:
-        - Update Spring from `5.3.20` to `5.3.21`
-        - Update Spring Security from `5.7.1` to `5.7.2`
-        - Update `org.scyscreamer:jsonassert` from `1.5.0` to `1.5.1`
-        - Update `org.liquibase:liquibase-core` from `4.12.0` to `4.13.0`
+      - Update Spring from `5.3.20` to `5.3.21`
+      - Update Spring Security from `5.7.1` to `5.7.2`
+      - Update `org.scyscreamer:jsonassert` from `1.5.0` to `1.5.1`
+      - Update `org.liquibase:liquibase-core` from `4.12.0` to `4.13.0`
 
 ### Fixed Issues
 

--- a/docs-java/release-notes.mdx
+++ b/docs-java/release-notes.mdx
@@ -62,23 +62,6 @@ To continue using the latest features outlined in the release notes for version 
 ### Compatibility Notes
 
 - The `RequestAccessor` API (along all the related classes - e.g. the `RequestThreadContextListener` and `RequestFacade`) has been deprecated. For a replacement, please refer to the `RequestHeaderAccessor`.
-  - Before:
-
-    ```
-    HttpServletRequest request;
-
-    RequestAccessor.executeWithRequest(request, () -> { ... });
-    ```
-
-  - After:
-    ```
-    HttpServletRequest request;
-    Map<String, Collection<String>> headers = Collections.list(request.getHeaderNames())
-      .stream()
-      .collect(Collectors.toMap(Function.identity(), key -> Collections.list(request.getHeaders(key))));
-
-    RequestHeaderAccessor.executeWithHeaderContainer(headers, () -> { ... });
-    ```
 
 ### New Functionality
 

--- a/docs-js/release-notes.mdx
+++ b/docs-js/release-notes.mdx
@@ -36,6 +36,7 @@ import LicenseBadge from '@site/src/sap/sdk-js/LicenseBadge';
 <!-- This line is used for our release notes automation -->
 
 ## 2.9.0 [Core Modules] - September 20, 2022
+
 **API Reference:** [2.9.0](https://sap.github.io/cloud-sdk/api/2.9.0)
 
 ### New Functionalities


### PR DESCRIPTION
## What Has Changed?

This PR adds release notes for the SAP Cloud SDK for Java release of version 3.75.0.

To be merged on September 23, 2022.

## Manual Checks?

- [x] Check spelling and grammar, e.g., using Grammarly.
- [x] Verify links still work, e.g., if `id` or the name of a file is changed.
- [x] Update the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js), e.g., if a new feature is added.
