### PR TITLE
fix: tutorial link in BAS guide

### DIFF
--- a/docs-js/guides/bas-external-system.mdx
+++ b/docs-js/guides/bas-external-system.mdx
@@ -236,7 +236,7 @@ Hence, you can use the same approach locally and in production.
 
 On Cloud Foundry, the access to services is granted via the `VCAP_SERVICE` variables.
 Make sure to configure your application so that it can access the destination service.
-If not, follow the [steps in the Cloud Foundry tutorial](https://developers.sap.com/group.s4sdk-js-cloud-foundry.html).
+If not, follow the [steps in the Cloud Foundry tutorial](../tutorials/getting-started/introduction).
 
 ### Implementation
 

--- a/docs-js_versioned_docs/version-v2/guides/bas-external-system.mdx
+++ b/docs-js_versioned_docs/version-v2/guides/bas-external-system.mdx
@@ -236,7 +236,7 @@ Hence, you can use the same approach locally and in production.
 
 On Cloud Foundry, the access to services is granted via the `VCAP_SERVICE` variables.
 We assume that you have configured your application so that it can access the destination service.
-If not, follow the [steps in the Cloud Foundry tutorial](https://developers.sap.com/group.s4sdk-js-cloud-foundry.html).
+If not, follow the [steps in the Cloud Foundry tutorial](../tutorials/getting-started/introduction).
 
 ### Implementation
 


### PR DESCRIPTION
## What Has Changed?

Update the broken tutorial links in the BAS guide

## Manual Checks?

- [ ] Check spelling and grammar, e.g., using Grammarly.
- [ ] Verify links still work, e.g., if `id` or the name of a file is changed.
- [ ] Update the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js), e.g., if a feature is added.
