### PR TITLE
fix: use NormalModuleReplacementPlugin

### DIFF
--- a/docs-js/guides/sdk-in-browser.mdx
+++ b/docs-js/guides/sdk-in-browser.mdx
@@ -259,9 +259,9 @@ An error message during the compilation from TS to JS provides a hint on how to 
       new ProvidePlugin({
         process: 'process/browser'
       }),
-      new NormalModuleReplacementPlugin(/^node:/, (resource) => {
-        resource.request = resource.request.replace(/^node:/, "");
-      }),
+      new NormalModuleReplacementPlugin(/^node:/, resource => {
+        resource.request = resource.request.replace(/^node:/, '');
+      })
     ];
 
     return config;

--- a/docs-js/guides/sdk-in-browser.mdx
+++ b/docs-js/guides/sdk-in-browser.mdx
@@ -258,7 +258,10 @@ An error message during the compilation from TS to JS provides a hint on how to 
       }),
       new ProvidePlugin({
         process: 'process/browser'
-      })
+      }),
+      new NormalModuleReplacementPlugin(/^node:/, (resource) => {
+        resource.request = resource.request.replace(/^node:/, "");
+      }),
     ];
 
     return config;

--- a/docs-js_versioned_docs/version-v2/guides/sdk-in-browser.mdx
+++ b/docs-js_versioned_docs/version-v2/guides/sdk-in-browser.mdx
@@ -259,9 +259,9 @@ An error message during the compilation from TS to JS provides a hint on how to 
       new ProvidePlugin({
         process: 'process/browser'
       }),
-      new NormalModuleReplacementPlugin(/^node:/, (resource) => {
-        resource.request = resource.request.replace(/^node:/, "");
-      }),
+      new NormalModuleReplacementPlugin(/^node:/, resource => {
+        resource.request = resource.request.replace(/^node:/, '');
+      })
     ];
 
     return config;

--- a/docs-js_versioned_docs/version-v2/guides/sdk-in-browser.mdx
+++ b/docs-js_versioned_docs/version-v2/guides/sdk-in-browser.mdx
@@ -258,7 +258,10 @@ An error message during the compilation from TS to JS provides a hint on how to 
       }),
       new ProvidePlugin({
         process: 'process/browser'
-      })
+      }),
+      new NormalModuleReplacementPlugin(/^node:/, (resource) => {
+        resource.request = resource.request.replace(/^node:/, "");
+      }),
     ];
 
     return config;


### PR DESCRIPTION
Use NormalModuleReplacementPlugin for internal node modules with node-protocol when compiling for browser.

## What Has Changed?

Applying changes into [Use the SAP Cloud SDK in the Browser](https://sap.github.io/cloud-sdk/docs/js/guides/browser) in current and v2 docs of JavaScript, to include a possible solution for [#1578](https://github.com/SAP/cloud-sdk/issues/1578) where `node:` protocol will fail for bundling towards brower.
