### PR TITLE
[Java] Release notes for `3.76.0`

### DIFF
--- a/docs-java_versioned_docs/version-v3/release-notes/release-notes-75-to-89.mdx
+++ b/docs-java_versioned_docs/version-v3/release-notes/release-notes-75-to-89.mdx
@@ -1,12 +1,42 @@
 <!-- vale off -->
 
+## 3.76.0 - October 31, 2022
+
+[Maven Central](https://search.maven.org/search?q=g:com.sap.cloud.sdk*%20AND%20v:3.76.0) | [Javadoc](https://help.sap.com/doc/d36e6a93f11b48bd920453bed2149bd3/1.0/en-US/index.html)
+
+### Improvements
+
+- The naming of the destination retrieval strategy (`SUBSCRIBER_THEN_PROVIDER`) both in the `ScpCfDestinationLoader` as well as in the `ScpNeoDestinationLoader` did not behave as the name implied, as it was taking the current tenant, which might, due to misconfiguration, also be the Provider Tenant for the first destination retrieval attempt.
+  This is now fixed by the following steps:
+  - Deprecation of the unclear `SUBSCRIBER_THEN_PROVIDER` strategy
+  - Adding a new strategy `CURRENT_TENANT_THEN_PROVIDER`, which will not perform a second retrieval attempt in case the current tenant is already the provider
+- The naming of the `ScpNeoDestinationRetrievalStrategy` (`ALWAYS_SUBSCRIBER`) in the `ScpNeoDestinationLoader` did not behave as the name implied, as it was taking the current tenant, which might, due to misconfiguration, also be the Provider Tenant.
+  This is now fixed by the following steps:
+  - Deprecation of the unclear `ALWAYS_SUBSCRIBER` strategy
+  - Alternative strategy keeping the same behavior: `CURRENT_TENANT`
+  - Adding a new strategy `ONLY_SUBSCRIBER` which actively enforces that the current tenant is not the provider tenant
+- Dependency Updates:
+  - Other dependency updates:
+    - Minor version updates:
+      - Update [Jackson BOM](https://search.maven.org/search?q=g:com.fasterxml.jackson%2BAND%2Ba:jackson-bom) (`com.fasterxml.jackson:jackson-bom`) from `2.13.3` to `2.13.4`
+      - Update [Jackson Databind](https://search.maven.org/search?q=g:com.fasterxml.jackson.core%2BAND%2Ba:jackson-databind) (`com.fasterxml.jackson.core:jackson-databind`) from `2.13.3` to `2.13.4.2`
+      - Update [Commons Text](https://search.maven.org/search?q=g:org.apache.commons%20AND%20a:commons-text) (`org.apache.commons:commons-text`) from `1.9.0` to `1.10.0`
+      - Update [Fabric SDK Java](https://search.maven.org/search?q=g:org.hyperledger.fabric-sdk-java%2BAND%2Ba:fabric-sdk-java) (`org.hyperledger.fabric-sdk-java:fabric-sdk-java`) from `2.2.10` to `2.2.18`
+      - Update [Snake YAML](https://search.maven.org/search?q=g:org.yaml%2BAND%2Ba:snakeyaml) (`org.yaml:snakeyaml`) from `1.31` to `1.33`
+      - Update [Protobuf Java](https://search.maven.org/search?q=g:com.google.protobuf%2BAND%2Ba:protobuf-java) (`com.google.protobuf:protobuf-java`) from `3.21.2` to `3.21.7`
+
+### Fixed Issues
+
+- Fix an issue with OData request payloads containing incomplete entity type indicators.
+- Fix an issue with JWT payload parsing from incoming requests: `aud` claim can be an atomic string or an array of strings.
+
 ## 3.75.0 - September 21, 2022
 
 [Maven Central](https://search.maven.org/search?q=g:com.sap.cloud.sdk*%20AND%20v:3.75.0) | [Javadoc](https://help.sap.com/doc/d36e6a93f11b48bd920453bed2149bd3/1.0/en-US/index.html)
 
 ### Compatibility Notes
 
-- The `RequestAccessor` API (along all the related classes - e.g. the `RequestThreadContextListener` and `RequestFacade`) has been deprecated.
+- The `RequestAccessor` API (along all the related classes - e.g. the `RequestThreadContextListener` and `RequestFacade`) is deprecated.
   For a replacement, please refer to the `RequestHeaderAccessor`.
 
 ### New Functionality


### PR DESCRIPTION
## What Has Changed?

This PR adds release notes for the SAP Cloud SDK for Java release of version 3.76.0.

To be merged on October 31, 2022.

## Manual Checks?

- [x] Check spelling and grammar, e.g., using Grammarly.
- [x] Verify links still work, e.g., if `id` or the name of a file is changed.
- [x] Update the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js), e.g., if a new feature is added.
