### PR TITLE
[JS] chore: Remove removed generator options from js docs

### DIFF
--- a/docs-js/features/odata/generate-odata-client.mdx
+++ b/docs-js/features/odata/generate-odata-client.mdx
@@ -139,7 +139,6 @@ const generatorConfig = {
   packageJson: false,
   /* optional:
     optionsPerService: 'test/directory',
-    changelogFile: 'test/directory',
     include: 'glob of files to include'
   */
 };

--- a/docs-js/features/odata/generate-odata-client.mdx
+++ b/docs-js/features/odata/generate-odata-client.mdx
@@ -133,13 +133,10 @@ const outputDir = 'odata-client';
 const generatorConfig = {
   overwrite: true,
   transpile: false,
-  useSwagger: false,
   readme: false,
   clearOutputDir: true,
   generateTypedocJson: false,
   packageJson: false,
-  sdkAfterVersionScript: false,
-  s4hanaCloud: false
   /* optional:
     optionsPerService: 'test/directory',
     changelogFile: 'test/directory',

--- a/docs-js/features/odata/generate-odata-client.mdx
+++ b/docs-js/features/odata/generate-odata-client.mdx
@@ -136,7 +136,7 @@ const generatorConfig = {
   readme: false,
   clearOutputDir: true,
   generateTypedocJson: false,
-  packageJson: false,
+  packageJson: false
   /* optional:
     optionsPerService: 'test/directory',
     include: 'glob of files to include'


### PR DESCRIPTION
## What Has Changed?

With this PR, the options which we removed or have hidden in version 3 are also removed from the usage example.