### PR TITLE
chore: Add mail multi tenancy documentation

### DIFF
--- a/docs-js/features/connectivity/destination.mdx
+++ b/docs-js/features/connectivity/destination.mdx
@@ -303,7 +303,7 @@ In the following, the term "subscriber account" will be used for the accounts us
 For simplicity, an optional argument of the destination lookup has been neglected in the beginning:
 
 ```ts
-await req.execute({ destinationName: 'DESTINATION', jwt: 'yourJWT' });
+await req.execute({ destinationName: 'DESTINATION', jwt: '<JWT>' });
 ```
 
 The `jwt` argument takes the JSON web token (JWT) issued by an XSUAA as input.

--- a/docs-js/features/mail-client/mail-client.mdx
+++ b/docs-js/features/mail-client/mail-client.mdx
@@ -173,7 +173,7 @@ You can disable the parallelization by passing `parallel: false` as mentioned ab
 
 :::
 
-### Mutli-Tenancy
+### Multi-Tenancy
 
 If you are setting up a multi-tenant application where subscriber tenants access a mail destination through their SAP Cloud Connector (SCC), you must include the user's JSON Web Token (JWT) in your call.
 

--- a/docs-js/features/mail-client/mail-client.mdx
+++ b/docs-js/features/mail-client/mail-client.mdx
@@ -177,7 +177,7 @@ You can disable the parallelization by passing `parallel: false` as mentioned ab
 
 If you are setting up a multi-tenant application where subscriber tenants access a mail destination through their SAP Cloud Connector (SCC), you must include the user's JSON Web Token (JWT) in your call.
 
-An example, in which the incoming request contains the user's JWT, would look like this:
+An example in which the incoming request contains the user's JWT looks like this:
 
 ```ts
 import { retrieveJwt } from '@sap-cloud-sdk/connectivity';

--- a/docs-js/features/mail-client/mail-client.mdx
+++ b/docs-js/features/mail-client/mail-client.mdx
@@ -175,9 +175,9 @@ You can disable the parallelization by passing `parallel: false` as mentioned ab
 
 ### Mutli-Tenancy
 
-If you are trying to set up a multi-tenancy application, where subscriber tenants try to access a mail destination through their own SAP Cloud Connector (SCC), you have to include a user jwt in your call.
+If you are trying to set up a multi-tenancy application, where subscriber tenants try to access a mail destination through their own SAP Cloud Connector (SCC), you have to include the user's JSON Web Token (JWT) in your call.
 
-An example, in which the incoming request contains the user's jwt, would look like this:
+An example, in which the incoming request contains the user's JWT, would look like this:
 
 ```ts
 import { retrieveJwt } from '@sap-cloud-sdk/connectivity';

--- a/docs-js/features/mail-client/mail-client.mdx
+++ b/docs-js/features/mail-client/mail-client.mdx
@@ -172,3 +172,17 @@ For some on-premise e-mail servers, including the test server, the parallelizati
 You can disable the parallelization by passing `parallel: false` as mentioned above.
 
 :::
+
+### Mutli-Tenancy
+
+If you are trying to set up a multi-tenancy application, where subscriber tenants try to access a mail destination through their own SAP Cloud Connector (SCC), you have to include a user jwt in your call.
+
+An example, in which the incoming request contains the user's jwt, would look like this:
+
+```ts
+import { retrieveJwt } from '@sap-cloud-sdk/connectivity';
+sendMail(
+  { destinationName: 'my-mail-destination', jwt: retrieveJwt(request) },
+  [mailConfig]
+);
+```

--- a/docs-js/features/mail-client/mail-client.mdx
+++ b/docs-js/features/mail-client/mail-client.mdx
@@ -175,7 +175,7 @@ You can disable the parallelization by passing `parallel: false` as mentioned ab
 
 ### Mutli-Tenancy
 
-If you are trying to set up a multi-tenancy application, where subscriber tenants try to access a mail destination through their own SAP Cloud Connector (SCC), you have to include the user's JSON Web Token (JWT) in your call.
+If you are setting up a multi-tenant application where subscriber tenants access a mail destination through their SAP Cloud Connector (SCC), you must include the user's JSON Web Token (JWT) in your call.
 
 An example, in which the incoming request contains the user's JWT, would look like this:
 

