### PR TITLE
Fixed crash when inspecting any page

### DIFF
--- a/src/theme/NavbarItem/NavbarNavLink.js
+++ b/src/theme/NavbarItem/NavbarNavLink.js
@@ -6,7 +6,7 @@ import {
 } from '@docusaurus/plugin-content-docs/client';
 
 export default function NavbarNavLinkWrapper(props) {
-  if (!props.to.includes('docs/js') || props.label === '🚀 JavaScript') {
+  if (typeof props.to != "undefined" && (!props.to.includes('docs/js') || props.label === '🚀 JavaScript')) {
     return <NavbarNavLink {...props} />;
   }
   const label = props.label;


### PR DESCRIPTION
## What Has Changed?

Right click -> Inspect any page of the docs would crash it.
Fixed the JavaScript code that would crash