### PR TITLE
[js] use description meta tag for snippet generation

### DIFF
--- a/src/pages/components/HomepageFeatures.js
+++ b/src/pages/components/HomepageFeatures.js
@@ -12,7 +12,7 @@ const FeatureList = [
     Svg: require('../../../static/img/logo-java.svg').default,
     badge: <MvnBadge />,
     description: (
-      <>
+      <div data-nosnippet>
         The SAP Cloud SDK for Java allows you to develop, extend, and
         communicate with SAP solutions SAP S/4HANA Cloud, SAP SuccessFactors,
         and many others.
@@ -20,7 +20,7 @@ const FeatureList = [
         <a href="docs/java/getting-started">
           Get started with the SDK for Java.
         </a>
-      </>
+      </div>
     )
   },
   {
@@ -33,7 +33,7 @@ const FeatureList = [
       </>
     ),
     description: (
-      <>
+      <div data-nosnippet>
         The SAP Cloud SDK for JavaScript (and TypeScript) helps you build
         cloud-based apps and extensions to SAP solutions using the power and
         flexibility of Node.js and its ecosystem.
@@ -41,7 +41,7 @@ const FeatureList = [
         <a href="docs/js/getting-started">
           Get started with the SDK for JavaScript
         </a>
-      </>
+      </div>
     )
   }
 ];

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -31,7 +31,7 @@ export default function Home() {
   return (
     <Layout
       title={`${siteConfig.title}`}
-      description="SAP Cloud SDK is a one stop shop for developing and extending SAP applications in a Cloud"
+      description="SAP Cloud SDK is a one-stop shop for developing and extending SAP applications in the cloud."
     >
       <HomepageHeader />
       <main>


### PR DESCRIPTION
## What Has Changed?

use description meta tag for snippet generation

The home [page](https://sap.github.io/cloud-sdk/) shows wrong snippets:
<img width="584" alt="Screenshot 2022-10-12 at 09 37 30" src="https://user-images.githubusercontent.com/33489572/195288554-30b07df8-73d4-494a-a86c-de7726659170.png">

## Manual Checks?

- [ ] Check spelling and grammar, e.g., using Grammarly.
- [ ] Verify links still work, e.g., if `id` or the name of a file is changed.
- [ ] Update the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js), e.g., if a new feature is added.
