### PR TITLE
fix: Typo in Service Binding Format

### DIFF
--- a/docs-java/features/connectivity/003-service-bindings.mdx
+++ b/docs-java/features/connectivity/003-service-bindings.mdx
@@ -237,7 +237,7 @@ For example, the following binding would be recognized:
   "label": "eventmesh-sap2sap-internal",
   "credentials": {
     "authentication-service": {
-      "service_label": "identity"
+      "service-label": "identity"
     },
     "endpoints": {
       "eventing-endpoint": {


### PR DESCRIPTION
## What Has Changed?

Fixes a typo in the service binding format for IAS backed services.
(For reference: [here](https://github.com/SAP/cloud-sdk-java/blob/main/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/IdentityAuthenticationServiceBindingDestinationLoader.java#L124) is the corresponding implementation in the SDK)
