### PR TITLE
Renamed spring archetype

### DIFF
--- a/docs-java_versioned_docs/version-v5/getting-started.mdx
+++ b/docs-java_versioned_docs/version-v5/getting-started.mdx
@@ -203,10 +203,6 @@ Please ensure that the application is annotated to scan for components of the SA
 
 Also, please check [the Spring version](https://mvnrepository.com/artifact/com.sap.cloud.sdk/sdk-bom/latest) declared in the SAP Cloud SDK BOM doesn't clash with your version of Spring.
 
-:::note Spring Support for Cloud Foundry
-For Spring based projects we provide out-of-the-box support only on Cloud Foundry with the archetype `spring-boot3`.
-:::
-
 :::note SAP Cloud SDK Modules Bill-of-Material
 
 By default, the SAP Cloud SDK archetypes reference the SAP Cloud SDK Bill-of-Material `sdk-bom`, which manages dependency versions for all SAP Cloud SDK modules and transitive dependencies.

--- a/docs-java_versioned_docs/version-v5/getting-started.mdx
+++ b/docs-java_versioned_docs/version-v5/getting-started.mdx
@@ -36,92 +36,13 @@ Alternatively, you can follow [these instructions](#integrate-the-cloud-sdk-for-
 
 ## Generating a Project from a Maven Archetype
 
-The SAP Cloud SDK provides archetypes based on [Spring](https://spring.io/).
+The SAP Cloud SDK provides an archetype based on [Spring 6](https://spring.io/).
 
 Run:
 
-<Tabs groupId="frameworks" defaultValue="spring5" values={[
-{ label: 'Spring 5', value: 'spring5', },
-{ label: 'Spring 6', value: 'spring6', }]}>
-
-<TabItem value="spring5">
-
 ```bash
 mvn archetype:generate "-DarchetypeGroupId=com.sap.cloud.sdk.archetypes" \
-    "-DarchetypeArtifactId=scp-cf-spring" \
-    "-DarchetypeVersion=RELEASE"
-```
-
-Maven will ask you to provide the following:
-
-- `groupId` - usually serves as your organization identifier, i.e. `foo.bar.cloud.app`
-- `artifactId` - it's your application's name, i.e. `mydreamapp`
-- `version` - we recommend keeping `1.0-SNAPSHOT` if you're just starting
-- `package` - by default this equals to `groupId`. Change it only if you know what you're doing
-
-After providing all the interactive values to the CLI it will generate your first SAP Cloud SDK based application:
-
-```bash
-[INFO] Scanning for projects...
-[INFO]
-[INFO] ------------------< org.apache.maven:standalone-pom >-------------------
-[INFO] Building Maven Stub Project (No POM) 1
-[INFO] --------------------------------[ pom ]---------------------------------
-[INFO]
-[INFO] >>> maven-archetype-plugin:3.1.2:generate (default-cli) > generate-sources @ standalone-pom >>>
-[INFO]
-[INFO] <<< maven-archetype-plugin:3.1.2:generate (default-cli) < generate-sources @ standalone-pom <<<
-[INFO]
-[INFO]
-[INFO] --- maven-archetype-plugin:3.1.2:generate (default-cli) @ standalone-pom ---
-[INFO] Generating project in Interactive mode
-[INFO] ....
-[INFO] ....
-Define value for property 'groupId': foo.bar.cloud.app
-Define value for property 'artifactId' (should match expression '[^_]+'): mydreamapp
-[INFO] Using property: artifactId = mydreamapp
-Define value for property 'version' 1.0-SNAPSHOT: :
-Define value for property 'package' foo.bar.cloud.app: :
-[INFO] Using property: gitignore = .gitignore
-[INFO] Using property: skipUsageAnalytics = false
-Confirm properties configuration:
-groupId: foo.bar.cloud.app
-artifactId: mydreamapp
-artifactId: mydreamapp
-version: 1.0-SNAPSHOT
-package: foo.bar.cloud.app
-gitignore: .gitignore
-skipUsageAnalytics: false
- Y: :
-[INFO] ----------------------------------------------------------------------------
-[INFO] Using following parameters for creating project from Archetype: scp-cf-spring:RELEASE
-[INFO] ----------------------------------------------------------------------------
-[INFO] Parameter: groupId, Value: foo.bar.cloud.app
-[INFO] Parameter: artifactId, Value: mydreamapp
-[INFO] Parameter: version, Value: 1.0-SNAPSHOT
-[INFO] Parameter: package, Value: foo.bar.cloud.app
-[INFO] Parameter: packageInPathFormat, Value: foo/bar/cloud/app
-[INFO] Parameter: package, Value: foo.bar.cloud.app
-[INFO] Parameter: version, Value: 1.0-SNAPSHOT
-[INFO] Parameter: groupId, Value: foo.bar.cloud.app
-[INFO] Parameter: skipUsageAnalytics, Value: false
-[INFO] Parameter: gitignore, Value: .gitignore
-[INFO] Parameter: artifactId, Value: mydreamapp
-[INFO] Project created from Archetype in dir: /home/user/dev/temp/mydreamapp
-[INFO] ------------------------------------------------------------------------
-[INFO] BUILD SUCCESS
-[INFO] ------------------------------------------------------------------------
-[INFO] Total time:  02:28 min
-[INFO] Finished at: 2020-04-19T19:25:33+02:00
-[INFO] ------------------------------------------------------------------------
-```
-
-</TabItem>
-<TabItem value="spring6">
-
-```bash
-mvn archetype:generate "-DarchetypeGroupId=com.sap.cloud.sdk.archetypes" \
-    "-DarchetypeArtifactId=scp-cf-spring-jakarta" \
+    "-DarchetypeArtifactId=spring-boot3" \
     "-DarchetypeVersion=RELEASE"
 ```
 
@@ -185,9 +106,6 @@ package: foo.bar.cloud.app
 [INFO] Finished at: 2023-09-07T13:12:09+02:00
 [INFO] ------------------------------------------------------------------------
 ```
-
-</TabItem>
-</Tabs>
 
 **Congratulations! You've just set up a brand-new application with the SAP Cloud SDK for Java.**
 
@@ -276,13 +194,7 @@ In general, the SAP Cloud SDK for Java integrates natively into the [Spring Boot
 In particular the [SAP Cloud SDK provides listeners](features/multi-tenancy/thread-context.mdx) that can extract tenant and principal information from an incoming request.
 To ensure these listeners are present, please configure your project accordingly.
 
-<Tabs groupId="frameworks" defaultValue="spring5" values={[
-{ label: 'Spring 5', value: 'spring5', },
-{ label: 'Spring 6', value: 'spring6', }]}>
-
-<TabItem value="spring5">
-
-For a **Spring 5** based project please ensure that the application is annotated to scan for components of the SAP Cloud SDK:
+Please ensure that the application is annotated to scan for components of the SAP Cloud SDK:
 
 ```java
 @ComponentScan({"com.sap.cloud.sdk", <your.own.package>})
@@ -292,37 +204,8 @@ For a **Spring 5** based project please ensure that the application is annotated
 Also, please check [the Spring version](https://mvnrepository.com/artifact/com.sap.cloud.sdk/sdk-bom/latest) declared in the SAP Cloud SDK BOM doesn't clash with your version of Spring.
 
 :::note Spring Support for Cloud Foundry
-For Spring based projects we provide out-of-the-box support only on Cloud Foundry with the archetype `scp-cf-spring`.
+For Spring based projects we provide out-of-the-box support only on Cloud Foundry with the archetype `spring-boot3`.
 :::
-
-</TabItem>
-<TabItem value="spring6">
-
-For a **Spring 6** based project please ensure that the application is annotated to scan for components of the SAP Cloud SDK:
-
-```java
-@ComponentScan({"com.sap.cloud.sdk", <your.own.package>})
-@ServletComponentScan({"com.sap.cloud.sdk.cloudplatform.servletjakarta", <your.own.package>})
-```
-
-Add the jakarta servlet dependency to your pom.xml:
-
-```xml
-<dependency>
-    <groupId>com.sap.cloud.sdk.cloudplatform</groupId>
-    <artifactId>servlet-jakarta</artifactId>
-</dependency>
-```
-
-And, in case you are using the `sdk-bom`, make sure to set the Spring and XSUAA Library versions before importing the bom.
-You can find more details about the configuration for Java 17 / Spring 6 / Spring Boot 3 [here](/docs/java/frequently-asked-questions#which-java-versions-are-supported-by-the-sap-cloud-sdk).
-
-:::note Spring Support for Cloud Foundry
-For Spring based projects we provide out-of-the-box support only on Cloud Foundry with the archetype `scp-cf-spring`.
-:::
-
-</TabItem>
-</Tabs>
 
 :::note SAP Cloud SDK Modules Bill-of-Material
 

--- a/docs-java_versioned_docs/version-v5/guides/linux-how-to.mdx
+++ b/docs-java_versioned_docs/version-v5/guides/linux-how-to.mdx
@@ -149,7 +149,7 @@ Another supported IDE is [Eclipse](https://www.eclipse.org/ide/).
 ### To Initialize Your SAP Cloud SDK App From the Maven Archetype
 
 ```bash
-mvn archetype:generate -DarchetypeGroupId=com.sap.cloud.sdk.archetypes -DarchetypeArtifactId=scp-cf-spring -DarchetypeVersion=RELEASE
+mvn archetype:generate -DarchetypeGroupId=com.sap.cloud.sdk.archetypes -DarchetypeArtifactId=spring-boot3 -DarchetypeVersion=RELEASE
 ```
 
 The snippet above will create a `Spring Boot` app.

--- a/docs-java_versioned_docs/version-v5/guides/logging-overview.mdx
+++ b/docs-java_versioned_docs/version-v5/guides/logging-overview.mdx
@@ -311,7 +311,7 @@ Mind that a value set via the CLI will be overridden if you re-deploy your appli
 #### Recommendation for Spring Boot (e.g. SAP Cloud Application Programming Model)
 
 It's possible to customize the log levels and formatting of your Spring Boot application, e.g. when using the [SAP Cloud Application Programming Model (CAP)](https://cap.cloud.sap/docs/) framework.
-For this we recommend the best practices as they are used in our [`scp-cf-spring`](https://sap.github.io/cloud-sdk/docs/java/getting-started#generating-a-project-from-a-maven-archetype) Maven archetype.
+For this we recommend the best practices as they are used in our [`spring-boot3`](../getting-started#generating-a-project-from-a-maven-archetype) Maven archetype.
 
 If not exist, add a `src/main/resources/logback-spring.xml` with the following contents:
 

--- a/docs-java_versioned_docs/version-v5/guides/spring-boot-war-deployment.mdx
+++ b/docs-java_versioned_docs/version-v5/guides/spring-boot-war-deployment.mdx
@@ -27,7 +27,7 @@ The advantage of that modern deployment form is that the application can be star
 ## Target Projects of This Guide
 
 This guide is applicable to all Spring-based Java projects which use the modern deployment of Spring as jar file.
-That comprises in the first place any project using the [new CAP stack](https://cap.cloud.sap/docs/) as well as the [Spring Boot Maven archetype](https://search.maven.org/artifact/com.sap.cloud.sdk.archetypes/scp-cf-spring) of the SAP Cloud SDK.
+That comprises in the first place any project using the [new CAP stack](https://cap.cloud.sap/docs/) as well as the [Spring Boot Maven archetype](https://search.maven.org/artifact/com.sap.cloud.sdk.archetypes/spring-boot3) of the SAP Cloud SDK.
 
 The problem with the modern deployment is that the [SAP Java Connector](https://support.sap.com/en/product/connectors/jco.html) library cannot be used when the application gets deployed as jar file.
 That results in runtime exceptions like `java.lang.NoClassDefFoundError: com/sap/conn/jco/JCoException`.

--- a/docs-java_versioned_docs/version-v5/guides/spring-boot-war-deployment.mdx
+++ b/docs-java_versioned_docs/version-v5/guides/spring-boot-war-deployment.mdx
@@ -18,6 +18,11 @@ keywords:
 This document outlines how to adjust a Spring Boot project to use WAR deployment (also known as traditional deployment).
 The traditional deployment of Spring helps overcome exceptions related to the SAP JCo library.
 
+:::warning WAR Deployment not supported for SDK 5
+SAP Cloud SDK 5 support for WAR deployment will only be available after the release of SAP Java Buildpack 2.
+For now, only SDK 4 supports WAR deployment.
+:::
+
 ## Modern and Traditional Spring Deployment
 
 Traditionally, Java projects based on Spring were built as war files which had to be deployed to standalone application servers, such as Tomcat.


### PR DESCRIPTION
## What Has Changed?

From [Rename jakarta archetype to spring-boot3#356](https://github.com/SAP/cloud-sdk-java-backlog/issues/356)
The v5 docs only mention only the new archetype.
Reviewers make sure that all mentions of old archetypes are gone.
