### PR TITLE
Remove indicators to deprecated OData VDM based modules

### DIFF
--- a/docs-java/features/odata/v2-client.mdx
+++ b/docs-java/features/odata/v2-client.mdx
@@ -23,7 +23,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 To leverage the type-safe OData v2 client, you need to add following dependencies to the `dependencies` section of your `pom.xml`:
 
-<Tabs groupId="odataClientType" defaultValue="PregeneratedCloud" values={[ { label: 'Pregenerated Clients (Cloud)', value: 'PregeneratedCloud' }, { label: 'Pregenerated Clients (On-Premise)', value: 'PregeneratedOnPremise' }, { label: 'Self Generated Clients', value: 'Selfgenerated' } ]}>
+<Tabs groupId="odataClientType" defaultValue="Selfgenerated" values={[ { label: 'Self Generated Clients', value: 'Selfgenerated' } ]}>
 
 <TabItem value="Selfgenerated">
 
@@ -46,27 +46,6 @@ To leverage the type-safe OData v2 client, you need to add following dependencie
 
 </TabItem>
 
-<TabItem value="PregeneratedCloud">
-
-```xml
-<dependency>
-    <groupId>com.sap.cloud.sdk.s4hana</groupId>
-    <artifactId>s4hana-api-odata</artifactId>
-</dependency>
-```
-
-</TabItem>
-
-<TabItem value="PregeneratedOnPremise">
-
-```xml
-<dependency>
-    <groupId>com.sap.cloud.sdk.s4hana</groupId>
-    <artifactId>s4hana-api-odata-onpremise</artifactId>
-</dependency>
-```
-
-</TabItem>
 </Tabs>
 
 :::tip Discover services on the SAP Business Accelerator Hub

--- a/docs-java/features/odata/v4-client.mdx
+++ b/docs-java/features/odata/v4-client.mdx
@@ -24,7 +24,7 @@ import NotImplemented from '@site/src/components/NotImplemented.js';
 
 To leverage the type-safe OData v4 client, you need to add following dependencies to the `dependencies` section of your `pom.xml`:
 
-<Tabs groupId="odataClientType" defaultValue="PregeneratedCloud" values={[ { label: 'Pregenerated Clients (Cloud)', value: 'PregeneratedCloud' }, { label: 'Pregenerated Clients (On-Premise)', value: 'PregeneratedOnPremise' }, { label: 'Self Generated Clients', value: 'Selfgenerated' } ]}>
+<Tabs groupId="odataClientType" defaultValue="Selfgenerated" values={[ { label: 'Self Generated Clients', value: 'Selfgenerated' } ]}>
 
 <TabItem value="Selfgenerated">
 
@@ -42,28 +42,6 @@ To leverage the type-safe OData v4 client, you need to add following dependencie
     <groupId>javax.inject</groupId>
     <artifactId>javax.inject</artifactId>
     <scope>provided</scope>
