### PR TITLE
[Java] Update migration guide with deleted classes

### DIFF
--- a/docs-java/guides/4.0-upgrade.mdx
+++ b/docs-java/guides/4.0-upgrade.mdx
@@ -228,6 +228,21 @@ All deprecated API is removed With version 4 (exception being audit logging).
             <td>TenantAccessor.executeWithPrincipal</td>
             <td></td>
         </tr>
+        <tr>
+            <td>All classes in com.sap.cloud.sdk.s4hana.connectivity.rfc.servlet.response</td>
+            <td>-</td>
+            <td>Removed without replacement</td>
+        </tr>
+        <tr>
+            <td>All classes in package com.sap.cloud.sdk.cloudplatform.servlet.exception</td>
+            <td>-</td>
+            <td>Removed without replacement</td>
+        </tr>
+        <tr>
+            <td>All classes in package com.sap.cloud.sdk.cloudplatform.servlet.response</td>
+            <td>-</td>
+            <td>Removed without replacement</td>
+        </tr>
     </tbody>
 </table>
 


### PR DESCRIPTION
## What Has Changed?

With a [support issue](https://github.com/SAP/cloud-sdk/issues/1187), we realised that we [had removed](https://github.wdf.sap.corp/MA/sdk/pull/7088) some public legacy classes from version 4 without deprecating them.
This PR acknowledges that these classes were removed in version 4.

## Manual Checks?

- [x] Check spelling and grammar, e.g., using Grammarly.
- [x] Verify links still work, e.g., if `id` or the name of a file is changed.
- [x] ~Update the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js), e.g., if a feature is added.~
