### PR TITLE
Fix: Update the INFO Box on top of the Release Notes

### DIFF
--- a/docs-java/release-notes.mdx
+++ b/docs-java/release-notes.mdx
@@ -36,7 +36,8 @@ It will help you:
 
 :::info Update to the SAP Cloud SDK v4
 
-Version 3.x of the SAP Cloud SDK for Java is now in maintenance and receives security fixes only.
+Version 3.x of the SAP Cloud SDK for Java has reached its end of life.
+As a consequence, there won't be any updates to the SAP Cloud SDK version 3 - not even security fixes.
 To continue using the latest features outlined in the release notes below, please [update to **the SAP Cloud SDK v4**](/docs/java/guides/4.0-upgrade).
 
 :::


### PR DESCRIPTION
## What Has Changed?

This PR updates the `:::info` box on top of the release notes to now correctly say that Cloud SDK version 3 has reached end of life status and won't receive any updates.

## Manual Checks?

- [x] Check spelling and grammar, e.g., using Grammarly.
- [x] ~Verify links still work, e.g., if `id` or the name of a file is changed.~
- [x] ~Update the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js), e.g., if a feature is added.~
