### PR TITLE
Java virtual threads compatibility with ThreadContextExecutor API

### DIFF
--- a/docs-java/features/multi-tenancy/thread-context.mdx
+++ b/docs-java/features/multi-tenancy/thread-context.mdx
@@ -192,14 +192,11 @@ ThreadContextExecutors.setExecutor(executor);
 ThreadContextExecutors.submit(myTask);
 ```
 
-The API is also compatible with Java virtual threads (JDK19+).
+The above API is also compatible with Java virtual threads (JDK21).
 
 ```java
-try (ExecutorService executor =
-  DefaultThreadContextExecutorService.of(Executors.newVirtualThreadPerTaskExecutor()))
-{
-  executor.submit(myTask);
-}
+ExecutorService executor =
+  DefaultThreadContextExecutorService.of(Executors.newVirtualThreadPerTaskExecutor());
 ```
 
 ### Modifying the ThreadContext

--- a/docs-java/features/multi-tenancy/thread-context.mdx
+++ b/docs-java/features/multi-tenancy/thread-context.mdx
@@ -195,7 +195,7 @@ ThreadContextExecutors.submit(myTask);
 The above API is also compatible with Java virtual threads (JDK21).
 
 ```java
-ExecutorService executor =
+ThreadContextExecutorService executor =
   DefaultThreadContextExecutorService.of(Executors.newVirtualThreadPerTaskExecutor());
 ```
 

--- a/docs-java/features/multi-tenancy/thread-context.mdx
+++ b/docs-java/features/multi-tenancy/thread-context.mdx
@@ -181,8 +181,8 @@ The `ThreadContextExecutors` class leverages a single `ThreadContextExecutorServ
 You can create a custom `ThreadContextExecutorService`, for example to use a different thread pool, via:
 
 ```java
-ThreadContextExecutorService executor = DefaultThreadContextExecutorService
-            .of(Executors.newFixedThreadPool(3));
+ThreadContextExecutorService executor =
+  DefaultThreadContextExecutorService.of(Executors.newFixedThreadPool(3));
 
 // use it directly:
 executor.submit(myTask);
@@ -190,6 +190,16 @@ executor.submit(myTask);
 // or set it to be used by the static ThreadContextExecutors API:
 ThreadContextExecutors.setExecutor(executor);
 ThreadContextExecutors.submit(myTask);
+```
+
+The API is also compatible with Java virtual threads (JDK19+).
+
+```java
+try (ExecutorService executor =
+  DefaultThreadContextExecutorService.of(Executors.newVirtualThreadPerTaskExecutor()))
+{
+  executor.submit(myTask);
+}
 ```
 
 ### Modifying the ThreadContext


### PR DESCRIPTION
## What Has Changed?

Mention native compatibility of virtual threads with Cloud SDK.
https://github.com/SAP/cloud-sdk-java-backlog/issues/369