### PR TITLE
refactor: Remove Mentions of `Zone` Concept

### DIFF
--- a/docs-java/features/multi-tenancy/thread-context.mdx
+++ b/docs-java/features/multi-tenancy/thread-context.mdx
@@ -34,10 +34,9 @@ To ensure different tenants and users are properly isolated in an application, t
 
 :::info
 Multi-tenancy describes the access of different, technically separated user groups to the same instance of an application.
-In the terms of XSUAA service, these user groups are called Tenants, while in terms of Identity Authentication Service (IAS) they are called Zones.
+These user groups are called _Tenants_.
 
-The SAP Cloud SDK for Java uses the term _Tenant_ to refer to both XSUAA Tenants and IAS Zones.
-This implies, that the _tenantId_ exposed in the _Tenant_ interface either returns the _tenantId_ or _zoneId_, depending on the context you are currently running in.
+The SAP Cloud SDK uses the `Tenant` interface to represent them.
 :::
 
 ## How Is a Thread Context Created?


### PR DESCRIPTION
## What Has Changed?

This PR refactors our documentation about multitenancy so that it no longer mentions the `Zone` concept.