### PR TITLE
[Java] Add gson dependency to OpenApi guide

### DIFF
--- a/docs-java/features/rest/generate-rest-client.mdx
+++ b/docs-java/features/rest/generate-rest-client.mdx
@@ -22,12 +22,16 @@ The SAP Cloud SDK offers an OpenAPI client generator as a Maven plugin and as a 
 Either can be used to generate a client library for a REST API based on its OpenAPI specification.
 The OpenAPI generator is a wrapper around the public open-source [OpenAPI Generator](https://github.com/OpenAPITools/openapi-generator) where we have adjusted the `mustache` templates to integrate the generated client library with the SAP Cloud SDK core.
 
-The generated Java classes need the following dependency to be present in your project:
+The generated Java classes need the following dependencies to be present in your project:
 
 ```xml
 <dependency>
 	<groupId>com.sap.cloud.sdk.datamodel</groupId>
 	<artifactId>openapi-core</artifactId>
+</dependency>
+<dependency>
+    <groupId>com.google.code.gson</groupId>
+    <artifactId>gson</artifactId>
 </dependency>
 ```
 

--- a/docs-java_versioned_docs/version-v3/features/rest/generate-rest-client.mdx
+++ b/docs-java_versioned_docs/version-v3/features/rest/generate-rest-client.mdx
@@ -22,12 +22,16 @@ The SAP Cloud SDK offers an OpenAPI client generator as a Maven plugin and as a 
 Either can be used to generate a client library for a REST API based on its OpenAPI specification.
 The OpenAPI generator is a wrapper around the public open-source [OpenAPI Generator](https://github.com/OpenAPITools/openapi-generator) where we have adjusted the `mustache` templates to integrate the generated client library with the SAP Cloud SDK core.
 
-The generated Java classes need the following dependency to be present in your project:
+The generated Java classes need the following dependencies to be present in your project:
 
 ```xml
 <dependency>
 	<groupId>com.sap.cloud.sdk.datamodel</groupId>
 	<artifactId>openapi-core</artifactId>
+</dependency>
+<dependency>
+    <groupId>com.google.code.gson</groupId>
+    <artifactId>gson</artifactId>
 </dependency>
 ```
 


### PR DESCRIPTION
## What Has Changed?

The code generated by the OpenApi generator actually also needs the `gson` dependency to compile.
This PR adds this to the Java OpenApi guide.

## Manual Checks?

- [x] Check spelling and grammar, e.g., using Grammarly.
- [x] Verify links still work, e.g., if `id` or the name of a file is changed.
- [x] Update the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js), e.g., if a new feature is added.
