### PR TITLE
Java migration guide added replacement for `AbstractHttpDestination`

### DIFF
--- a/docs-java/guides/5.0-upgrade-steps.mdx
+++ b/docs-java/guides/5.0-upgrade-steps.mdx
@@ -337,8 +337,8 @@ Once the build doesn't complain about missing dependency versions anymore, you c
       </tr>
       <tr>
         <td>AbstractHttpDestination</td>
-        <td>DefaultHttpDestination</td>
-        <td>Any class extending AbstractHttpDestination<br />can be replaced by using DefaultHttpDestination's API</td>
+        <td>-</td>
+        <td>No direct replacement.<br />Most use cases, however, should be able to leverage the <code>DefaultHttpDestination</code> instead.</td>
       </tr>
       <tr>
         <td>WrappedDestination</td>

--- a/docs-java/guides/5.0-upgrade-steps.mdx
+++ b/docs-java/guides/5.0-upgrade-steps.mdx
@@ -337,8 +337,8 @@ Once the build doesn't complain about missing dependency versions anymore, you c
       </tr>
       <tr>
         <td>AbstractHttpDestination</td>
-        <td>-</td>
-        <td>No replacement necessary</td>
+        <td>DefaultHttpDestination</td>
+        <td>Any class extending AbstractHttpDestination<br />can be replaced by using DefaultHttpDestination's API</td>
       </tr>
       <tr>
         <td>WrappedDestination</td>


### PR DESCRIPTION
From the support issue https://github.wdf.sap.corp/MA/sdk/issues/8683

Should I add this change to all Abstract destinations in the table?