### PR TITLE
Java: Migration Guide for Auditlog

### DIFF
--- a/docs-java_versioned_docs/version-v5/guides/5.0-upgrade.mdx
+++ b/docs-java_versioned_docs/version-v5/guides/5.0-upgrade.mdx
@@ -168,6 +168,9 @@ Additionally, `asHttp` and `asRfc` will no longer always return a new instance o
   - `com.sap.cloud.sdk.plugins:plugins-parent`
   - `com.sap.cloud.sdk.plugins:scp-neo-maven-plugin`
   - `com.sap.cloud.sdk.cloudplatform:security-servlet`
+  - `com.sap.cloud.sdk.cloudplatform:auditlog`
+  - `com.sap.cloud.sdk.cloudplatform:auditlog-scp-cf`
+  - `com.sap.cloud.sdk.cloudplatform:auditlog-scp-neo`
   - `com.sap.cloud.sdk.datamodel:odata-generator-cli`
     - Call the generator directly as a maven plugin: `mvn com.sap.cloud.sdk.datamodel:odata-generator-maven-plugin:5.0.0:generate`
   - `com.sap.cloud.sdk.datamodel:odata-v4-generator-cli`
@@ -327,6 +330,15 @@ Additionally, `asHttp` and `asRfc` will no longer always return a new instance o
           &nbsp;&nbsp;.sign(Algorithm.none());<br />
           AuthToken token = new AuthToken(JWT.decode(jwt));</pre>
           Alternatively for creating extended unit tests based on token handling, please find the <a href="https://github.com/SAP/cloud-security-services-integration-library/tree/main/java-security-test">SAP BTP Java Security Test</a> library instead.
+        </td>
+      </tr>
+      <tr>
+        <td>AuditLogger</td>
+        <td>-</td>
+        <td>
+          Please approach the SAP Cloud SDK development team about migration guidance by <a href="https://github.com/SAP/cloud-sdk-java/issues/new">creating a GitHub support issue</a>.
+          <br />
+          This change also affects the Auditlog integration with the S/4HANA Connectivity module.
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
## What Has Changed?

This PR adds a few notes about the removal of our `auditlog*` modules.
