### PR TITLE
chore: add missing alias config

### DIFF
--- a/docs-js/guides/sdk-in-browser.mdx
+++ b/docs-js/guides/sdk-in-browser.mdx
@@ -132,7 +132,8 @@ An error message during the compilation from TS to JS provides a hint on how to 
     resolve: {
       alias: {
         process: 'process/browser',
-        https: 'agent-base'
+        https: 'agent-base',
+        http: 'agent-base'
       },
       fallback: {
         url: false,


### PR DESCRIPTION
## What Has Changed?

Add the missing http: 'agent-base' in alias config

## Manual Checks?

- [ ] Check spelling and grammar, e.g., using Grammarly.
- [ ] Verify links still work, e.g., if `id` or the name of a file is changed.
- [ ] Update the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js), e.g., if a new feature is added.
