### PR TITLE
Add version dropdown for Java v3 and v4

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -93,12 +93,12 @@ module.exports = {
           type: 'docsVersionDropdown',
           position: 'right',
           docsPluginId: 'docs-js'
-        }
-        /*{
+        },
+        {
           type: 'docsVersionDropdown',
           position: 'right',
           docsPluginId: 'docs-java'
-        }*/
+        }
       ]
     },
     footer: {


### PR DESCRIPTION
## What Has Changed?

Both the versioned v3 and current v4 java docs can be displayed using the dropdown.

## Manual Checks?

- [x] Check spelling and grammar, e.g., using Grammarly.
- [x] Verify links still work, e.g., if `id` or the name of a file is changed.
- [x] Update the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js), e.g., if a new feature is added.
