### PR TITLE
Fix typo in TS Multi-Tenancy Guide

### DIFF
--- a/docs-js_versioned_docs/version-v2/tutorials/multi-tenant-application.mdx
+++ b/docs-js_versioned_docs/version-v2/tutorials/multi-tenant-application.mdx
@@ -423,7 +423,7 @@ const appRouterName = 'approuter';
 export async function subscribeRoute(req: Request, res: Response) {
   try {
     const subscribedSubdomain = req.body.subscribedSubdomain;
-    const subscriberRoute = `https://route-prefix-${subscribedSubdomain}.${getLandscape()`;
+    const subscriberRoute = `https://route-prefix-${subscribedSubdomain}.${getLandscape()}`;
     logger.info(`subscribe: ${subscriberRoute}`);
 
     const guids = await getCfGuids(appRouterName);


### PR DESCRIPTION
## What Has Changed?

Add missing `}` in the TS Multi-Tenancy guide.

## Manual Checks?

- [x] Check spelling and grammar, e.g., using Grammarly.
- [x] Verify links still work, e.g., if `id` or the name of a file is changed.
- [x] Update the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js), e.g., if a feature is added.
