### PR TITLE
chore: rename `actionImports` and `functionImports` to `operations`

### DIFF
--- a/docs-js/features/odata/common/batch/responses.mdx
+++ b/docs-js/features/odata/common/batch/responses.mdx
@@ -56,7 +56,7 @@ As function imports are not entity based, you obtain the response using the `res
 
 ```ts
 const {
-  functionImports: { getPdf }
+  operations: { getPdf }
 } = billingDocumentService();
 
 async function batchExample(billingDocument: string) {

--- a/docs-js/features/odata/common/batch/retrieve-request.mdx
+++ b/docs-js/features/odata/common/batch/retrieve-request.mdx
@@ -11,7 +11,7 @@ This service is an OData v2 service, but the syntax is the same for OData v2 and
 ```ts
 const {
   billingDocumentApi,
-  functionImports: { getPdf }
+  operations: { getPdf }
 } = billingDocumentService();
 
 async function batchExample(documentIds: string[]) {

--- a/docs-js/features/odata/v2/changeset-example.mdx
+++ b/docs-js/features/odata/v2/changeset-example.mdx
@@ -4,18 +4,18 @@ Since the function `deleteBomHeaderWithEcn()` changes data, it is included with 
 ```ts
 const {
   materialBomApi,
-  functionImports: { deleteBomHeaderWithEcn }
+  operations: { deleteBomHeaderWithEcn }
 } = billOfMaterialV2Service();
 
 async function batchExample(billOfMaterial: string) {
-  const functionImportRequest = deleteBomHeaderWithEcn({ billOfMaterial });
+  const functionRequestBuilder = deleteBomHeaderWithEcn({ billOfMaterial });
   const updateRequestBuilder = materialBomApi
     .requestBuilder()
     .update(materialBomApi.entityBuilder().fromJson({ billOfMaterial }));
 
   // Execute batch request with one changeset
   const batchResponses = await batch(
-    changeset(functionImportRequest, updateRequestBuilder)
+    changeset(functionRequestBuilder, updateRequestBuilder)
   ).execute(destination);
 
   // Get response for the changeset request

--- a/docs-js/features/odata/v2/request-builder.mdx
+++ b/docs-js/features/odata/v2/request-builder.mdx
@@ -7,7 +7,7 @@ The example below creates a function import request builder for the service oper
 
 ```ts
 const {
-  functionImports: { postGoodsIssue }
+  operations: { postGoodsIssue }
 } = warehouseOutboundDeliveryOrderService();
 
 postGoodsIssue({ outboundDeliveryOrder: 'order' }).execute(destination);

--- a/docs-js/features/odata/v4/changeset-example.mdx
+++ b/docs-js/features/odata/v4/changeset-example.mdx
@@ -4,18 +4,18 @@ Since the action `active()` changes data, it is included with other changing req
 ```ts
 const {
   materialsActiveApi,
-  actionImports: { activate }
+  operations: { activate }
 } = materialsService();
 
 async function batchExample(id: string) {
-  const actionImportRequestBuilder = activate({});
+  const actionRequestBuilder = activate({});
   const updateRequestBuilder = materialsActiveApi
     .requestBuilder()
     .update(materialsActiveApi.entityBuilder().fromJson({ id }));
 
   // Execute batch request with one changeset
   const batchResponses = await batch(
-    changeset(actionImportRequestBuilder, updateRequestBuilder)
+    changeset(actionRequestBuilder, updateRequestBuilder)
   ).execute(destination);
 
   // Get response for the changeset request

--- a/docs-js/features/odata/v4/request-builder.mdx
+++ b/docs-js/features/odata/v4/request-builder.mdx
@@ -33,14 +33,15 @@ entity
   .execute(destination);
 ```
 
-Unbound operations are generated into `actionImports` and `functionImports` respectively.
+Unbound actions and functions are generated into `operations`.
 
 The following code snippet shows the syntax for using them:
 
 ```ts
 const {
-  actionImports: { unboundActionWithArguments, unboundActionWithoutArguments },
-  functionImports: {
+  operations: {
+    unboundActionWithArguments,
+    unboundActionWithoutArguments,
     unboundFunctionWithArguments,
     unboundFunctionWithoutArguments
   }

--- a/docs-js_versioned_docs/version-v2/features/odata/common/batch/responses.mdx
+++ b/docs-js_versioned_docs/version-v2/features/odata/common/batch/responses.mdx
@@ -56,7 +56,7 @@ As function imports are not entity based, you obtain the response using the `res
 
 ```ts
 const {
-  functionImports: { getPdf }
+  operations: { getPdf }
 } = billingDocumentService();
 
 async function batchExample(billingDocument: string) {

--- a/docs-js_versioned_docs/version-v2/features/odata/common/batch/retrieve-request.mdx
+++ b/docs-js_versioned_docs/version-v2/features/odata/common/batch/retrieve-request.mdx
@@ -11,7 +11,7 @@ This service is an OData v2 service, but the syntax is the same for OData v2 and
 ```ts
 const {
   billingDocumentApi,
-  functionImports: { getPdf }
+  operations: { getPdf }
 } = billingDocumentService();
 
 async function batchExample(documentIds: string[]) {

--- a/docs-js_versioned_docs/version-v2/features/odata/v2/changeset-example.mdx
+++ b/docs-js_versioned_docs/version-v2/features/odata/v2/changeset-example.mdx
@@ -4,18 +4,18 @@ Since the function `deleteBomHeaderWithEcn` changes data, it is included with ot
 ```ts
 const {
   materialBomApi,
-  functionImports: { deleteBomHeaderWithEcn }
+  operations: { deleteBomHeaderWithEcn }
 } = billOfMaterialV2Service();
 
 async function batchExample(billOfMaterial: string) {
-  const functionImportRequest = deleteBomHeaderWithEcn({ billOfMaterial });
+  const functionRequestBuilder = deleteBomHeaderWithEcn({ billOfMaterial });
   const updateRequestBuilder = materialBomApi
     .requestBuilder()
     .update(materialBomApi.entityBuilder().fromJson({ billOfMaterial }));
 
   // Execute batch request with one changeset
   const batchResponses = await batch(
-    changeset(functionImportRequest, updateRequestBuilder)
+    changeset(functionRequestBuilder, updateRequestBuilder)
   ).execute(destination);
 
   // Get response for the changeset request

--- a/docs-js_versioned_docs/version-v2/features/odata/v2/request-builder.mdx
+++ b/docs-js_versioned_docs/version-v2/features/odata/v2/request-builder.mdx
@@ -7,7 +7,7 @@ The example below creates a function import request builder for the service oper
 
 ```ts
 const {
-  functionImports: { postGoodsIssue }
+  operations: { postGoodsIssue }
 } = warehouseOutboundDeliveryOrderService();
 
 postGoodsIssue({ outboundDeliveryOrder: 'order' }).execute(destination);

--- a/docs-js_versioned_docs/version-v2/features/odata/v4/changeset-example.mdx
+++ b/docs-js_versioned_docs/version-v2/features/odata/v4/changeset-example.mdx
@@ -4,18 +4,18 @@ Since the action `active` changes data, it is included with other changing reque
 ```ts
 const {
   materialsActiveApi,
-  actionImports: { activate }
+  operations: { activate }
 } = materialsService();
 
 async function batchExample(id: string) {
-  const actionImportRequestBuilder = activate({});
+  const actionRequestBuilder = activate({});
   const updateRequestBuilder = materialsActiveApi
     .requestBuilder()
     .update(materialsActiveApi.entityBuilder().fromJson({ id }));
 
   // Execute batch request with one changeset
   const batchResponses = await batch(
-    changeset(actionImportRequestBuilder, updateRequestBuilder)
+    changeset(actionRequestBuilder, updateRequestBuilder)
   ).execute(destination);
 
   // Get response for the changeset request

--- a/docs-js_versioned_docs/version-v2/features/odata/v4/request-builder.mdx
+++ b/docs-js_versioned_docs/version-v2/features/odata/v4/request-builder.mdx
@@ -33,14 +33,15 @@ entity
   .execute(destination);
 ```
 
-Unbound operations are generated into `actionImports` and `functionImports` respectively.
+Unbound actions and functions are generated into `operations`.
 
 The following code snippet shows the syntax for using them:
 
 ```ts
 const {
-  actionImports: { unboundActionWithArguments, unboundActionWithoutArguments },
-  functionImports: {
+  operations: {
+    unboundActionWithArguments,
+    unboundActionWithoutArguments,
     unboundFunctionWithArguments,
     unboundFunctionWithoutArguments
   }


### PR DESCRIPTION
In this PR I renamed the `actionImports` and `functionImports` to `operations`.