### PR TITLE
Javascript: Custom request config default disallowed keys

### DIFF
--- a/docs-js/features/common/custom-request-config-note.mdx
+++ b/docs-js/features/common/custom-request-config-note.mdx
@@ -2,7 +2,6 @@
 
 To ensure API consistency, the SAP Cloud SDK does not allow overriding the following options:
 
-- `method`
 - `url`
 - `baseURL`
 - `data`


### PR DESCRIPTION
## What Has Changed?

While investigating SAP/cloud-sdk-backlog#1187, I found out that the documentation for **Setting a Custom Request Configuration** was not updated fully after `method` was removed from `defaultDisallowedKeys` in `http-request` to support custom http request method [in this PR](https://github.com/SAP/cloud-sdk-js/pull/2303). 

This update removes the `method` option from the disallowed overwrites to align with the above mentioned PR. 


