### PR TITLE
Add Documentation for the `ServiceBindingDestinationLoader` API

### DIFF
--- a/docs-java/features/connectivity/destinations.mdx
+++ b/docs-java/features/connectivity/destinations.mdx
@@ -858,7 +858,7 @@ private HttpDestination getDestinationServiceDestination()
         ServiceBindingDestinationOptions.builder(BindableService.DESTINATION, destinationServiceBinding).build();
 
     // 3. convert the ServiceBinding into an HttpDestination
-    return new DelegatingServiceBindingDestinationLoader().tryGetDestination(options).getOrNull();
+    return ServiceBindingDestinationLoader.defaultLoaderChain().tryGetDestination(options);
 }
 ```
 
@@ -889,5 +889,5 @@ This extensibility is based around the idea of having various dependencies, each
 There is, for example, the [connectivity-oauth](https://search.maven.org/search?q=g:com.sap.cloud.sdk.cloudplatform%2BAND%2Ba:connectivity-oauth) module, which provides an implementation of the `ServiceBindingDestinationLoader` interface that is capable of creating OAuth2 based `HttpDestination` instances.
 By customizing their dependecies, applications are able to easily choose the capabilities that fit their use case.
 
-Things are tied together using the `DelegatingServiceBindingDestinationLoader` class, which (by default) searches for available `ServiceBindingDestinationLoader` implementations on the classpath and delegates the actual transformation logic.
-This class can be leveraged as shown above.
+Things are tied together using the _loader chain_ concept, which (by default) searches for available `ServiceBindingDestinationLoader` implementations on the classpath and delegates the actual transformation logic.
+A default implementation of that concept can be leveraged as demonstrated above.

--- a/docs-java/features/connectivity/destinations.mdx
+++ b/docs-java/features/connectivity/destinations.mdx
@@ -855,10 +855,22 @@ private HttpDestination getDestinationServiceDestination()
     // 2. create ServiceBindingDestinationOptions
     final ServiceBindingDestinationOptions
         options =
-        ServiceBindingDestinationOptions.builder(BindableService.DESTINATION, destinationServiceBinding).build();
+        ServiceBindingDestinationOptions
+            .builder()
+            .bindableService(BindableService.DESTINATION)
+            .serviceBinding(destinationServiceBinding)
+            .build();
 
     // 3. convert the ServiceBinding into an HttpDestination
-    return ServiceBindingDestinationLoader.defaultLoaderChain().tryGetDestination(options);
+    final Try<HttpDestination>
+        maybeDestination =
+        ServiceBindingDestinationLoader.defaultLoaderChain().tryGetDestination(options);
+
+    if( maybeDestination.isSuccess() ) {
+        return maybeDestination.get();
+    }
+
+    throw new IllegalStateException(maybeDestination.getCause());
 }
 ```
 
@@ -869,8 +881,7 @@ The snippet above consists of three steps:
 As the name of the API suggests, a `ServiceBinding` instance is required.
 Getting such an instance can be achieved in different ways.
 One could, as demonstrated, use the `DefaultServiceBindingAccessor` to load all `ServiceBinding` instance that are available to the application.
-Alternatively, one could also create a `ServiceBinding` instance progammatically.
-This might be especially handy when testing.
+Alternatively, one could also create a `ServiceBinding` instance progammatically - this might be especially handy when testing.
 
 2. _Create ServiceBindingDestinationOptions_
 

--- a/docs-java/features/connectivity/destinations.mdx
+++ b/docs-java/features/connectivity/destinations.mdx
@@ -716,6 +716,15 @@ The information there also applies to the SAP Cloud SDK for Java.
 
 #### Skip Destination Creation Step for Certain Authentication Types on Cloud Foundry
 
