### PR TITLE
fix: Ignore linting generated & minified files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,5 +24,5 @@ module.exports = {
   rules: {
     'react/prop-types': 'off'
   },
-  ignorePatterns: ['build/**', 'node_modules/**']
+  ignorePatterns: ['build/**', 'node_modules/**', 'static/**']
 };


### PR DESCRIPTION
## What Has Changed?

Currently, the `lint:fix` command fails in `main` with a syntax error in `static/api/v3/assets/main.js`.
But, these are minified files which have been generated, linting is not required to be run on these folders. 

This PR excludes these folders from linting.

**If you are working on the Java v4 docs, remember to also apply the changes to v5**
