### PR TITLE
[Java] Added missing classes in upgrade guide

### DIFF
--- a/docs-java/guides/5.0-upgrade-steps.mdx
+++ b/docs-java/guides/5.0-upgrade-steps.mdx
@@ -357,6 +357,11 @@ Once the build doesn't complain about missing dependency versions anymore, you c
         <td>No replacement necessary</td>
       </tr>
       <tr>
+        <td>ScpCfAuthTokenFacade</td>
+        <td>DefaultAuthTokenFacade</td>
+        <td>-</td>
+      </tr>
+      <tr>
         <td>ScpCfDestination</td>
         <td>-</td>
         <td>No replacement necessary</td>

--- a/docs-java/guides/5.0-upgrade-steps.mdx
+++ b/docs-java/guides/5.0-upgrade-steps.mdx
@@ -362,6 +362,16 @@ Once the build doesn't complain about missing dependency versions anymore, you c
         <td>No replacement necessary</td>
       </tr>
       <tr>
+        <td>ScpCfDestinationLoader</td>
+        <td>DestinationService</td>
+        <td>-</td>
+      </tr>
+      <tr>
+        <td>ScpCfDestinationOptionsAugmenter</td>
+        <td>DestinationServiceOptionsAugmenter</td>
+        <td>-</td>
+      </tr>
+      <tr>
         <td>ScpCfDestinationServiceResponseProvider</td>
         <td>-</td>
         <td>No replacement necessary</td>


### PR DESCRIPTION
## What Has Changed?

Some classes were renamed in v5 but not mentioned in the upgrade guide.
