### PR TITLE
[JS] Add documentation for setting custom base path (v3)

### DIFF
--- a/docs-js/features/odata/execute-odata-request.mdx
+++ b/docs-js/features/odata/execute-odata-request.mdx
@@ -231,7 +231,7 @@ const { myEntityApi } = myEntityService();
 myEntityApi.requestBuilder().getAll().setBasePath('my/custom/service/path');
 ```
 
-This will change the base path of your request.
+This will change the base path of the request.
 Executing the example request above against a destination with the URL `https://my.s4-system.com` will result in a request against the target like this: `https://my.s4-system.com/my/custom/service/path/MyEntity`.
 
 ### Setting a Custom Request Configuration

--- a/docs-js_versioned_docs/version-v3/features/openapi/execute-openapi-request.mdx
+++ b/docs-js_versioned_docs/version-v3/features/openapi/execute-openapi-request.mdx
@@ -120,9 +120,7 @@ A custom base path can be manually set in the `options-per-service.json` during 
 It can also be adjusted per request by using the `setBasePath()` method:
 
 ```ts
-MyApi.myFunction()
-  .setBasePath('/base/path/to/service')
-  .execute(destination);
+MyApi.myFunction().setBasePath('/base/path/to/service').execute(destination);
 ```
 
 This will change the base path of your request.

--- a/docs-js_versioned_docs/version-v3/features/openapi/execute-openapi-request.mdx
+++ b/docs-js_versioned_docs/version-v3/features/openapi/execute-openapi-request.mdx
@@ -116,14 +116,14 @@ MyEntity.requestBuilder()
 
 ### Setting a Custom Service Path
 
-A custom base path can be manually set in the `options-per-service.json` during client generation.
+A custom service path can be manually set in the `options-per-service.json` by providing a `basePath` property during client generation.
 It can also be adjusted per request by using the `setBasePath()` method:
 
 ```ts
 MyApi.myFunction().setBasePath('/base/path/to/service').execute(destination);
 ```
 
-This will change the base path of your request.
+This will change the base path of the request.
 Executing the example request above against a destination with the URL `https://my.some-system.com` will result in a request against the target like this: `https://my.some-system.com/base/path/to/service/function/path`, where `/function/path` is the API path parameter.
 
 ### Setting Middlewares

--- a/docs-js_versioned_docs/version-v3/features/openapi/execute-openapi-request.mdx
+++ b/docs-js_versioned_docs/version-v3/features/openapi/execute-openapi-request.mdx
@@ -114,7 +114,7 @@ MyEntity.requestBuilder()
 
 <CustomRequestConfigNote />
 
-### Setting a Custom Base Path
+### Setting a Custom Service Path
 
 A custom base path can be manually set in the `options-per-service.json` during client generation.
 It can also be adjusted per request by using the `setBasePath()` method:

--- a/docs-js_versioned_docs/version-v3/features/openapi/execute-openapi-request.mdx
+++ b/docs-js_versioned_docs/version-v3/features/openapi/execute-openapi-request.mdx
@@ -124,7 +124,7 @@ MyApi.myFunction().setBasePath('/base/path/to/service').execute(destination);
 ```
 
 This will change the base path of the request.
-Executing the example request above against a destination with the URL `https://my.some-system.com` will result in a request against the target like this: `https://my.some-system.com/base/path/to/service/function/path`, where `/function/path` is the API path parameter.
+Executing the example request above against a destination with the URL `https://my.some-system.com` will result in a request against the target like this: `https://my.some-system.com/base/path/to/service/myFunctionPath`, where `/myFunctionPath` is the API path parameter.
 
 ### Setting Middlewares
 

--- a/docs-js_versioned_docs/version-v3/features/openapi/execute-openapi-request.mdx
+++ b/docs-js_versioned_docs/version-v3/features/openapi/execute-openapi-request.mdx
@@ -114,6 +114,20 @@ MyEntity.requestBuilder()
 
 <CustomRequestConfigNote />
 
+### Setting a Custom Base Path
+
+A custom base path can be manually set in the `options-per-service.json` during client generation.
+It can also be adjusted per request by using the `setBasePath()` method:
+
+```ts
+MyApi.myFunction()
+  .setBasePath('/base/path/to/service')
+  .execute(destination);
+```
+
+This will change the base path of your request.
+Executing the example request above against a destination with the URL `https://my.some-system.com` will result in a request against the target like this: `https://my.some-system.com/base/path/to/service/function/path`, where `/function/path` is the API path parameter.
+
 ### Setting Middlewares
 
 You can specify middlewares for a request via the `middleware()` method on the request builder:

--- a/docs-js_versioned_docs/version-v3/features/openapi/generate-openapi-client.mdx
+++ b/docs-js_versioned_docs/version-v3/features/openapi/generate-openapi-client.mdx
@@ -50,7 +50,7 @@ This file is used for customizing subdirectory naming and contains a mapping fro
 
 - `directoryName`: the name of the subdirectory the client code will be generated into.
 - `packageName`: the name of the npm package, if a package.json file is generated.