+:::tip SUCCESSOR API PLANNED
+
+The feature described in the section below is about to be replaced with a new API.
+For the time being, the described approach is still fully functional and may be used without further limitations.
+Starting from the next major version of the SAP Cloud SDK (version 5), however, we recommend switching to the new `ServiceBindingDestinationLoader` API.
+Please refer to the [this section](#transform-servicebindings-into-httpdestinations) for more details.
+
+:::
+
 For certain authentication types i.e. `NoAuthentication`, `OAuth2ClientCredentials` and `OAuth2UserTokenExchange` there is an API that eliminates the need to manually create a destination in the CF account for connecting to services.
 
 Example:
@@ -790,3 +799,76 @@ cf ssh app-name -L proxy-port:proxy-host:proxy-port
 :::success Ready
 Now your local setup is ready to consume an On-premise HTTP destination.
 :::
+
+## Transform ServiceBindings into HttpDestinations
+
+:::danger BETA Feature
+
+The feature described in the following section is still under active development.
+Therefore, breaking changes might happen at any time.
+It is planned to have a production-ready version of this feature in the next major release of the SAP Cloud SDK (version 5).
+
+:::
+
+The SAP Cloud SDK offers an API to convert a given [ServiceBinding](https://github.com/SAP/btp-environment-variable-access/wiki/Fundamentals#service-binding) into an `HttpDestination` - regardless of the concrete environment the application is running in.
+This API is called the `ServiceBindingDestinationLoader` API and is going to replace the known `ScpCfServiceDestinationLoader` utility class.
+
+It can be used as shown below:
+
+```java
+private HttpDestination getDestinationServiceDestination()
+{
+    // 1. get the ServiceBinding
+    final ServiceBinding
+        destinationServiceBinding =
+        DefaultServiceBindingAccessor
+            .getInstance()
+            .getServiceBindings()
+            .stream()
+            .filter(binding -> "destination".equalsIgnoreCase(binding.getServiceName().orElse(null)))
+            .findFirst()
+            .orElse(null);
+
+    if( destinationServiceBinding == null ) {
+        return null;
+    }
+
+    // 2. create ServiceBindingDestinationOptions
+    final ServiceBindingDestinationOptions
+        options =
+        ServiceBindingDestinationOptions.builder(BindableService.DESTINATION, destinationServiceBinding).build();
+
+    // 3. convert the ServiceBinding into an HttpDestination
+    return new DelegatingServiceBindingDestinationLoader().tryGetDestination(options).getOrNull();
+}
+```
+
+The snippet above consists of three steps:
+
+1. _Get a ServiceBinding_
+
+As the name of the API suggests, a `ServiceBinding` instance is required.
+Getting such an instance can be achieved in different ways.
+One could, as demonstrated, use the `DefaultServiceBindingAccessor` to load all `ServiceBinding` instance that are available to the application.
+Alternatively, one could also create a `ServiceBinding` instance progammatically.
+This might be especially handy when testing.
+
+2. _Create ServiceBindingDestinationOptions_
+
+The `ServiceBindingDestinationLoader` interface defines just a single method: `Try<HttpDestination> tryGetDestination(ServiceBindingDestinationOptions)`.
+That said, it is obvious that the provided `ServiceBindingDestinationOptions` instance must contain all information that are required to execute the transformation.
+This includes:
+
+- A `BindableService` instance, which determines the service we are trying to connect to.
+- A `ServiceBinding` instance that should be transformed.
+- Optionally, a `OnBehalfOf`, which determines the tenant that should be used for the connection. If no explicit `OnBehalfOf` is provided, the default value (`TECHNICAL_USER_CURRENT_TENANT`) will be used.
+
+3. _Convert the ServiceBinding into an HttpDestination_
+
+The implementation around the `ServiceBindingDestinationLoader` interface is designed to be modular and, therefore, extensible.
+This extensibility is based around the idea of having various dependencies, each fulfilling one specific purpose.
+There is, for example, the [connectivity-oauth](https://search.maven.org/search?q=g:com.sap.cloud.sdk.cloudplatform%2BAND%2Ba:connectivity-oauth) module, which provides an implementation of the `ServiceBindingDestinationLoader` interface that is capable of creating OAuth2 based `HttpDestination` instances.
+By customizing their dependecies, applications are able to easily choose the capabilities that fit their use case.
+
+Things are tied together using the `DelegatingServiceBindingDestinationLoader` class, which (by default) searches for available `ServiceBindingDestinationLoader` implementations on the classpath and delegates the actual transformation logic.
+This class can be leveraged as shown above.


### PR DESCRIPTION
## ⚠️ WAIT UNTIL VERSION `4.16.0` IS AVAILABLE BEFORE MERGING ⚠️

## What Has Changed?

This PR adds documentation for the new `ServiceBindingDestinationLoader` API, which is about to be released with the next minor version of the SAP Cloud SDK for Java.

## Manual Checks?

- [x] Check spelling and grammar, e.g., using Grammarly.
- [x] Verify links still work, e.g., if `id` or the name of a file is changed.
- [x] ~Update the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js), e.g., if a feature is added.~
