### PR TITLE
Java: Deprecation Notice on `ScpCfServiceDestinationLoader`

### DIFF
--- a/docs-java/features/connectivity/destinations.mdx
+++ b/docs-java/features/connectivity/destinations.mdx
@@ -741,6 +741,12 @@ The information there also applies to the SAP Cloud SDK for Java.
 
 #### Skip Destination Creation Step for Certain Authentication Types on Cloud Foundry
 
+:::danger Deprecated API
+
+The APIs mentioned below are **deprecated** and will be removed in version 5 of the SAP Cloud SDK, which is scheduled to be released in Q3 2023.
+
+:::
+
 For certain authentication types i.e. `NoAuthentication`, `OAuth2ClientCredentials` and `OAuth2UserTokenExchange` there is an API that eliminates the need to manually create a destination in the CF account for connecting to services.
 
 Example:

--- a/docs-java/features/rest/clients/btp-business-rules-rest-api.mdx
+++ b/docs-java/features/rest/clients/btp-business-rules-rest-api.mdx
@@ -143,6 +143,12 @@ After adding the dependency to your `pom.xml` file, run `mvn clean install` to l
 
 #### Create Destination
 
+:::danger Deprecated API
+
+The APIs mentioned below are **deprecated** and will be removed in version 5 of the SAP Cloud SDK, which is scheduled to be released in Q3 2023.
+
+:::
+
 Let's create a Java representation of this destination.
 You can use `ScpCfServiceDestinationLoader.getDestinationForService` to create a destination by reading properties from the `VCAP_SERVICES` environment variable entry for the Business Rules service:
 

--- a/docs-java/features/rest/clients/scp-workflow-rest-api.mdx
+++ b/docs-java/features/rest/clients/scp-workflow-rest-api.mdx
@@ -186,6 +186,12 @@ After adding the dependency to your `pom.xml` file, run `mvn clean install` to l
 
 #### Create Destination
 
+:::danger Deprecated API
+
+The APIs mentioned below are **deprecated** and will be removed in version 5 of the SAP Cloud SDK, which is scheduled to be released in Q3 2023.
+
+:::
+
 Let's create a Java representation of this destination.
 You can use `ScpCfServiceDestinationLoader.getDestinationForService` to create a destination by reading properties from the `VCAP_SERVICES` environment variable entry for the workflow service.
 

--- a/docs-java_versioned_docs/version-v5/features/connectivity/destinations.mdx
+++ b/docs-java_versioned_docs/version-v5/features/connectivity/destinations.mdx
@@ -738,47 +738,6 @@ If you are developing an application in the **Business Application Studio (BAS)*
 Please refer to [the BAS connectivity guide](/docs/js/guides/bas-external-system) created for the SAP Cloud SDK for JavaScript to get more information and a detailed description of the technical background.
 The information there also applies to the SAP Cloud SDK for Java.
 
-#### Skip Destination Creation Step for Certain Authentication Types on Cloud Foundry
-
-For certain authentication types i.e. `NoAuthentication`, `OAuth2ClientCredentials` and `OAuth2UserTokenExchange` there is an API that eliminates the need to manually create a destination in the CF account for connecting to services.
-
-Example:
-
-```java
-final Map<String, String> mapping =
-      ScpCfServiceDestinationLoader.buildClientCredentialsMapping(
-        "credentials.endpoints.service_rest_url",
-        "credentials.uaa.clientid",
-        "credentials.uaa.clientsecret",
-        "credentials.endpoints.token_url");
-```
-
-The `ScpCfServiceDestinationLoader.buildClientCredentialsMapping` method creates a mapping for loading a destination and provides JSON paths for all required destination properties.
-
-```java
-final HttpDestination destination =
-      ScpCfServiceDestinationLoader.getDestinationForService(
-        "label",
-        "serviceBindingName",
-        AuthenticationType.OAUTH2_CLIENT_CREDENTIALS,
-        mapping);
-```
-
-For certain services (only SAP BTP Workflow service for now), we provide further convenience that skips the need to provide the `mapping` explicitly.
-Example:
-
-```java
-final HttpDestination destination =
-      ScpCfServiceDestinationLoader.getDestinationForService(
-        ScpCfServiceDestinationLoader.CfServices.WORKFLOW,
-        "my-workflow");
-```
-
-:::note Caching
-These destinations are currently not cached.
-Please consider re-using the obtained destination objects when using `OAuth2ClientCredentials` or `OAuth2UserTokenExchange` oo avoid unnecessary token retrievals.
-:::
-
 #### Enable Access to SAP Business Technology Platform Connectivity Service
 
 The SAP BTP connectivity service builds the connection between SAP BTP and the On-premise network.


### PR DESCRIPTION
# ⚠️ WAIT UNTIL VERSION `4.23.0` HAS BEEN RELEASED ⚠️

## What Has Changed?

This PR adds a deprecation warning where we mention our `ScpCfServiceDestinationLoader` API.
As discussed, we are not (yet) mentioning the replacement API as it has not been documented yet.
