### PR TITLE
chore: Remove the (and TypeScrip)

### DIFF
--- a/src/pages/components/HomepageFeatures.js
+++ b/src/pages/components/HomepageFeatures.js
@@ -34,7 +34,7 @@ const FeatureList = [
     ),
     description: (
       <div data-nosnippet>
-        The SAP Cloud SDK for JavaScript (and TypeScript) helps you build
+        The SAP Cloud SDK for JavaScript helps you build
         cloud-based apps and extensions to SAP solutions using the power and
         flexibility of Node.js and its ecosystem.
         <br />

--- a/src/pages/components/HomepageFeatures.js
+++ b/src/pages/components/HomepageFeatures.js
@@ -34,9 +34,9 @@ const FeatureList = [
     ),
     description: (
       <div data-nosnippet>
-        The SAP Cloud SDK for JavaScript helps you build
-        cloud-based apps and extensions to SAP solutions using the power and
-        flexibility of Node.js and its ecosystem.
+        The SAP Cloud SDK for JavaScript helps you build cloud-based apps and
+        extensions to SAP solutions using the power and flexibility of Node.js
+        and its ecosystem.
         <br />
         <a href="docs/js/getting-started">
           Get started with the SDK for JavaScript


### PR DESCRIPTION
Relates: https://github.com/SAP/cloud-sdk-backlog/issues/1022

As discussed here: https://github.com/SAP/cloud-sdk-backlog/issues/1022 we are the JavaScript SDK. So we removed the (and TypeScript) consistently.