### PR TITLE
DestinationProperty now public added

### DIFF
--- a/docs-java/features/connectivity/destinations.mdx
+++ b/docs-java/features/connectivity/destinations.mdx
@@ -258,6 +258,23 @@ It can be a destination object that you defined in the Cloud Foundry Cockpit, or
 For that, call the `.property()` method on the destination.
 It expects a key-value pair with a key formatted as `URL.headers.<key>` and an arbitrary value string.
 
+Alternatively you can make use of a predefined `DestinationPropertyKey` available in the `DestinationProperty` class, for example:
+
+```java
+destination =
+            DefaultHttpDestination
+                .builder(server.baseUrl())
+                .property(DestinationProperty.URI, "value1")
+                .build();
+```
+
+These predefined keys can also be used when querying property values, for example:
+
+```java
+Option<String> uri =
+            destination.get(DestinationProperty.URI);
+```
+
 ## Provide Query Parameters for Destinations
 
 ### How It Works
@@ -280,6 +297,23 @@ destination =
 To include query parameters in the query string when calling to a target system you can define them as properties on the destination.
 For that, call the `.property()` method on the destination.
 It expects a key-value pair with a key formatted as `URL.headers.<key>` and an arbitrary value string.
+
+Alternatively you can make use of a predefined `DestinationPropertyKey` available in the `DestinationProperty` class, for example:
+
+```java
+destination =
+            DefaultHttpDestination
+                .builder(server.baseUrl())
+                .property(DestinationProperty.URI, "value1")
+                .build();
+```
+
+These predefined keys can also be used when querying property values, for example:
+
+```java
+Option<String> uri =
+            destination.get(DestinationProperty.URI);
+```
 
 ## Retrieving Destinations
 


### PR DESCRIPTION
## What Has Changed?

Updated JavaDocs: Features -> Destinations to include explanation of using the now-public DestinationProperty class as predefined property keys for both creating and querying destination properties.

## Manual Checks?

- [x] Check spelling and grammar, e.g., using Grammarly.
- [ ] ~~Verify links still work, e.g., if `id` or the name of a file is changed.~~
- [ ] ~~Update the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js), e.g., if a feature is added.~~
