### PR TITLE
Removed version tag from OData generator

### DIFF
--- a/docs-java/features/odata/generator.mdx
+++ b/docs-java/features/odata/generator.mdx
@@ -146,8 +146,6 @@ Use it by adding it to your `application/pom.xml` file under the `<plugin>` sect
 <plugin>
     <groupId>com.sap.cloud.sdk.datamodel</groupId>
     <artifactId>odata-generator-maven-plugin</artifactId>
-    <!-- Please use the latest version here-->
-    <version>5.XX.X</version>
     <executions>
         <execution>
             <id>generate-consumption</id>

--- a/docs-java/features/odata/generator.mdx
+++ b/docs-java/features/odata/generator.mdx
@@ -112,6 +112,8 @@ Use it by adding it to your `application/pom.xml` file under the `<plugin>` sect
 <plugin>
     <groupId>com.sap.cloud.sdk.datamodel</groupId>
     <artifactId>odata-v4-generator-maven-plugin</artifactId>
+    <!-- Please use the latest version here-->
+    <version>5.XX.X</version>
     <executions>
         <execution>
             <id>generate-consumption</id>
@@ -146,6 +148,8 @@ Use it by adding it to your `application/pom.xml` file under the `<plugin>` sect
 <plugin>
     <groupId>com.sap.cloud.sdk.datamodel</groupId>
     <artifactId>odata-generator-maven-plugin</artifactId>
+    <!-- Please use the latest version here-->
+    <version>5.XX.X</version>
     <executions>
         <execution>
             <id>generate-consumption</id>

--- a/docs-java/features/odata/generator.mdx
+++ b/docs-java/features/odata/generator.mdx
@@ -112,8 +112,6 @@ Use it by adding it to your `application/pom.xml` file under the `<plugin>` sect
 <plugin>
     <groupId>com.sap.cloud.sdk.datamodel</groupId>
     <artifactId>odata-v4-generator-maven-plugin</artifactId>
-    <!-- Please use the latest version here-->
-    <version>4.XX.X</version>
     <executions>
         <execution>
             <id>generate-consumption</id>
@@ -149,7 +147,7 @@ Use it by adding it to your `application/pom.xml` file under the `<plugin>` sect
     <groupId>com.sap.cloud.sdk.datamodel</groupId>
     <artifactId>odata-generator-maven-plugin</artifactId>
     <!-- Please use the latest version here-->
-    <version>4.XX.X</version>
+    <version>5.XX.X</version>
     <executions>
         <execution>
             <id>generate-consumption</id>


### PR DESCRIPTION
## What Has Changed?

The version number was outdated on the v5 docs.