### PR TITLE
chore: remove `VALUE_IS_UNDEFINED` from OData `servicePath` docs

### DIFF
--- a/docs-js/features/odata/execute-odata-request.mdx
+++ b/docs-js/features/odata/execute-odata-request.mdx
@@ -222,8 +222,8 @@ If you want to set a query parameter in quotes (e.g. `language='en'`) you will h
 
 ### Setting a Custom Service Path
 
-If a service specification contains a specification for the `servicePath`, the SAP Cloud SDK generator generates an OData client with a default service path according to the specification (typically `'/sap/opus/data/sap/'` for SAP S/4HANA services).
-When there is no such path defined in the specification, it can be manually set in the `service-mapping.json`.
+If a service specification contains a specification for the `servicePath`, the SAP Cloud SDK generator generates an OData client with a default service path according to the specification (typically `'/sap/opu/odata/sap/'` for SAP S/4HANA services).
+When there is no such path defined in the specification, it can be manually set in the `options-per-service.json`.
 It can also be adjusted per request by using the `withCustomServicePath()` method:
 
 ```ts

--- a/docs-js/features/odata/generate-odata-client.mdx
+++ b/docs-js/features/odata/generate-odata-client.mdx
@@ -62,11 +62,12 @@ This file is used for customizing subdirectory naming and contains a mapping fro
 - `directoryName`: the name of the subdirectory the client code will be generated into.
 - `npmPackageName`: the name of the npm package, if a `package.json` file is generated.
   This information is optional.
-- `servicePath`: the URL path to be prepended before every request.
-  The url is read from the either the EDMX or Swagger file, if available.
-  Client generation will fail if a service path cannot be determined.
-  To prevent failure, set the `--skipValidation` option to true, in which case, `servicePath` value is set to `/` and a warn message is logged.
-  Or, specify the `servicePath` in the `options-per-service.json` file manually and re-generate the client.
+- `servicePath`: the URL path to be prepended before every request (e.g. `'/sap/opu/odata/sap/'` for SAP S/4HANA services).
+  The SDK will try to determine this value from either the EDMX or Swagger file.
+  However, if automatic determination fails, client generation will also fail.
+  In that case, to generate a client successfully, you can do either of the following:
+  - Manually specify the `servicePath` in the `options-per-service.json` file and re-generate the client, or
+  - Set the `--skipValidation` option to true, in which case, the SDK will set the `servicePath` value to `/` and log a warning message.
 
 This information can be adjusted manually and ensure that every run of the generator produces the same names for the generation.
 

--- a/docs-js/features/odata/generate-odata-client.mdx
+++ b/docs-js/features/odata/generate-odata-client.mdx
@@ -54,18 +54,19 @@ This will generate OData clients for all your service specifications.
 
 An `options-per-service.json` file is created using the `--optionsPerService` option.
 
-- When set to a directory path, a `options-per-service.json` is read from or created in the given directory.
+- When set to a directory path, an `options-per-service.json` file is read from or created in the given directory.
 - When set to a file path, the file is read or created with the given name.
 
 This file is used for customizing subdirectory naming and contains a mapping from the original file name to the following information:
 
 - `directoryName`: the name of the subdirectory the client code will be generated into.
-- `servicePath`: the URL path to be prepended before every request.
-  By default, this is read from the EDMX file, if available.
-  Otherwise, the value will be set as `VALUE_IS_UNDEFINED`, and an error will be logged.
-  In this case, you can specify `servicePath` in the `options-per-service.json` file manually and re-generate again.
 - `npmPackageName`: the name of the npm package, if a `package.json` file is generated.
   This information is optional.
+- `servicePath`: the URL path to be prepended before every request.
+  The url is read from the either the EDMX or Swagger file, if available.
+  Client generation will fail if a service path cannot be determined.
+  To prevent failure, set the `--skipValidation` option to true, in which case, `servicePath` value is set to `/` and a warn message is logged.
+  Or, specify the `servicePath` in the `options-per-service.json` file manually and re-generate the client.
 
 This information can be adjusted manually and ensure that every run of the generator produces the same names for the generation.
 

--- a/docs-js/tutorials/getting-started/2-execute-odata-request.mdx
+++ b/docs-js/tutorials/getting-started/2-execute-odata-request.mdx
@@ -106,7 +106,7 @@ Steps:
 2. Create a folder `service-specifications` at the root of the project.
 3. Download the EDMX file for the business partner service in the [SAP API Business Hub](https://api.sap.com/api/API_BUSINESS_PARTNER/overview).
 4. Copy the `API_BUSINESS_PARTNER.edmx` file into the `service-specifications` folder.
-5. Create a `service-mapping.json` file in the `service-specifications` folder with the following content:
+5. Create a `options-per-service.json` file in the `service-specifications` folder with the following content:
 
    ```json
    {
@@ -121,7 +121,7 @@ Steps:
 6. Generate the `BusinessPartner` service.
 
    ```bash
-   npx generate-odata-client --inputDir service-specifications --outputDir services
+   npx generate-odata-client --inputDir service-specifications --outputDir services --optionsPerService service-specifications/options-per-service.json
    ```
 
 The generated client library is in `services/business-partner-service`.


### PR DESCRIPTION
## What Has Changed?

Update servicePath docs after removing VALUE_IS_UNDEFINED

## Manual Checks?

- [ ] Check spelling and grammar, e.g., using Grammarly.
- [ ] Verify links still work, e.g., if `id` or the name of a file is changed.
- [ ] Update the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js), e.g., if a feature is added.