--- a/docs-js/guides/bas-external-system.mdx
+++ b/docs-js/guides/bas-external-system.mdx
@@ -116,7 +116,7 @@ The SAP Cloud SDK has a [destination lookup](../features/connectivity/destinatio
 The trick is to define a `destinations` environment variable when you run locally, which works like a switch under the hood when you execute:
 
 ```ts
-executeHttpRequest({ destinationName: 'myDestinationName', jwt: 'myJWT' });
+executeHttpRequest({ destinationName: 'myDestinationName', jwt: '<JWT>' });
 ```
 
 The code is the same for local execution and production.

--- a/docs-js_versioned_docs/version-v1/features/connectivity/destination-cache-isolation.mdx
+++ b/docs-js_versioned_docs/version-v1/features/connectivity/destination-cache-isolation.mdx
@@ -29,7 +29,7 @@ All the discussed options apply to the `execute()` and `getDestination()` method
 The destination caching is disabled by default and you switch it on by the `useCache` flag:
 
 ```ts
-.execute({ destinationName: 'myDestination', jwt: 'yourJWT' }, { useCache: true })
+.execute({ destinationName: 'myDestination', jwt: '<JWT>' }, { useCache: true })
 ```
 
 A cached destination is stored for 5 minutes in the cache.

--- a/docs-js_versioned_docs/version-v1/features/connectivity/destination.mdx
+++ b/docs-js_versioned_docs/version-v1/features/connectivity/destination.mdx
@@ -240,7 +240,7 @@ After this little definition detour, let's go back to the destination service an
 For simplicity, an optional argument of the destination lookup has been neglected in the beginning:
 
 ```ts
-.execute({ destinationName: 'myDestination', jwt: 'yourJWT',})
+.execute({ destinationName: 'myDestination', jwt: '<JWT>',})
 ```
 
 The `jwt` argument takes the JSON web token (JWT) issued by an XSUAA as input.
@@ -259,7 +259,7 @@ If no token is given or the destination is not found in the subscriber account, 
 To control this fallback behavior, a selection strategy can be passed to the destination lookup:
 
 ```ts
-.execute({ destinationName: 'myDestination', jwt: 'yourJWT' }, { selectionStrategy:'alwaysSubscriber' })
+.execute({ destinationName: 'myDestination', jwt: '<JWT>' }, { selectionStrategy:'alwaysSubscriber' })
 ```
 
 There are three selection strategies defined in the SAP Cloud SDK: `alwaysSubscriber`, `alwaysProvider`, and `subscriberFirst`.

--- a/docs-js_versioned_docs/version-v1/guides/bas-external-system.mdx
+++ b/docs-js_versioned_docs/version-v1/guides/bas-external-system.mdx
@@ -116,7 +116,7 @@ The SAP Cloud SDK has a [destination lookup](../features/connectivity/destinatio
 The trick is to define a `destinations` environment variable when you run locally, which works like a switch under the hood when you execute:
 
 ```ts
-executeHttpRequest({ destinationName: 'myDestinationName', jwt: 'myJWT' });
+executeHttpRequest({ destinationName: 'myDestinationName', jwt: '<JWT>' });
 ```
 
 The code is the same for local execution and production.

--- a/docs-js_versioned_docs/version-v2/features/connectivity/destination-cache-isolation.mdx
+++ b/docs-js_versioned_docs/version-v2/features/connectivity/destination-cache-isolation.mdx
@@ -29,7 +29,7 @@ The destination caching is disabled by default.
 Setting the `useCache` flag to `true` enables it:
 
 ```ts
-.execute({ destinationName: 'myDestination', jwt: 'yourJWT', useCache: true })
+.execute({ destinationName: 'myDestination', jwt: '<JWT>', useCache: true })
 ```
 
 A cached destination is stored for 5 minutes in the cache.

--- a/docs-js_versioned_docs/version-v2/features/connectivity/destination.mdx
+++ b/docs-js_versioned_docs/version-v2/features/connectivity/destination.mdx
@@ -325,7 +325,7 @@ In the following, the term "subscriber account" will be used for the accounts us
 For simplicity, an optional argument of the destination lookup has been neglected in the beginning:
 
 ```ts
-MyRequest.execute({ destinationName: 'myDestination', jwt: 'yourJWT' });
+MyRequest.execute({ destinationName: 'myDestination', jwt: '<JWT>' });
 ```
 
 The `jwt` argument takes the JSON web token (JWT) issued by an XSUAA as input.

--- a/docs-js_versioned_docs/version-v2/guides/bas-external-system.mdx
+++ b/docs-js_versioned_docs/version-v2/guides/bas-external-system.mdx
@@ -116,7 +116,7 @@ The SAP Cloud SDK has a [destination lookup](../features/connectivity/destinatio
 The trick is to define a `destinations` environment variable when you run locally, which works like a switch under the hood when you execute:
 
 ```ts
-executeHttpRequest({ destinationName: 'myDestinationName', jwt: 'myJWT' });
+executeHttpRequest({ destinationName: 'myDestinationName', jwt: '<JWT>' });
 ```
 
 The code is the same for local execution and production.


### PR DESCRIPTION
## What Has Changed?

This PR relates to our latest addition of multi-tenancy in on-premise mail destinations.
See: https://github.com/SAP/cloud-sdk-js/pull/4808

I also took the liberty to unify the spelling of the  `JWT` placeholder.
