### PR TITLE
fix: replace maven central search links for our modules

### DIFF
--- a/docs-java/environments/kyma.mdx
+++ b/docs-java/environments/kyma.mdx
@@ -29,7 +29,7 @@ You can also refer to this additional material available for getting started wit
 The SAP Cloud SDK supports the Kyma runtime through the regular Cloud Foundry specific modules and classes.
 Hence, Cloud Foundry application developers usually don't need to adjust their code to deploy and run it on Kyma.
 
-Nevertheless, before deploying your application on a Kyma cluster, please ensure that following dependency is on the classpath: [`com.sap.cloud.environment.servicebinding:java-sap-service-operator`](https://search.maven.org/search?q=g:com.sap.cloud.environment.servicebinding%20AND%20a:java-sap-service-operator).
+Nevertheless, before deploying your application on a Kyma cluster, please ensure that following dependency is on the classpath: [`com.sap.cloud.environment.servicebinding:java-sap-service-operator`](https://central.sonatype.com/artifact/com.sap.cloud.environment.servicebinding/java-sap-service-operator).
 
 Find below the list of features we currently support:
 Legend: ✅ - supported, ❗- partially supported, ❌ - not supported

--- a/docs-java/faq.mdx
+++ b/docs-java/faq.mdx
@@ -19,8 +19,8 @@ keywords:
 ### How Often Do You Release a New SAP Cloud SDK Version?
 
 We release a [minor version](release-policy.mdx#minor-release-schedule) every two weeks.
-All the features that are _Generally Available_ or _Beta_ get into the next [release](https://search.maven.org/artifact/com.sap.cloud.sdk/sdk-bom).
-You can find the latest SAP Cloud SDK version and the list of previous releases [here](release-notes.mdx) or on [Maven Central](https://search.maven.org/artifact/com.sap.cloud.sdk/sdk-bom).
+All the features that are _Generally Available_ or _Beta_ get into the next [release](https://central.sonatype.com/artifact/com.sap.cloud.sdk/sdk-bom).
+You can find the latest SAP Cloud SDK version and the list of previous releases [here](release-notes.mdx) or on [Maven Central](https://central.sonatype.com/artifact/com.sap.cloud.sdk/sdk-bom).
 Find more details in our [release policy](release-policy.mdx).
 
 ### Should I Update With Every Release?

--- a/docs-java/features/connectivity/001-btp-destination-service.mdx
+++ b/docs-java/features/connectivity/001-btp-destination-service.mdx
@@ -17,7 +17,7 @@ keywords:
   - btp
 ---
 
-The [`DestinationAccessor`](pathname:///java-api/v5/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationAccessor.html) API is part of the [`cloudplatform-connectivity` artifact](https://search.maven.org/artifact/com.sap.cloud.sdk.cloudplatform/cloudplatform-connectivity) and provides easy and convenient access to destinations that can be identified by their name.
+The [`DestinationAccessor`](pathname:///java-api/v5/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationAccessor.html) API is part of the [`cloudplatform-connectivity` artifact](https://central.sonatype.com/artifact/com.sap.cloud.sdk.cloudplatform/cloudplatform-connectivity) and provides easy and convenient access to destinations that can be identified by their name.
 Those are, in the vast majority of use cases, destinations managed in the [BTP Destination Service on Cloud Foundry](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/connectivity-in-cloud-foundry-environment).
 
 ```java
@@ -28,7 +28,7 @@ Destination myDestination = DestinationAccessor.getDestination("my-destination")
 
 To use the `DestinationAccessor` to retrieve destinations from the BTP Destination Service on Cloud Foundry, the following prerequisites must be met:
 
-- The [**`connectivity-destination-service` artifact**](https://search.maven.org/artifact/com.sap.cloud.sdk.cloudplatform/connectivity-destination-service) must be on the classpath.
+- The [**`connectivity-destination-service` artifact**](https://central.sonatype.com/artifact/com.sap.cloud.sdk.cloudplatform/connectivity-destination-service) must be on the classpath.
 - There must be **_exactly_ one service binding** for the BTP Destination Service on Cloud Foundry available at runtime.
 
 :::info Caching

--- a/docs-java/features/connectivity/003-service-bindings.mdx
+++ b/docs-java/features/connectivity/003-service-bindings.mdx
@@ -40,7 +40,7 @@ HttpDestination destination = ServiceBindingDestinationLoader.defaultLoaderChain
 
 :::caution Prerequisites
 
-For the following to work, the application needs to add the [**`connectivity-oauth` artifact**](https://search.maven.org/artifact/com.sap.cloud.sdk.cloudplatform/connectivity-oauth) to its dependencies.
+For the following to work, the application needs to add the [**`connectivity-oauth` artifact**](https://central.sonatype.com/artifact/com.sap.cloud.sdk.cloudplatform/connectivity-oauth) to its dependencies.
 
 :::
 
@@ -90,7 +90,7 @@ ServiceBindingDestinationOptions
 ## How It Works
 
 In general, the [`ServiceBindingDestinationLoader` API](pathname:///java-api/v5/com/sap/cloud/sdk/cloudplatform/connectivity/ServiceBindingDestinationLoader.html) can be used to convert `ServiceBinding` instances into `HttpDestination` instances.
-It comes as part of the [`cloudplatform-connectivity` artifact](https://search.maven.org/artifact/com.sap.cloud.sdk.cloudplatform/cloudplatform-connectivity).
+It comes as part of the [`cloudplatform-connectivity` artifact](https://central.sonatype.com/artifact/com.sap.cloud.sdk.cloudplatform/cloudplatform-connectivity).
 
 The API is designed for easy extensibility and customization.
 Hereby, each `ServiceBindingDestinationLoader` implementation is supposed to provide the transformation logic for one specific "type" of `ServiceBinding`. <br />
@@ -225,7 +225,7 @@ class MyCustomServiceBindingLoader implements ServiceBindingDestinationLoader
 
 ## About the _OAuth2Loader_
 
-The [`OAuth2ServiceBindingDestinationLoader`](pathname:///java-api/v5/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceBindingDestinationLoader.html) comes as part of the [`connectivity-oauth` artifact](https://search.maven.org/artifact/com.sap.cloud.sdk.cloudplatform/connectivity-oauth) and provides a customizable implementation for converting `ServiceBinding`s that use OAuth2 authentication into `HttpDestination` instances. <br />
+The [`OAuth2ServiceBindingDestinationLoader`](pathname:///java-api/v5/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceBindingDestinationLoader.html) comes as part of the [`connectivity-oauth` artifact](https://central.sonatype.com/artifact/com.sap.cloud.sdk.cloudplatform/connectivity-oauth) and provides a customizable implementation for converting `ServiceBinding`s that use OAuth2 authentication into `HttpDestination` instances. <br />
 More precisely, it supports the **OAuth2 Client Credentials** and **OAuth2 Client Certificate** grant types.
 
 Internally, the implementation performs the following steps:

--- a/docs-java/features/connectivity/004-http-destinations.mdx
+++ b/docs-java/features/connectivity/004-http-destinations.mdx
@@ -231,7 +231,7 @@ The result should look like this:
 
 The SAP Cloud SDK comes with a set of `DestinationHeaderProvider`s that are automatically added to any `DefaultHttpDestination` instance.
 
-The [`ErpDestinationHeaderProvider`](pathname:///java-api/v5/com/sap/cloud/sdk/cloudplatform/connectivity/ErpDestinationHeaderProvider.html) is part of the [`cloudplatform-connectivity` artifact](https://search.maven.org/artifact/com.sap.cloud.sdk.cloudplatform/cloudplatform-connectivity) and, therefore, will **always** be added to any `DefaultHttpDestination` instance. <br />
+The [`ErpDestinationHeaderProvider`](pathname:///java-api/v5/com/sap/cloud/sdk/cloudplatform/connectivity/ErpDestinationHeaderProvider.html) is part of the [`cloudplatform-connectivity` artifact](https://central.sonatype.com/artifact/com.sap.cloud.sdk.cloudplatform/cloudplatform-connectivity) and, therefore, will **always** be added to any `DefaultHttpDestination` instance. <br />
 It provides the following headers:
 
 - The `sap-client` header, **iff** the `DefaultHttpDestination` contains a `sap-client` property.

--- a/docs-java/features/connectivity/005-http-client.mdx
+++ b/docs-java/features/connectivity/005-http-client.mdx
@@ -58,7 +58,7 @@ All APIs related to the Apache version 5 `HttpClient` are currently in `Beta`, i
 
 :::
 
-To make use the `ApacheHttpClient5Accessor`, make sure to include the [cloudplatform-connectivity](https://search.maven.org/search?q=g:com.sap.cloud.sdk.cloudplatform%2BAND%2Ba:cloudplatform-connectivity) **and** the [apache-httpclient5](https://search.maven.org/search?q=g:com.sap.cloud.sdk.frameworks%2BAND%2Ba:apache-httpclient5) dependencies in your project.
+To use the `ApacheHttpClient5Accessor`, make sure to include the [cloudplatform-connectivity](https://search.maven.org/search?q=g:com.sap.cloud.sdk.cloudplatform%2BAND%2Ba:cloudplatform-connectivity) **and** the [connectivity-apache-httpclient5](https://search.maven.org/search?q=g:com.sap.cloud.sdk.cloudplatform%2BAND%2Ba:connectivity-apache-httpclient5) dependencies in your project.
 
 ```java
 HttpClient client = ApacheHttpClient5Accessor.getHttpClient();

--- a/docs-java/features/connectivity/005-http-client.mdx
+++ b/docs-java/features/connectivity/005-http-client.mdx
@@ -36,7 +36,7 @@ The SAP Cloud SDK itself uses the accessor class for all internal requests as we
   ]}>
 <TabItem value="v4">
 
-To make use the `HttpClientAccessor`, make sure to include the [cloudplatform-connectivity](https://search.maven.org/search?q=g:com.sap.cloud.sdk.cloudplatform%2BAND%2Ba:cloudplatform-connectivity) dependency in your project.
+To make use the `HttpClientAccessor`, make sure to include the [cloudplatform-connectivity](https://central.sonatype.com/artifact/com.sap.cloud.sdk.cloudplatform/cloudplatform-connectivity) dependency in your project.
 
 ```java
 HttpClient client = HttpClientAccessor.getHttpClient();
@@ -58,7 +58,7 @@ All APIs related to the Apache version 5 `HttpClient` are currently in `Beta`, i
 
 :::
 
-To use the `ApacheHttpClient5Accessor`, make sure to include the [cloudplatform-connectivity](https://search.maven.org/search?q=g:com.sap.cloud.sdk.cloudplatform%2BAND%2Ba:cloudplatform-connectivity) **and** the [connectivity-apache-httpclient5](https://search.maven.org/search?q=g:com.sap.cloud.sdk.cloudplatform%2BAND%2Ba:connectivity-apache-httpclient5) dependencies in your project.
+To use the `ApacheHttpClient5Accessor`, make sure to include the [cloudplatform-connectivity](https://central.sonatype.com/atifrtifact/com.sap.cloud.sdk.cloudplatform/cloudplatform-connectivity) **and** the [connectivity-apache-httpclient5](https://central.sonatype.com/artifact/com.sap.cloud.sdk.cloudplatform/connectivity-apache-httpclient5) dependencies in your project.
 
 ```java
 HttpClient client = ApacheHttpClient5Accessor.getHttpClient();

--- a/docs-java/guides/5.0-upgrade-steps.mdx
+++ b/docs-java/guides/5.0-upgrade-steps.mdx
@@ -32,7 +32,7 @@ Starting with version 5.0.0 the SAP Cloud SDK requires a Java version of at leas
 
 :::warning WAR Deployment
 `war` deployment in combination with the **SAP Java Buildpack** is currently **not supported**.
-As a consequence, we are **not releasing** our [`rfc` artifact](https://search.maven.org/artifact/com.sap.cloud.sdk.s4hana/rfc) with the SAP Cloud SDK for Java in version 5 at the moment. <br />
+As a consequence, we are **not releasing** our [`rfc` artifact](https://central.sonatype.com/artifact/com.sap.cloud.sdk.s4hana/rfc) with the SAP Cloud SDK for Java in version 5 at the moment. <br />
 Support will come after the release of the upcoming SAP Java Buildpack 2.X<br />
 Consumers that need to use the RFC functionality (e.g. JCo) are requested to **stay on version 4** for now.
 :::

--- a/docs-java/guides/spring-boot-war-deployment.mdx
+++ b/docs-java/guides/spring-boot-war-deployment.mdx
@@ -20,7 +20,7 @@ The traditional deployment of Spring helps overcome exceptions related to the SA
 
 :::warning WAR Deployment
 `war` deployment in combination with the **SAP Java Buildpack** is currently **not supported**.
-As a consequence, we are **not releasing** our [`rfc` artifact](https://search.maven.org/artifact/com.sap.cloud.sdk.s4hana/rfc) with the SAP Cloud SDK for Java in version 5 at the moment. <br />
+As a consequence, we are **not releasing** our [`rfc` artifact](https://central.sonatype.com/artifact/com.sap.cloud.sdk.s4hana/rfc) with the SAP Cloud SDK for Java in version 5 at the moment. <br />
 Consumers that need to use the RFC functionality (e.g. JCo) are requested to **stay on version 4** for now.
 :::
 
@@ -33,7 +33,7 @@ The advantage of that modern deployment form is that the application can be star
 ## Target Projects of This Guide
 
 This guide is applicable to all Spring-based Java projects which use the modern deployment of Spring as jar file.
-That comprises in the first place any project using the [new CAP stack](https://cap.cloud.sap/docs/) as well as the [Spring Boot Maven archetype](https://search.maven.org/artifact/com.sap.cloud.sdk.archetypes/spring-boot3) of the SAP Cloud SDK.
+That comprises in the first place any project using the [new CAP stack](https://cap.cloud.sap/docs/) as well as the [Spring Boot Maven archetype](https://central.sonatype.com/artifact/com.sap.cloud.sdk.archetypes/spring-boot3) of the SAP Cloud SDK.
 
 The problem with the modern deployment is that the [SAP Java Connector](https://support.sap.com/en/product/connectors/jco.html) library cannot be used when the application gets deployed as jar file.
 That results in runtime exceptions like `java.lang.NoClassDefFoundError: com/sap/conn/jco/JCoException`.

--- a/docs-java/release-notes/release-notes-0-to-14.mdx
+++ b/docs-java/release-notes/release-notes-0-to-14.mdx
@@ -182,7 +182,7 @@
 - SAP dependency updates:
   - Update the [SAP Security Library](https://github.com/SAP/cloud-security-services-integration-library) from `3.3.0` to `3.3.1`
 - Other dependency updates:
-  - Update [Apache HttpClient 5](https://search.maven.org/artifact/org.apache.httpcomponents.client5/httpclient5) from `5.2.1` to `5.3`
+  - Update [Apache HttpClient 5](https://central.sonatype.com/artifact/org.apache.httpcomponents.client5/httpclient5) from `5.2.1` to `5.3`
   - Update [Apache HttpCore 5](https://search.maven.org/search?q=a:httpcore5) from `5.2.3` to `5.2.4`
 
 ### 🐛 Fixed Issues

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -104,7 +104,7 @@ module.exports = {
             },
             {
               label: 'Maven',
-              href: 'https://search.maven.org/search?q=g:com.sap.cloud.sdk*'
+              href: 'https://central.sonatype.com/search?q=g:com.sap.cloud.sdk*&smo=true'
             },
             {
               label: 'Support',

--- a/sidebarsDocsJava.js
+++ b/sidebarsDocsJava.js
@@ -103,7 +103,7 @@ module.exports = {
     {
       type: 'link',
       label: 'Maven Central',
-      href: 'https://search.maven.org/search?q=g:com.sap.cloud.sdk*'
+      href: 'https://central.sonatype.com/search?q=g:com.sap.cloud.sdk*&smo=true'
     }
   ]
 };

--- a/src/sap/sdk-data/data.js
+++ b/src/sap/sdk-data/data.js
@@ -47,7 +47,7 @@ export const features = [
       'SAP S/4HANA Cloud, SAP S/4HANA On-Premise, Workflow and more...',
       <>
         Available on{' '}
-        <a href="https://search.maven.org/search?q=g:com.sap.cloud.sdk*">
+        <a href="https://central.sonatype.com/search?q=g:com.sap.cloud.sdk*&smo=true">
           Maven Central
         </a>
       </>,


### PR DESCRIPTION
## What Has Changed?

Follow-up of #1728 

This PR replaces links that pointed to the old Sonatype UI for our modules.
