### PR TITLE
Java release notes 4.30.0

### DIFF
--- a/docs-java_versioned_docs/version-v4/release-notes/release-notes-15-to-29.mdx
+++ b/docs-java_versioned_docs/version-v4/release-notes/release-notes-15-to-29.mdx
@@ -1,3 +1,12 @@
+## 4.30.0 - February 29, 2024
+
+### Improvements
+
+- Dependency Updates:
+  - Minor version updates:
+    - Update [Spring Framework](https://search.maven.org/search?q=g:org.springframework%20AND%20a:spring-framework-bom) (`org.springframework:spring-framework-bom`) from `5.3.31` to `5.3.32`
+    - Update [org.apache.commons:commons-compress](https://commons.apache.org/proper/commons-compress/) from `1.24.0` to `1.26.0`
+
 ## 4.29.0 - January 22nd, 2024
 
 ### Improvements


### PR DESCRIPTION
## What Has Changed?

Added release notes for 4.30.0, also too lazy to create a new `release-notes-30-to-44.mdx` file
