### PR TITLE
[Java V3] Replace Deprecated Destination Retrieval Strategy

### DIFF
--- a/docs-java/features/connectivity/destinations.mdx
+++ b/docs-java/features/connectivity/destinations.mdx
@@ -384,9 +384,9 @@ For a provider/subscriber setup, a [retrieval strategy](https://help.sap.com/doc
 - `CURRENT_TENANT` (default, same behavior as the deprecated `ALWAYS_SUBSCRIBER`)
 - `ALWAYS_PROVIDER`
 - `ONLY_SUBSCRIBER`
-- `SUBSCRIBER_THEN_PROVIDER`
+- `CURRENT_TENANT_THEN_PROVIDER`
 
-Here is an example for `SUBSCRIBER_THEN_PROVIDER` option:
+Here is an example for `CURRENT_TENANT_THEN_PROVIDER` option:
 
 ```java
 DestinationOptions options =
@@ -395,7 +395,7 @@ DestinationOptions options =
         .augmentBuilder(
             ScpCfDestinationOptionsAugmenter
                 .augmenter()
-                .retrievalStrategy(ScpCfDestinationRetrievalStrategy.SUBSCRIBER_THEN_PROVIDER))
+                .retrievalStrategy(ScpCfDestinationRetrievalStrategy.CURRENT_TENANT_THEN_PROVIDER))
         .build();
 ```
 


### PR DESCRIPTION
## What Has Changed?

This PR replaces the deprecated destination retrieval strategy `SUBSCRIBER_THEN_PROVIDER` (for both Cloud Foundry and Neo) with the new `CURRENT_TENANT_THEN_PROVIDER` strategy.

**DON'T MERGE THIS UNTIL CLOUD SDK 3.76.0 IS RELEASED.**

## Manual Checks?

- [x] Check spelling and grammar, e.g., using Grammarly.
- [x] Verify links still work, e.g., if `id` or the name of a file is changed.
- [x] Update the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js), e.g., if a new feature is added.
