### PR TITLE
Mention CDS `2.4.0` as min supported version 

### DIFF
--- a/docs-java_versioned_docs/version-v5/features/multi-tenancy/thread-context.mdx
+++ b/docs-java_versioned_docs/version-v5/features/multi-tenancy/thread-context.mdx
@@ -157,7 +157,7 @@ Such a custom `ThreadContextDecorator` can be registered via `DefaultThreadConte
 
 :::tip
 The SAP Cloud SDK already comes with a default decorator that passes on the `SecurityContext` of `com.sap.cloud.security:java-api`.
-If the [CAP integration](../../guides/cap-sdk-integration.mdx) is used, also the `RequestContext` is passed on (requires CDS version `1.28` or higher).
+If the [CAP integration](../../guides/cap-sdk-integration.mdx) is used, also the `RequestContext` is passed on (requires CDS version `2.4.0` or higher).
 :::
 
 ### Configuring the Executor

--- a/docs-java_versioned_docs/version-v5/guides/cap-sdk-integration.mdx
+++ b/docs-java_versioned_docs/version-v5/guides/cap-sdk-integration.mdx
@@ -129,7 +129,7 @@ To still manipulate the request context, please refer to [the CAP documentation]
 :::note Multitenancy Integration with CAP
 You can learn more about how the multitenancy of the SAP Cloud SDK integrates with CAP in [this article](../features/multi-tenancy/thread-context#how-is-a-thread-context-created).
 Please make sure you are using a CDS version that is up to date.
-For the integration at least `1.28` is required.
+For the integration at least `2.4.0` is required.
 :::
 
 :::info

--- a/docs-java_versioned_docs/version-v5/overview.mdx
+++ b/docs-java_versioned_docs/version-v5/overview.mdx
@@ -189,7 +189,7 @@ For apps built on TomEE / Tomcat Java 11 is supported.
 
 ### Supported Frameworks
 
-The SAP Cloud SDK can be integrated into applications based on [SAP Cloud Application Programming Model](https://cap.cloud.sap/docs/), [Spring](https://spring.io/projects/spring-framework) or [Spring Boot](https://spring.io/projects/spring-boot).
+The SAP Cloud SDK can be integrated into applications based on [SAP Cloud Application Programming Model](https://cap.cloud.sap/docs/) version `2.4.0` or higher, [Spring 6](https://spring.io/projects/spring-framework) or [Spring Boot 3](https://spring.io/projects/spring-boot).
 
 ### Availability and Licensing
 


### PR DESCRIPTION
## What Has Changed?

Some places were not updated in [chore: minimum CAP version requirement](https://github.com/SAP/cloud-sdk/pull/1599#top)
I updated the min version to be `2.4.0` like the rest of the v5 docs