### PR TITLE
chore: add warning for frontend usage

### DIFF
--- a/docs-java/features/connectivity/003-service-bindings.mdx
+++ b/docs-java/features/connectivity/003-service-bindings.mdx
@@ -154,7 +154,6 @@ The code above instructs the SAP Cloud SDK to
 This configuration results in a destination that uses the XSUAA instance of your application to authenticate against, but communicates with the system reachable under the provided URI.
 Without the option specified in line 3, the destination would target the XSUAA instance itself.
 
-
 :::note Principal Propagation with IAS
 
 For IAS-based applications and services principal propagation requires additional configuration.

--- a/docs-js/guides/sdk-in-browser.mdx
+++ b/docs-js/guides/sdk-in-browser.mdx
@@ -12,6 +12,12 @@ keywords:
   - sap cloud sdk
 ---
 
+:::danger Warning
+
+The SAP Cloud SDK no longer supports frontend use cases, therefore we do not recommend its usage in the browser anymore.
+
+:::
+
 The SAP Cloud SDK for JavaScript can be used both as a backend and frontend library when used in a browser.
 Because of the specifics of a browser environment, some features might be unavailable.
 To help you get up and running faster in a browser, this document outlines the main steps and caveats of using SAP Cloud SDK on the frontend.


### PR DESCRIPTION
## What Has Changed?

As we dropped our frontend E2E tests, we no longer actively support it.
This PR adds a warning to our frontend guide.