### PR TITLE
refactor: stop splitting header values in RequestHeaderContainer

### DIFF
--- a/docs-java/features/multi-tenancy/thread-context.mdx
+++ b/docs-java/features/multi-tenancy/thread-context.mdx
@@ -341,7 +341,7 @@ These values can be accessed as follows:
 ```java
 RequestHeaderContainer headers = RequestHeaderAccessor.getHeaderContainer();
 headers.getHeaderValues("authorization"); // will return ["Bearer DUMMY_JWT"]
-headers.getHeaderValues("set-cookie"); // will return ["cookie-1; cookie-2"]
+headers.getHeaderValues("set-cookie"); // will return ["cookie-1", "cookie-2"]
 headers.getHeaderValues("accept-language"); // will return ["en-US"]
 headers.getHeaderValues("x-app-specific-header"); // will return ["customer-value"]
 ```

--- a/docs-java/features/multi-tenancy/thread-context.mdx
+++ b/docs-java/features/multi-tenancy/thread-context.mdx
@@ -341,7 +341,7 @@ These values can be accessed as follows:
 ```java
 RequestHeaderContainer headers = RequestHeaderAccessor.getHeaderContainer();
 headers.getHeaderValues("authorization"); // will return ["Bearer DUMMY_JWT"]
-headers.getHeaderValues("set-cookie"); // will return ["cookie-1", "cookie-2"]
+headers.getHeaderValues("set-cookie"); // will return ["cookie-1; cookie-2"]
 headers.getHeaderValues("accept-language"); // will return ["en-US"]
 headers.getHeaderValues("x-app-specific-header"); // will return ["customer-value"]
 ```

--- a/docs-java_versioned_docs/version-v5/features/multi-tenancy/thread-context.mdx
+++ b/docs-java_versioned_docs/version-v5/features/multi-tenancy/thread-context.mdx
@@ -341,7 +341,7 @@ These values can be accessed as follows:
 ```java
 RequestHeaderContainer headers = RequestHeaderAccessor.getHeaderContainer();
 headers.getHeaderValues("authorization"); // will return ["Bearer DUMMY_JWT"]
-headers.getHeaderValues("set-cookie"); // will return ["cookie-1", "cookie-2"]
+headers.getHeaderValues("set-cookie"); // will return ["cookie-1; cookie-2"]
 headers.getHeaderValues("accept-language"); // will return ["en-US"]
 headers.getHeaderValues("x-app-specific-header"); // will return ["customer-value"]
 ```


### PR DESCRIPTION
## What Has Changed?

SAP/cloud-sdk-java-backlog#156.

This PR changes the documentation of our `RequestHeaderContainer` to no longer mention the header value splitting.
