### PR TITLE
Update how-to-add-resilience.mdx

### DIFF
--- a/docs-js/guides/how-to-add-resilience.mdx
+++ b/docs-js/guides/how-to-add-resilience.mdx
@@ -72,7 +72,7 @@ You apply the resilience by adding it to your request as discussed in the [middl
 import { executeHttpRequest } from '@sap-cloud-sdk/http-client';
 import { myService } from './generated-client';
 
-executeHttpRequest(myDestination, { middleware: resilience() });
+executeHttpRequest(myDestination, { middleware: [resilience()] });
 
 const { myApi } = myService();
 myApi.getAll().middleware(resilience()).execute(myDestination);


### PR DESCRIPTION
Using the resilience middleware in SAP Cloud SDK for JS was incorrectly documented, when using it with `executeHttpRequest()`.

Relates to https://github.com/SAP/cloud-sdk-js/issues/3941