### PR TITLE
Js oData common: Serialize entity-to-json capability

### DIFF
--- a/docs-js/features/odata/common/entity/index.jsx
+++ b/docs-js/features/odata/common/entity/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import CustomFieldsContent from './custom-fields.mdx';
 import CustomDeSerializersContent from './custom-de-serializers.mdx';
 import DeserializeEntityContent from './deserialize-entity.mdx';
+import SerializeEntityContent from './serialize-entity.mdx';
 import EntityBuilderContent from './entity-builder.mdx';
 import EntityContent from './entity.mdx';
 import FromJsonContent from './from-json.mdx';
@@ -16,6 +17,10 @@ export function CustomDeSerializers() {
 
 export function DeserializeEntity() {
   return <DeserializeEntityContent />;
+}
+
+export function SerializeEntity() {
+  return <SerializeEntityContent />;
 }
 
 export function EntityBuilder() {

--- a/docs-js/features/odata/common/entity/serialize-entity.mdx
+++ b/docs-js/features/odata/common/entity/serialize-entity.mdx
@@ -1,0 +1,38 @@
+Other rare cases will bring you to the situation where you want to serialize your Entity back to the oData structure you did receive before.
+If you need to transform it from your SAP Cloud SDK representation of an entity back to a oData representation,
+you can use the `executeRaw()` functionality directly within your original request or
+you can serialize the SDK representation / entity by using the `serializeEntity` function.
+This function is part of the common oData service and has to be imported from the SAP Cloud SDK `odata-common` package.
+
+```ts
+import {
+  entitySerializer
+} from '@sap-cloud-sdk/odata-common';
+import { businessPartnerService } from './generated/business-partner-service';
+
+const { businessPartnerApi } = businessPartnerService();
+
+const deserializedEntity = businessPartnerApi
+  .entityBuilder()
+  .firstName('Peter')
+  .lastName('Pan')
+  .toBusinessPartnerAddress([
+    businessPartnerAddressApi.entityBuilder().country('Neverland').build()
+  ])
+  .build();
+
+const serializedEntity = entitySerializer(
+  businessPartnerApi.deSerializers
+).serializeEntity(deserializedEntity, businessPartnerApi);
+
+console.log(serializedEntity); 
+=> {
+  FirstName: 'Peter',
+  LastName: 'Pan',
+  to_BusinessPartnerAddress: [
+    {
+      Country: 'Neverland'
+    }
+  ]
+}
+```

--- a/docs-js/features/odata/odata-v2-client.mdx
+++ b/docs-js/features/odata/odata-v2-client.mdx
@@ -20,6 +20,7 @@ import {
   CustomFields,
   CustomDeSerializers,
   DeserializeEntity,
+  SerializeEntity,
   Entity,
   EntityBuilder,
   FromJson
@@ -88,6 +89,10 @@ For more details on **how to execute requests** using a OData type-safe client b
 ### Deserialize an OData JSON Response to an Entity
 
 <DeserializeEntity />
+
+### Serialize an Entity to a OData JSON (Response)
+
+<SerializeEntity />
 
 ### Customize (De-)Serialization
 


### PR DESCRIPTION
## What Has Changed?

Added additional documentation to explain how to serialize an SDK-Entity to get back a oData-JSON representation. Before, it's only about `deSerialization`. Now it does explain how to serialize as well. This is necessary, as the functionality is part of `odata-common` and not part of v2 / v4 packages like it is with `deSerialization`

## Manual Checks?

- [ ] Check spelling and grammar, e.g., using Grammarly.
- [ ] Verify links still work, e.g., if `id` or the name of a file is changed.
- [ ] Update the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js), e.g., if a feature is added.
