### PR TITLE
Added `ScpCfServiceDestinationLoader` to the migration guide

### DIFF
--- a/docs-java_versioned_docs/version-v5/guides/5.0-upgrade.mdx
+++ b/docs-java_versioned_docs/version-v5/guides/5.0-upgrade.mdx
@@ -294,6 +294,15 @@ Additionally, `asHttp` and `asRfc` will no longer always return a new instance o
         <td>-</td>
       </tr>
       <tr>
+        <td>ScpCfServiceDestinationLoader</td>
+        <td>
+          <a href="../features/connectivity/destination/service-binding-destination-loader">
+            ServiceBindingDestinationLoader
+          </a>
+        </td>
+        <td>-</td>
+      </tr>
+      <tr>
         <td>StringConverter</td>
         <td>Java Standard Library</td>
         <td>
@@ -463,12 +472,12 @@ Additionally, `asHttp` and `asRfc` will no longer always return a new instance o
         <td>See comment on <a href="#XsuaaComment">retrieving token information.</a></td>
       </tr>
       <tr>
-        <td>ScpCfDestinationRetrievalStrategy.CURRENT_TENANT_THEN_PROVIDER</td>
+        <td><p>ScpCfDestinationRetrievalStrategy</p><p>.CURRENT_TENANT_THEN_PROVIDER</p></td>
         <td>Please query subscriber and provider tenants individually instead using <code>ONLY_SUBSCRIBER</code> and <code>ALWAYS_PROVIDER</code></td>
         <td>-</td>
       </tr>
       <tr>
-        <td>PrincipalPropagationStrategy.setDefaultStrategy(...)</td>
+        <td><p>PrincipalPropagationStrategy</p><p>.setDefaultStrategy(...)</p></td>
         <td>Destination custom property: <br /><code>cloudsdk.principalPropagationMode = (recommended|compatibility)</code></td>
         <td>Default: <code>compatibility</code>, for reduced token exchanges. <a href="https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/configure-principal-propagation-via-user-exchange-token" target="_new">See more.</a></td>
       </tr>


### PR DESCRIPTION
## Context

This change is part of [this comment](https://github.com/SAP/cloud-sdk/pull/1500#discussion_r1312733781) and [[Documentation] Document new ServiceBinding Connectivity API](https://github.com/SAP/cloud-sdk-java-backlog/issues/178#top)

## What Has Changed?

- I added the missing deprecated class to the v5 migration guide
  - It merges on Johannes' PR because I need to link to his page of the replacement API.
- I also added line breaks to make the table more readable, otherwise you have no idea that the comment section exists
