### PR TITLE
chore: change servicePath docs to basePath

### DIFF
--- a/docs-js/features/odata/execute-odata-request.mdx
+++ b/docs-js/features/odata/execute-odata-request.mdx
@@ -222,20 +222,8 @@ If you want to set a query parameter in quotes (e.g. `language='en'`) you will h
 
 ### Setting a Custom Service Path
 
-If a service specification contains a specification for the `servicePath`, the SAP Cloud SDK generator generates an OData client with a default service path according to the specification (typically `'/sap/opu/odata/sap/'` for SAP S/4HANA services).
+If a service specification contains a specification for the `basePath`, the SAP Cloud SDK generator generates an OData client with a default service path according to the specification (typically `'/sap/opu/odata/sap/'` for SAP S/4HANA services).
 When there is no such path defined in the specification, it can be manually set in the `options-per-service.json`.
-It can also be adjusted per request by using the `withCustomServicePath()` method:
-
-```ts
-const { myEntityApi } = myEntityService();
-myEntityApi
-  .requestBuilder()
-  .getAll()
-  .withCustomServicePath('my/custom/service/path');
-```
-
-This will add the custom service path to your request.
-Executing the example request above against a destination with URL `https://my.s4-system.com` would result in a request against something like this: `https://my.s4-system.com/my/custom/service/path/MyEntity`.
 
 ### Setting a Custom Request Configuration
 

--- a/docs-js/features/odata/generate-odata-client.mdx
+++ b/docs-js/features/odata/generate-odata-client.mdx
@@ -62,12 +62,12 @@ This file is used for customizing subdirectory naming and contains a mapping fro
 - `directoryName`: the name of the subdirectory the client code will be generated into.
 - `npmPackageName`: the name of the npm package, if a `package.json` file is generated.
   This information is optional.
-- `servicePath`: the URL path to be prepended before every request (e.g. `'/sap/opu/odata/sap/'` for SAP S/4HANA services).
+- `basePath`: the URL path to be prepended before every request (e.g. `'/sap/opu/odata/sap/'` for SAP S/4HANA services).
   The SDK will try to determine this value from either the EDMX or Swagger file.
   However, if automatic determination fails, client generation will also fail.
   In that case, to generate a client successfully, you can do either of the following:
-  - Manually specify the `servicePath` in the `options-per-service.json` file and re-generate the client, or
-  - Set the `--skipValidation` option to true, in which case, the SDK will set the `servicePath` value to `/` and log a warning message.
+  - Manually specify the `basePath` in the `options-per-service.json` file and re-generate the client, or
+  - Set the `--skipValidation` option to true, in which case, the SDK will set the `basePath` value to `/` and log a warning message.
 
 This information can be adjusted manually and ensure that every run of the generator produces the same names for the generation.
 
@@ -77,7 +77,7 @@ Example:
 {
   "MyService": {
     "directoryName": "my-service",
-    "servicePath": "/odata/v2",
+    "basePath": "/odata/v2",
     "npmPackageName": "my-service"
   }
 }

--- a/docs-js/tutorials/getting-started/2-execute-odata-request.mdx
+++ b/docs-js/tutorials/getting-started/2-execute-odata-request.mdx
@@ -112,7 +112,7 @@ Steps:
    {
      "API_BUSINESS_PARTNER": {
        "directoryName": "business-partner-service",
-       "servicePath": "/sap/opu/odata/sap/API_BUSINESS_PARTNER",
+       "basePath": "/sap/opu/odata/sap/API_BUSINESS_PARTNER",
        "npmPackageName": "business-partner-service"
      }
    }


### PR DESCRIPTION
## What Has Changed?

Changes the docs relating to the removed `servicePath` parameter to `basePath`.
Also removes a docs section regarding a method that doesn't exist.

## Manual Checks?

- [x] Check spelling and grammar, e.g., using Grammarly.
- [x] Verify links still work, e.g., if `id` or the name of a file is changed.
- [x] Update the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js), e.g., if a feature is added.
