### PR TITLE
Add release notes for version 2.13.0 and 2.12.1

### DIFF
--- a/docs-js_versioned_docs/version-v2/release-notes.mdx
+++ b/docs-js_versioned_docs/version-v2/release-notes.mdx
@@ -20,6 +20,37 @@ import LicenseBadge from '@site/src/sap/sdk-js/LicenseBadge';
 <!-- vale off -->
 <!-- This line is used for our release notes automation -->
 
+## 2.13.0 [Core Modules] - January 06, 2023
+
+**API Reference:** [2.13.0](https://sap.github.io/cloud-sdk/api/2.13.0)
+
+### Compatibility Notes
+
+- [generator] The SAP Cloud SDK does not differentiate between function imports and action imports anymore. Therefore the `actionImports` and `functionImports` exposed in generated services are now deprecated and replaced by `options`. (aa0cf4820)
+- [openapi-generator] The options `licenseInPackageJson` and `versionInPackageJson` are deprecated. If you want to set the license or version in your generated `package.json` file, use the `include` option to add a custom `package.json` instead. (aa0cf4820)
+
+### Fixed Issues
+
+- [odata-v2] Allow to update OData v2 entities to `null`. Fixes [3204](https://github.com/SAP/cloud-sdk-js/issues/3204).
+  - @sap-cloud-sdk/connectivity@2.13.0
+  - @sap-cloud-sdk/http-client@2.13.0
+  - @sap-cloud-sdk/odata-common@2.13.0
+  - @sap-cloud-sdk/util@2.13.0 (83eee1a3b)
+
+## 2.12.1 [Core Modules] - January 03, 2023
+
+**API Reference:** [2.12.1](https://sap.github.io/cloud-sdk/api/2.12.1)
+
+### Improvements
+
+- [connectivity] Update `jsonwebtoken` to 9.0.0 due to several security vulnerabilities:
+
+  - [CVE-2022-23529 (CVSS 9.8)](https://github.com/advisories/GHSA-27h2-hvpr-p74q)
+  - [CVE-2022-23539 (CVSS 8.1)](https://github.com/advisories/GHSA-8cf7-32gw-wr33)
+  - [CVE-2022-23540 (CVSS 9.8)](https://github.com/advisories/GHSA-qwph-4952-7xr6)
+  - [CVE-2022-23541 (CVSS 9.8)](https://github.com/advisories/GHSA-hjrf-2m68-5959)
+  - @sap-cloud-sdk/util@2.12.1 (466cbec36)
+
 ## 2.12.0 [Core Modules] - December 07, 2022
 
 **API Reference:** [2.12.0](https://sap.github.io/cloud-sdk/api/2.12.0)


### PR DESCRIPTION
Turns out our automation adds the release notes not to the page that is visible by default