### PR TITLE
fix: typo in generator doc

### DIFF
--- a/docs-java/features/odata/generator.mdx
+++ b/docs-java/features/odata/generator.mdx
@@ -204,7 +204,7 @@ The maven plugin can also be invoked without a project from the command line usi
 <TabItem value="v4">
 
 ```bash
-mvn com.sap.cloud.datamodel:odata-v4-generator-maven-plugin:5.XX.X:generate -Dodatav4.generate.inputDirectory=foo -Dodatav4.generate.outputDirectory=bar
+mvn com.sap.cloud.sdk.datamodel:odata-v4-generator-maven-plugin:5.XX.X:generate -Dodatav4.generate.inputDirectory=foo -Dodatav4.generate.outputDirectory=bar
 ```
 
 See the full list of parameters [here](https://github.com/SAP/cloud-sdk-java/blob/main/datamodel/odata-v4/odata-v4-generator-maven-plugin/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/generator/DataModelGeneratorMojo.java).
@@ -213,7 +213,7 @@ See the full list of parameters [here](https://github.com/SAP/cloud-sdk-java/blo
 <TabItem value="v2">
 
 ```bash
-mvn com.sap.cloud.datamodel:odata-generator-maven-plugin:5.XX.X:generate -Dodatav2.generate.inputDirectory=foo -Dodatav2.generate.outputDirectory=bar
+mvn com.sap.cloud.sdk.datamodel:odata-generator-maven-plugin:5.XX.X:generate -Dodatav2.generate.inputDirectory=foo -Dodatav2.generate.outputDirectory=bar
 ```
 
 See the full list of parameters [here](https://github.com/SAP/cloud-sdk-java/blob/main/datamodel/odata/odata-generator-maven-plugin/src/main/java/com/sap/cloud/sdk/datamodel/odata/generator/DataModelGeneratorMojo.java).

--- a/docs-java_versioned_docs/version-v4/features/odata/generator.mdx
+++ b/docs-java_versioned_docs/version-v4/features/odata/generator.mdx
@@ -212,7 +212,7 @@ Use the `.withServicePath("/path/to/my/service")` option on the service class.
 The maven plugin can also be invoked without a project from the command line using `-D` parameter flags, for example:
 
 ```
-mvn com.sap.cloud.datamodel:odata-v4-generator-maven-plugin:4.XX.X:generate -Dodatav4.generate.inputDirectory=foo -Dodatav4.generate.outputDirectory=bar
+mvn com.sap.cloud.sdk.datamodel:odata-v4-generator-maven-plugin:4.XX.X:generate -Dodatav4.generate.inputDirectory=foo -Dodatav4.generate.outputDirectory=bar
 ```
 
 See the full list of parameters [here](#available-parameters).

--- a/docs-java_versioned_docs/version-v4/features/rest/generate-rest-client.mdx
+++ b/docs-java_versioned_docs/version-v4/features/rest/generate-rest-client.mdx
@@ -154,7 +154,7 @@ We recommend using a Maven property for defining the version of both the Maven p
 The maven plugin can also be invoked without a project from the command line using `-D` parameter flags, for example:
 
 ```
-mvn com.sap.cloud.datamodel:openapi-generator-maven-plugin:4.XX.X:generate -Dopenapi.generate.inputSpec=foo -Dopenapi.generate.outputDirectory=bar
+mvn com.sap.cloud.sdk.datamodel:openapi-generator-maven-plugin:4.XX.X:generate -Dopenapi.generate.inputSpec=foo -Dopenapi.generate.outputDirectory=bar
 ```
 
 ### Generating Java Client Library for Multiple OpenAPI Specifications


### PR DESCRIPTION
## What Has Changed?

Found some minor typos in the generator docs. It should be `com.sap.cloud.sdk.datamodel` instead of `om.sap.cloud.datamodel` to work correctly.