-</dependency>
-```
-
-</TabItem>
-
-<TabItem value="PregeneratedCloud">
-
-```xml
-<dependency>
-    <groupId>com.sap.cloud.sdk.s4hana</groupId>
-    <artifactId>s4hana-api-odata-v4</artifactId>
-</dependency>
-```
-
-</TabItem>
-
-<TabItem value="PregeneratedOnPremise">
-
-```xml
-<dependency>
-    <groupId>com.sap.cloud.sdk.s4hana</groupId>
-    <artifactId>s4hana-api-odata-v4-onpremise</artifactId>
 </dependency>
 ```
 

--- a/docs-java/getting-started.mdx
+++ b/docs-java/getting-started.mdx
@@ -251,51 +251,9 @@ If your application is running on **SAP Business Technology Platform** please ad
 </TabItem>
 </Tabs>
 
-If you want to connect to an **SAP S/4HANA** system via the **OData** protocol, you should also add a dependency to the client libraries of the SAP Cloud SDK.
-The dependencies differ with respect to the type of **SAP S/4HANA** system([**SAP S/4HANA Cloud**](https://api.sap.com/package/SAPS4HANACloud?section=Artifacts) or [**SAP S/4HANA On-premise**](https://api.sap.com/package/S4HANAOPAPI?section=Artifacts)):
-
-<Tabs groupId="s4" defaultValue="s4hc" values={[
-{ label: 'SAP S/4HANA Cloud', value: 's4hc', },
-{ label: 'SAP S/4HANA On-premise', value: 's4hop', }]}>
-
-<TabItem value="s4hc">
-
-<!-- vale off -->
-
-```xml
-<dependency>
-    <groupId>com.sap.cloud.sdk.s4hana</groupId>
-    <artifactId>s4hana-all</artifactId>
-</dependency>
-```
-
-</TabItem>
-
-<TabItem value="s4hop">
-
-```xml
-<dependency>
-    <groupId>com.sap.cloud.sdk.s4hana</groupId>
-    <artifactId>s4hana-api-odata-onpremise</artifactId>
-</dependency>
-<dependency>
-    <groupId>com.sap.cloud.sdk.s4hana</groupId>
-    <artifactId>s4hana-api-odata-v4-onpremise</artifactId>
-</dependency>
-<dependency>
- <groupId>com.sap.cloud.sdk.s4hana</groupId>
- <artifactId>s4hana-connectivity</artifactId>
-</dependency>
-<dependency>
- <groupId>com.sap.cloud.sdk.s4hana</groupId>
- <artifactId>s4hana-core</artifactId>
-</dependency>
-```
-
-<!-- vale on -->
-
-</TabItem>
-</Tabs>
+If you want to connect to an **SAP S/4HANA** system via the **OData** protocol, you should checkout our convenient [OData code generator](features/odata/vdm-generator).
+By downloading the OData service specifications for either type of **SAP S/4HANA** system ([**SAP S/4HANA Cloud**](https://api.sap.com/package/SAPS4HANACloud?section=Artifacts) or [**SAP S/4HANA On-premise**](https://api.sap.com/package/S4HANAOPAPI?section=Artifacts)) you can generate your own set of classes.
+Similarly the SAP Cloud SDK offers a [code generator for Open API](features/rest/generate-rest-client) protocol.
 
 In case you have a **CAP application** which uses **multitenancy** features and/or a **protected backend** your service will need the following dependency:
 

--- a/docs-java/getting-started.mdx
+++ b/docs-java/getting-started.mdx
@@ -223,20 +223,6 @@ If your application is running on **SAP Business Technology Platform** please ad
 </dependency>
 ```
 
-</TabItem>
-
-<TabItem value="neo">
-
-```xml
-<dependency>
-    <groupId>com.sap.cloud.sdk.cloudplatform</groupId>
-    <artifactId>scp-neo</artifactId>
-</dependency>
-```
-
-</TabItem>
-</Tabs>
-
 If you want to connect to an **SAP S/4HANA** system via the **OData** protocol, you should checkout our convenient [OData code generator](features/odata/vdm-generator).
 By downloading the OData service specifications for either type of **SAP S/4HANA** system ([**SAP S/4HANA Cloud**](https://api.sap.com/package/SAPS4HANACloud?section=Artifacts) or [**SAP S/4HANA On-premise**](https://api.sap.com/package/S4HANAOPAPI?section=Artifacts)) you can generate your own set of classes.
 Similarly the SAP Cloud SDK offers a [code generator for Open API](features/rest/generate-rest-client) protocol.


### PR DESCRIPTION
## ⚠️ WAIT FOR VERSION `4.17.0` TO BE PUBLICLY AVAILABLE ⚠️

## What Has Changed?

* OData VDM based modules have been deprecated with 4.17.0
* Mentioning it on the documentation portal is no longer recommended.

## Manual Checks?

- [x] Check spelling and grammar, e.g., using Grammarly.
- [x] Verify links still work, e.g., if `id` or the name of a file is changed.
- [x] Update the [feature matrix](https://github.com/SAP/cloud-sdk/blob/main/docs/components/data/features.js), e.g., if a feature is added.
