### PR TITLE
[Java] Added replacement for `getVcapApplication`

### DIFF
--- a/docs-java/guides/5.0-upgrade-steps.mdx
+++ b/docs-java/guides/5.0-upgrade-steps.mdx
@@ -640,29 +640,31 @@ Once the build doesn't complain about missing dependency versions anymore, you c
       <tr>
         <td>CloudPlatform</td>
         <td>-</td>
-        <td>No replacement, as all platform specifics are handled by the <a href="https://github.com/SAP/btp-environment-variable-access">Service Binding library</a>.</td>
+        <td>No SDK replacement. <br />
+        Handling bound applications (i.e. <code>VCAP_SERVICES</code>) is done via the <a href="https://github.com/SAP/btp-environment-variable-access">Service Binding library</a>.<br />
+        Handling application information (i.e. <code>VCAP_APPLICATION</code>) can be done manually: <br />
+        <pre>new Gson().fromJson(System.getenv("VCAP_APPLICATION"), JsonObject.class).asMap();</pre>
+        </td>
       </tr>
       <tr>
         <td>ScpCfCloudPlatform</td>
         <td>-</td>
-        <td>No replacement, as all platform specifics are handled by the <a href="https://github.com/SAP/btp-environment-variable-access">Service Binding library</a>.</td>
+        <td>No replacement. See note on <code>CloudPlatform</code> (above).</td>
       </tr>
       <tr>
         <td>CloudPlatformFacade</td>
         <td>-</td>
-        <td>No replacement, as all platform specifics are handled by the <a href="https://github.com/SAP/btp-environment-variable-access">Service Binding library</a><br />
-Except for <code>getVcapApplication()</code>, which is replaced by:<br />
-<pre>new Gson().fromJson(JsonSanitizer.sanitize(System.getenv("VCAP_APPLICATION")), new TypeToken &lt;Map&lt;String, JsonElement>>(){}.getType());</pre></td>
+        <td>No replacement. See note on <code>CloudPlatform</code> (above).</td>
       </tr>
       <tr>
         <td>ScpCfCloudPlatformFacade</td>
         <td>-</td>
-        <td>No replacement, as all platform specifics are handled by the <a href="https://github.com/SAP/btp-environment-variable-access">Service Binding library</a>.</td>
+        <td>No replacement. See note on <code>CloudPlatform</code> (above).</td>
       </tr>
       <tr>
         <td>CloudPlatformAccessor</td>
         <td>-</td>
-        <td>No replacement, as all platform specifics are handled by the <a href="https://github.com/SAP/btp-environment-variable-access">Service Binding library</a>.</td>
+        <td>No replacement. See note on <code>CloudPlatform</code> (above).</td>
       </tr>
       <tr>
         <td>ThreadContextInvocationInterceptor</td>

--- a/docs-java/guides/5.0-upgrade-steps.mdx
+++ b/docs-java/guides/5.0-upgrade-steps.mdx
@@ -650,7 +650,9 @@ Once the build doesn't complain about missing dependency versions anymore, you c
       <tr>
         <td>CloudPlatformFacade</td>
         <td>-</td>
-        <td>No replacement, as all platform specifics are handled by the <a href="https://github.com/SAP/btp-environment-variable-access">Service Binding library</a>.</td>
+        <td>No replacement, as all platform specifics are handled by the <a href="https://github.com/SAP/btp-environment-variable-access">Service Binding library</a><br />
+Except for <code>getVcapApplication()</code>, which is replaced by:<br />
+<pre>new Gson().fromJson(JsonSanitizer.sanitize(System.getenv("VCAP_APPLICATION")), new TypeToken &lt;Map&lt;String, JsonElement>>(){}.getType());</pre></td>
       </tr>
       <tr>
         <td>ScpCfCloudPlatformFacade</td>


### PR DESCRIPTION
## What Has Changed?

The service binding lib doesn't replace `getVcapApplication`, we need to add a code snippet to help customers migrate
