### PR TITLE
Adapt to new signature of executeHttpRequest function

### DIFF
--- a/docs-js/features/connectivity/generic-http-client.mdx
+++ b/docs-js/features/connectivity/generic-http-client.mdx
@@ -67,7 +67,7 @@ It takes the following parameters:
 
 - The `destination` argument is of type `DestinationOrFetchOptions`
   - This can either be a <LinkToLatestJsApiDocs slug="interfaces/sap_cloud_sdk_connectivity.Destination" name="destination object" /> which was already fetched or an <LinkToLatestJsApiDocs slug="interfaces/sap_cloud_sdk_connectivity.DestinationFetchOptions" name="object containing a destination name and an optional JWT" />
-- The `requestConfig` argument is of type <LinkToLatestJsApiDocs slug="types/sap_cloud_sdk_http_client.HttpRequestConfig" name="HttpRequestConfig" /> or <LinkToLatestJsApiDocs slug="types/sap_cloud_sdk_http_client.HttpRequestConfigWithOrigin" name="HttpRequestConfigWithOrigin" />.
+- The `requestConfig` argument is of type <LinkToLatestJsApiDocs slug="types/sap_cloud_sdk_http_client.HttpRequestConfig" name="HttpRequestConfig" />.
   - This parameter is optional
   - The default value is a `GET` request
 - The `httpRequestOptions` argument is of type `HttpRequestOptions`


### PR DESCRIPTION
## What Has Changed?

Updated docs to match [current implementation](https://github.com/SAP/cloud-sdk-js/blob/main/packages/http-client/src/http-client.ts#L351) of the function.

