### PR TITLE
[Java V4] Replace Removed Destination Retrieval Strategy

### DIFF
--- a/docs-java/features/connectivity/destinations.mdx
+++ b/docs-java/features/connectivity/destinations.mdx
@@ -338,9 +338,9 @@ For a provider/subscriber setup, a [retrieval strategy](https://help.sap.com/doc
 - `CURRENT_TENANT` (default)
 - `ALWAYS_PROVIDER`
 - `ONLY_SUBSCRIBER`
-- `SUBSCRIBER_THEN_PROVIDER`
+- `CURRENT_TENANT_THEN_PROVIDER`
 
-Here is an example for `SUBSCRIBER_THEN_PROVIDER` option:
+Here is an example for `CURRENT_TENANT_THEN_PROVIDER` option:
 
 ```java
 DestinationOptions options =
@@ -349,7 +349,7 @@ DestinationOptions options =
         .augmentBuilder(
             ScpCfDestinationOptionsAugmenter
                 .augmenter()
-                .retrievalStrategy(ScpCfDestinationRetrievalStrategy.SUBSCRIBER_THEN_PROVIDER))
+                .retrievalStrategy(ScpCfDestinationRetrievalStrategy.CURRENT_TENANT_THEN_PROVIDER))
         .build();
 ```
 


### PR DESCRIPTION
## What Has Changed?

This PR replaced the removed `SUBSCRIBER_THEN_PROVIDER` destination retrieval strategy with the new `CURRENT_TENANT_THEN_PROVIDER` one.

## Manual Checks?

- [x] Check spelling and grammar, e.g., using Grammarly.
- [x] Verify links still work, e.g., if `id` or the name of a file is changed.
- [x] Update the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js), e.g., if a new feature is added.
