### PR TITLE
[V5] framework module removed

### DIFF
--- a/docs-java_versioned_docs/version-v5/features/resilience/resilience.mdx
+++ b/docs-java_versioned_docs/version-v5/features/resilience/resilience.mdx
@@ -31,7 +31,7 @@ To make use of the resilience capabilities by the SAP Cloud SDK, make sure to ad
     <artifactId>resilience</artifactId>
 </dependency>
 <dependency>
-    <groupId>com.sap.cloud.sdk.frameworks</groupId>
+    <groupId>com.sap.cloud.sdk.cloudplatform</groupId>
     <artifactId>resilience4j</artifactId>
     <scope>runtime</scope>
 </dependency>

--- a/docs-java_versioned_docs/version-v5/guides/5.0-upgrade.mdx
+++ b/docs-java_versioned_docs/version-v5/guides/5.0-upgrade.mdx
@@ -180,6 +180,9 @@ Additionally, `asHttp` and `asRfc` will no longer always return a new instance o
     - Call the generator directly as a maven plugin: `mvn com.sap.cloud.sdk.datamodel:odata-v4-generator-maven-plugin:5.0.0:generate`
   - `com.sap.cloud.sdk.datamodel:openapi-generator-cli`
     - Call the generator directly as a maven plugin: `mvn com.sap.cloud.sdk.datamodel:openapi-generator-maven-plugin:5.0.0:generate`
+  - `com.sap.cloud.sdk.frameworks`
+    - child module `com.sap.cloud.sdk.frameworks:resilience4j` has been moved to `com.sap.cloud.sdk.cloudplatform:resilience4j`
+    - child module `com.sap.cloud.sdk.frameworks:apache-httpclient5` has been moved to `com.sap.cloud.sdk.cloudplatform:connectivity-apache-httpclient5`
 
 </details>
 


### PR DESCRIPTION
## What Has Changed?

Added line to migration guide about `frameworks` removal and child module movement. Updated dependency ids.
