### PR TITLE
Java: Retroactively add release notes for IAS support

### DIFF
--- a/docs-java/features/connectivity/003-service-bindings.mdx
+++ b/docs-java/features/connectivity/003-service-bindings.mdx
@@ -166,7 +166,7 @@ In case your service is not using the default format you can still use the `IasO
 ```java
 var options = ServiceBindingDestinationOptions
         .forService(ServiceIdentifier.IDENTITY_AUTHENTICATION)
-        .withOption(IasOptions.withTargetUri("https://foo.com"))
+        .withOption(BtpServiceOptions.IasOptions.withTargetUri("https://foo.com"))
         .build();
 ```
 
@@ -179,8 +179,8 @@ In case the service does not require a JWT token (e.g. the Event Broker service)
 ```java {4,5}
 var options = ServiceBindingDestinationOptions
         .forService(ServiceIdentifier.IDENTITY_AUTHENTICATION)
-        .withOption(IasOptions.withTargetUri("https://foo.com"))
-        .withOption(IasOptions.withoutTokenForTechnicalProviderUser())
+        .withOption(BtpServiceOptions.IasOptions.withTargetUri("https://foo.com"))
+        .withOption(BtpServiceOptions.IasOptions.withoutTokenForTechnicalProviderUser())
         .onBehalfOf(OnBehalfOf.TECHNICAL_USER_PROVIDER)
         .build();
 ```
@@ -199,8 +199,8 @@ In case you want to connect to a system that is registered as an application wit
 ```java {3}
 var options = ServiceBindingDestinationOptions
         .forService(ServiceIdentifier.IDENTITY_AUTHENTICATION)
-        .withOption(IasOptions.withApplicationName("application-name"))
-        .withOption(IasOptions.withTargetUri("https://foo.com"))
+        .withOption(BtpServiceOptions.IasOptions.withApplicationName("application-name"))
+        .withOption(BtpServiceOptions.IasOptions.withTargetUri("https://foo.com"))
         .build();
 ```
 
@@ -211,8 +211,8 @@ If you received an incoming request from an application using IAS you can use th
 ```java {3}
 var options = ServiceBindingDestinationOptions
         .forService(ServiceIdentifier.IDENTITY_AUTHENTICATION)
-        .withOption(IasOptions.withConsumerClient("client-id", "tenant-id"))
-        .withOption(IasOptions.withTargetUri("https://foo.com"))
+        .withOption(BtpServiceOptions.IasOptions.withConsumerClient("client-id", "tenant-id"))
+        .withOption(BtpServiceOptions.IasOptions.withTargetUri("https://foo.com"))
         .build();
 ```
 

--- a/docs-java/release-notes/release-notes-0-to-14.mdx
+++ b/docs-java/release-notes/release-notes-0-to-14.mdx
@@ -18,6 +18,12 @@
 
 ### ✨ New Functionality
 
+- Add support for connecting to applications and services backed by the [SAP Identity Authentication Service (IAS)](https://help.sap.com/docs/identity-authentication).
+  - The `ServiceBindingDestinationLoader` API now supports service bindings to the IAS service.
+  - The `BtpServiceOptions` class has now offers `IasOptions` to pass additional options depending on the use case.
+  - A standardised service binding format for IAS-backed services is introduced.
+  - Support connecting to arbitrary services as long as their service binding conforms to the standardised format.
+  - Head over to [the documentation](/docs/java/features/connectivity/service-bindings#using-the-identity-and-authentication-service-ias) for more information on the new features.
 - Support service bindings to the [SAP BTP AI Core Service](https://api.sap.com/api/AI_CORE_API) by default in the `ServiceBindingDestinationLoader` API.
 - Failed OData v4 Batch requests now return the specific failed request from the exception: `ODataResponseException.getRequest()`.
 


### PR DESCRIPTION
At the time of the release the docs weren't available yet, thus adding it now retroactively..