### PR TITLE
Added Spring SecurityContext instructions

### DIFF
--- a/docs-java/features/multi-tenancy/thread-context.mdx
+++ b/docs-java/features/multi-tenancy/thread-context.mdx
@@ -100,12 +100,21 @@ public class AsynchronousConfiguration implements AsyncConfigurer {
 
 You can read more about the `@Async` functionality [here](https://www.baeldung.com/spring-async).
 
-:::tip
+:::tip Security Context
 The Spring `SecurityContext` can be propagated to `@Async` calls.
 Replace the above executor with this one:
 
 ```java
 new DelegatingSecurityContextExecutor(ThreadContextExecutors.getExecutor());
+```
+
+And add this dependency:
+
+```xml
+<dependency>
+    <groupId>org.springframework.security</groupId>
+    <artifactId>spring-security-core</artifactId>
+</dependency>
 ```
 
 :::

--- a/docs-java/features/multi-tenancy/thread-context.mdx
+++ b/docs-java/features/multi-tenancy/thread-context.mdx
@@ -79,16 +79,11 @@ Future runningTask = ThreadContextExecutors.submit(myTask);
 Operations that are submitted this way will be executed by a single instance of `ThreadContextExecutorService`.
 By default, this instance is based on a `CachedThreadPool`, which manages the concurrency internally.
 
-:::tip Spring Integration
-You can also use this functionality with Springs `@Async` annotation.
-Refer to the [dedicated section below](#spring-integration).
-:::
-
 ### Spring Integration
 
 You can conveniently integrate this functionality to work with Springs `@Async` annotation.
 
-Below configuration will ensure all methods annotated with `@Async` will have the `ThreadContext` available:
+The configuration below will ensure all methods annotated with `@Async` will have the `ThreadContext` available:
 
 ```java
 @EnableAsync
@@ -104,6 +99,16 @@ public class AsynchronousConfiguration implements AsyncConfigurer {
 ```
 
 You can read more about the `@Async` functionality [here](https://www.baeldung.com/spring-async).
+
+:::tip
+The Spring `SecurityContext` can be propagated to `@Async` calls.
+Replace the above executor with this one:
+
+```java
+new DelegatingSecurityContextExecutor(ThreadContextExecutors.getExecutor());
+```
+
+:::
 
 ### Passing on Other ThreadLocals
 


### PR DESCRIPTION
## What Has Changed?

Added new instructions to propagate the Spring `SecurityContext` to `@Async` calls.
- Removed a redundant tip
- Fixed grammar
- Added the new instructions in a tip

## Manual Checks?

- [x] Check spelling and grammar, e.g., using Grammarly.
- [x] Verify links still work, e.g., if `id` or the name of a file is changed.
- [x] Update the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js), e.g., if a feature is added.
