### PR TITLE
add top(1) to call to bussinessPartnerAPI

### DIFF
--- a/docs-js/tutorials/getting-started/2-execute-odata-request.mdx
+++ b/docs-js/tutorials/getting-started/2-execute-odata-request.mdx
@@ -214,6 +214,7 @@ async getAllBusinessPartners(): Promise<BusinessPartner[]> {
   return await businessPartnerApi
     .requestBuilder()
     .getAll()
+    .top(1)
     .addCustomHeaders({ APIKey: '<YOUR-API-KEY>' })
     .execute({
       url: 'https://sandbox.api.sap.com/s4hanacloud'


### PR DESCRIPTION
without it I get: "statusCode":500,"message":"Failed to get business partners - get request to https://sandbox.api.sap.com/s4hanacloud/sap/opu/odata/sap/API_BUSINESS_PARTNER failed! "}

Also noted here: https://github.com/SAP/cloud-sdk-js/issues/2896

## What Has Changed?

get the top(1) result because it shows an error
