### PR TITLE
chore: Reference GenAI contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,7 @@ SAP uses [the standard DCO text of the Linux Foundation](https://developercertif
 
 ## Contributing with AI-generated Code
 
-As artificial intelligence evolves, AI-generated code is becoming valuable for many software projects, including open-source initiatives. While we recognize the potential benefits of incorporating AI-generated content into our open-source projects there a certain requirements that need to be reflected and adhered to when making contributions.
+As artificial intelligence evolves, AI-generated code is becoming valuable for many software projects, including open-source initiatives. 
+While we recognize the potential benefits of incorporating AI-generated content into our open-source projects there a certain requirements that need to be reflected and adhered to when making contributions.
 
 Please see our [Guideline for AI-generated code contributions to SAP Open Source Software Projects](https://github.com/SAP/.github/blob/main/CONTRIBUTING_USING_GENAI.md) for more details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,3 +102,9 @@ Once you are part of the team, you can submit `pull requests` without forking th
 Due to legal reasons, contributors will be asked to accept a DCO before they submit the first pull request to this project.
 This happens in an automated fashion during the submission process.
 SAP uses [the standard DCO text of the Linux Foundation](https://developercertificate.org/).
+
+## Contributing with AI-generated Code
+
+As artificial intelligence evolves, AI-generated code is becoming valuable for many software projects, including open-source initiatives. While we recognize the potential benefits of incorporating AI-generated content into our open-source projects there a certain requirements that need to be reflected and adhered to when making contributions.
+
+Please see our [Guideline for AI-generated code contributions to SAP Open Source Software Projects](https://github.com/SAP/.github/blob/main/CONTRIBUTING_USING_GENAI.md) for more details.


### PR DESCRIPTION
## What Has Changed?

AI/gen-ai-hub-sdk-js-backlog#140.

Reference GenAI contribution guidelines as requested by OSPO.
