### PR TITLE
[Java] Add release notes for 4.29.0 

### DIFF
--- a/docs-java_versioned_docs/version-v4/release-notes/release-notes-15-to-29.mdx
+++ b/docs-java_versioned_docs/version-v4/release-notes/release-notes-15-to-29.mdx
@@ -1,3 +1,12 @@
+## 4.29.0 - January 22nd, 2024
+
+### Improvements
+
+- Dependency Updates:
+  - SAP dependency updates:
+    - Update [SAP Java Buildpack](https://central.sonatype.com/artifact/com.sap.cloud.sjb.cf/cf-tomcat-bom/1.85.0) from `1.82.0` to `1.85.0`
+    - Update [XSUAA Security Client](https://central.sonatype.com/artifact/com.sap.cloud.security/java-bom/2.17.2) from `2.17.1` to `2.17.2`
+
 ## 4.28.0 - December 5th, 2023
 
 ### Compatibility Notes


### PR DESCRIPTION
Adding release notes for `4.29`

To be merged after `4.29` is available on Maven central.