### PR TITLE
Fix: API Reference Dropdown

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -85,12 +85,7 @@ module.exports = {
           type: 'dropdown',
           label: 'API Reference',
           position: 'right',
-          items: [
-            {
-              label: 'Swizzle Placeholder',
-              href: 'https://www.example.com'
-            }
-          ],
+          items: [],
           docsPluginId: 'docs-js',
           apiReference: true
         },

--- a/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
+++ b/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import DocsVersionDropdownNavbarItem from '@theme-original/NavbarItem/DocsVersionDropdownNavbarItem';
 import { useActiveDocContext } from '@docusaurus/plugin-content-docs/client';
-import { shouldShow, hasMoreThanOneVersion } from './helper';
+import { containsCurrentDocsPluginId, hasMoreThanOneVersion } from './helper';
 import HtmlNavbarItem from '@theme-original/NavbarItem/HtmlNavbarItem';
 
 /**
@@ -9,18 +9,18 @@ import HtmlNavbarItem from '@theme-original/NavbarItem/HtmlNavbarItem';
  * Furthermore, only shows a single version instead of a dropdown if the current file is unique to one version.
  */
 export default function DocsVersionDropdownNavbarItemWrapper(props) {
-  if (shouldShow(props)) {
-    if (hasMoreThanOneVersion(props.docsPluginId)) {
-      return <DocsVersionDropdownNavbarItem {...props} />;
-    } else {
-      const label = useActiveDocContext(props.docsPluginId).activeVersion.label;
-      const newProps = {
-        position: 'right',
-        value: `<button>${label}</button>`
-      };
-      return <HtmlNavbarItem {...newProps} />;
-    }
+  if (!containsCurrentDocsPluginId(props)) {
+    return null;
   }
 
-  return null;
+  if (hasMoreThanOneVersion(props.docsPluginId)) {
+    return <DocsVersionDropdownNavbarItem {...props} />;
+  }
+
+  const label = useActiveDocContext(props.docsPluginId).activeVersion.label;
+  const newProps = {
+    position: 'right',
+    value: `<button>${label}</button>`
+  };
+  return <HtmlNavbarItem {...newProps} />;
 }

--- a/src/theme/NavbarItem/DropdownNavbarItem.js
+++ b/src/theme/NavbarItem/DropdownNavbarItem.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shouldShow } from './helper';
+import { containsCurrentDocsPluginId } from './helper';
 import DropdownNavbarItem from '@theme-original/NavbarItem/DropdownNavbarItem';
 import sdkVersions from '@site/static/api/versions';
 import { useActiveVersion } from '@docusaurus/plugin-content-docs/client';
@@ -9,10 +9,11 @@ import { useActiveVersion } from '@docusaurus/plugin-content-docs/client';
  * the wrapper overwrites its default `items` value with all versions matching the currently selected major version.
  */
 export default function DropdownNavbarItemWrapper(props) {
-  if (shouldShow(props) && props.apiReference) {
+  let newProps = null;
+  if (containsCurrentDocsPluginId(props) && props.apiReference) {
     const currentSelectedVersion = useActiveVersion(props.docsPluginId)
       .label[1];
-    const newProps = {
+    newProps = {
       ...props,
       items: sdkVersions
         .filter(version => {
@@ -26,7 +27,13 @@ export default function DropdownNavbarItemWrapper(props) {
           };
         })
     };
-    return <DropdownNavbarItem {...newProps} />;
+  } else {
+    newProps = props;
   }
-  return <DropdownNavbarItem {...props} />;
+
+  if (!newProps || !newProps.items || !newProps.items.length) {
+    return null;
+  }
+
+  return <DropdownNavbarItem {...newProps} />;
 }

--- a/src/theme/NavbarItem/helper.js
+++ b/src/theme/NavbarItem/helper.js
@@ -10,7 +10,7 @@ export function getPathFromPluginId(docsPluginId) {
 /**
  * Checks if a component should be shown, by matching the current path with the path in the docsPluginId.
  */
-export function shouldShow(props) {
+export function containsCurrentDocsPluginId(props) {
   const activeDocContext = useActiveDocContext(props.docsPluginId);
   const docPath = activeDocContext?.activeVersion?.path;
   return docPath?.includes(getPathFromPluginId(props.docsPluginId));


### PR DESCRIPTION
## What Has Changed?

This PR hides the _API Reference_ dropdown in case there are not items to be display (as it currently is for the Java documentation).

![image](https://user-images.githubusercontent.com/9248711/194253637-d8cd733a-f37f-4169-94d1-b2e843c19cec.png)

![image](https://user-images.githubusercontent.com/9248711/194253777-2147bce3-482b-406b-bc23-a63096ef38f1.png)

## Manual Checks?

- [x] ~Check spelling and grammar, e.g., using Grammarly.~
- [x] ~Verify links still work, e.g., if `id` or the name of a file is changed.~
- [x] ~Update the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js), e.g., if a new feature is added.~