-This information is optional.
+  This information is optional.
 - `basePath`: the URL path to be prepended before the API path before every request.
 
 This information can be adjusted manually and ensures that every run of the generator produces the same names for the generation.

--- a/docs-js_versioned_docs/version-v3/features/openapi/generate-openapi-client.mdx
+++ b/docs-js_versioned_docs/version-v3/features/openapi/generate-openapi-client.mdx
@@ -51,7 +51,7 @@ This file is used for customizing subdirectory naming and contains a mapping fro
 - `directoryName`: the name of the subdirectory the client code will be generated into.
 - `packageName`: the name of the npm package, if a package.json file is generated.
   This information is optional.
-- `basePath`: the URL path to be prepended before the API path for every request.
+- `basePath`: the URL path to be prepended to the API path before every request.
 
 This information can be adjusted manually and ensures that every run of the generator produces the same names for the generation.
 

--- a/docs-js_versioned_docs/version-v3/features/openapi/generate-openapi-client.mdx
+++ b/docs-js_versioned_docs/version-v3/features/openapi/generate-openapi-client.mdx
@@ -51,7 +51,7 @@ This file is used for customizing subdirectory naming and contains a mapping fro
 - `directoryName`: the name of the subdirectory the client code will be generated into.
 - `packageName`: the name of the npm package, if a package.json file is generated.
   This information is optional.
-- `basePath`: the URL path to be prepended before the API path before every request.
+- `basePath`: the URL path to be prepended before the API path for every request.
 
 This information can be adjusted manually and ensures that every run of the generator produces the same names for the generation.
 

--- a/docs-js_versioned_docs/version-v3/features/openapi/generate-openapi-client.mdx
+++ b/docs-js_versioned_docs/version-v3/features/openapi/generate-openapi-client.mdx
@@ -49,7 +49,8 @@ An `options-per-service.json` file is created using the `--optionsPerService` op
 This file is used for customizing subdirectory naming and contains a mapping from the original file name to the following information:
 
 - `directoryName`: the name of the subdirectory the client code will be generated into.
-- `packageName`: the name of the npm package, if a package.json file is generated. This information is optional.
+- `packageName`: the name of the npm package, if a package.json file is generated.
+This information is optional.
 - `basePath`: the URL path to be prepended before the API path before every request.
 
 This information can be adjusted manually and ensures that every run of the generator produces the same names for the generation.

--- a/docs-js_versioned_docs/version-v3/features/openapi/generate-openapi-client.mdx
+++ b/docs-js_versioned_docs/version-v3/features/openapi/generate-openapi-client.mdx
@@ -41,6 +41,31 @@ npx openapi-generator --input <input> --outputDir <outputDirectory>
 
 The `<input>` points to your specification file or a directory containing the specification(s) and `<outputDirectory>` to the target folder where the generated client(s) will be saved.
 
+An `options-per-service.json` file is created using the `--optionsPerService` option.
+
+- When set to a directory path, an `options-per-service.json` file is read from or created in the given directory.
+- When set to a file path, the file is read or created with the given name.
+
+This file is used for customizing subdirectory naming and contains a mapping from the original file name to the following information:
+
+- `directoryName`: the name of the subdirectory the client code will be generated into.
+- `packageName`: the name of the npm package, if a package.json file is generated. This information is optional.
+- `basePath`: the URL path to be prepended before the API path parameter for every request.
+
+This information can be adjusted manually and ensures that every run of the generator produces the same names for the generation.
+
+Example:
+
+```json
+{
+  "path/to/your/service-specifications/MyService.yaml": {
+    "directoryName": "my-service",
+    "basePath": "/base/path/to/service",
+    "packageName": "my-service"
+  }
+}
+```
+
 By default, the generated clients will each contain:
 
 - API files as `.ts` files - one for each "API" in the service.

--- a/docs-js_versioned_docs/version-v3/features/openapi/generate-openapi-client.mdx
+++ b/docs-js_versioned_docs/version-v3/features/openapi/generate-openapi-client.mdx
@@ -50,7 +50,7 @@ This file is used for customizing subdirectory naming and contains a mapping fro
 
 - `directoryName`: the name of the subdirectory the client code will be generated into.
 - `packageName`: the name of the npm package, if a package.json file is generated. This information is optional.
-- `basePath`: the URL path to be prepended before the API path parameter for every request.
+- `basePath`: the URL path to be prepended before the API path before every request.
 
 This information can be adjusted manually and ensures that every run of the generator produces the same names for the generation.
 


### PR DESCRIPTION
## What Has Changed?

Adding documentation for `setBasePath` and  `basePath` support in `options-per-service.json` file.
Changes for v3, new version `3.25.0` already released.

~**If you are working on the Java v4 docs, remember to also apply the changes to v5**~
