### PR TITLE
Motivate `ExecutorService#invokeAll`

### DIFF
--- a/docs-java/features/multi-tenancy/thread-context.mdx
+++ b/docs-java/features/multi-tenancy/thread-context.mdx
@@ -87,7 +87,6 @@ ThreadContextExecutorService executor = ThreadContextExecutors.getExecutor();
 List<Future> runningTasks = executor.invokeAll(tasks);
 ```
 
-
 ### Spring Integration
 
 You can conveniently integrate this functionality to work with Springs `@Async` annotation.

--- a/docs-java/features/multi-tenancy/thread-context.mdx
+++ b/docs-java/features/multi-tenancy/thread-context.mdx
@@ -79,6 +79,15 @@ Future runningTask = ThreadContextExecutors.submit(myTask);
 Operations that are submitted this way will be executed by a single instance of `ThreadContextExecutorService`.
 By default, this instance is based on a `CachedThreadPool`, which manages the concurrency internally.
 
+For executing multiple asynchronous operations we recommend the following:
+
+```java
+List<Callable> tasks;
+ThreadContextExecutorService executor = ThreadContextExecutors.getExecutor();
+List<Future> runningTasks = executor.invokeAll(tasks);
+```
+
+
 ### Spring Integration
 
 You can conveniently integrate this functionality to work with Springs `@Async` annotation.


### PR DESCRIPTION
## What Has Changed?

Latest troubleshooting session with a customer resulted in the clear recommendation for `ExecutorService` to use `invokeAll`, instead of looping via `submit`.

## Manual Checks?

- [x] Check spelling and grammar, e.g., using Grammarly.
- [x] Verify links still work, e.g., if `id` or the name of a file is changed.
- [x] Update the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js), e.g., if a feature is added.
