### PR TITLE
chore: Make v3 docs the default

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -235,16 +235,15 @@ module.exports = {
         editUrl: 'https://github.com/SAP/cloud-sdk/edit/main',
         routeBasePath: 'docs/js',
         sidebarPath: require.resolve('./sidebarsDocsJs.js'),
-        lastVersion: 'v2',
+        lastVersion: 'current',
         versions: {
           current: {
             label: 'v3',
-            path: 'v3',
-            banner: 'unreleased',
             badge: false
           },
           v2: {
             label: 'v2',
+            path: 'v2',
             banner: 'none',
             badge: false
           },


### PR DESCRIPTION
## What Has Changed?

The PR switches the default path for docs to v3

## Manual Checks?

- [ ] Check spelling and grammar, e.g., using Grammarly.
- [ ] Verify links still work, e.g., if `id` or the name of a file is changed.
- [ ] Update the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js), e.g., if a feature is added.
