### PR TITLE
Remove CAP project diagram

### DIFF
--- a/docs/about.mdx
+++ b/docs/about.mdx
@@ -63,6 +63,4 @@ CAP plays on the API and service publishing side, while SAP Cloud SDK deals with
 The SAP Cloud SDK is also used internally by CAP for consuming remote services of SAP and other solutions.
 If you do not interact with other services or SAP solutions, you may not need the capabilities of the SAP Cloud SDK.
 
-![CAP project diagram](https://cap.cloud.sap/docs/assets/overview.drawio.bcd4584e.svg)
-
 Depending on your use case, you can use SAP Cloud SDK and SAP Cloud Application Programming Model individually or in combination.


### PR DESCRIPTION
## What Has Changed?

Removed the CAP project diagram because the file went missing. Could not find the file again.
