### PR TITLE
Improve JS `getDestinationFromServiceBinding()` doc

### DIFF
--- a/docs-js/features/connectivity/destination.mdx
+++ b/docs-js/features/connectivity/destination.mdx
@@ -200,7 +200,7 @@ The SAP Cloud SDK provides a default implementation for the transformation of se
 
 The default implementation also retrieves a service token, if needed.
 
-Additionally, we provide a function to transform service bindings into OAuth2ClientCredentials destinations, assuming the service binding follows the structure outlined below:
+Additionally, if the service binding follows the structure, we provide a transform function `transformServiceBindingToClientCredentialsDestination()` to transform the service binding to an `OAuth2ClientCredentials` destination.
 
 ```json
 {
@@ -221,30 +221,33 @@ Additionally, we provide a function to transform service bindings into OAuth2Cli
 }
 ```
 
-If the service URL is not specified in the `url` property, it can alternatively be provided as part of the `options` parameter.
-
-The following is a multi-tenant example, where the user's JWT is used for tenant-isolation in the cache together with a custom URL as target.
+The following example shows how to retrieve an `OAuth2ClientCredentials` destination from a service binding with retrieved jwt from the incoming request, and a custom URL:
 
 ```ts
-const serviceBinding = getServiceBinding('custom-service');
 const userJwt = retrieveJwt(request);
 const destination = getDestinationFromServiceBinding({
-  destinationName: 'custom-service',
+  destinationName: 'my-custom-service',
   jwt: userJwt,
   useCache: true,
-  transformServiceBindingToClientCredentialsDestination(serviceBinding, { url: 'custom-url', jwt: userJwt })
+  serviceBindingTransformFn: async (service, options) => transformServiceBindingToClientCredentialsDestination({
+    service,
+    {
+      ...options,
+      url: 'https://example.com'
+    }
+  })
 })
 ```
 
-For other types of service bindings or if you want to overwrite the default behavior, provide a callback function (`serviceBindingTransformFn()`) in the request execution.
+For other service binding structure, write your own transform function of type `ServiceBindingTransformFunction`.
 
-For example, if you have a binding for a custom service:
+For example, if you have the following binding for a custom service:
 
 ```json
 {
   "VCAP_SERVICES": {
     "custom-service": [
-      // This object is passed to `serviceBindingTransformFn()`
+      // This is the `service` object passed to `serviceBindingTransformFn()` function.
       {
         "name": "my-custom-service",
         "label": "custom-service",
@@ -259,8 +262,7 @@ For example, if you have a binding for a custom service:
 }
 ```
 
-To transform this custom service binding you need to provide the `serviceBindingTransformFn()` function.
-In the example below, we access the `service.credentials` to create a destination with authentiction type "BasicAuthentication".
+You can write the following `serviceBindingTransformFn()` to create a destination with authentiction type "BasicAuthentication".
 
 ```ts
 await req.execute({

--- a/docs-js/features/connectivity/destination.mdx
+++ b/docs-js/features/connectivity/destination.mdx
@@ -221,7 +221,7 @@ Additionally, if the service binding follows the structure, we provide a transfo
 }
 ```
 
-The following example shows how to retrieve an `OAuth2ClientCredentials` destination from a service binding with retrieved jwt from the incoming request, and a custom URL:
+The following example shows how to retrieve an `OAuth2ClientCredentials` destination from a service binding with retrieved JWT from the incoming request, and a custom URL:
 
 ```ts
 const userJwt = retrieveJwt(request);
@@ -262,7 +262,7 @@ For example, if you have the following binding for a custom service:
 }
 ```
 
-You can write the following `serviceBindingTransformFn()` to create a destination with authentiction type "BasicAuthentication".
+You can write the following `serviceBindingTransformFn()` to create a destination with authentication type "BasicAuthentication".
 
 ```ts
 await req.execute({

--- a/docs-js/features/connectivity/destination.mdx
+++ b/docs-js/features/connectivity/destination.mdx
@@ -239,7 +239,7 @@ const destination = getDestinationFromServiceBinding({
 })
 ```
 
-For other service binding structure, write your own transform function of type `ServiceBindingTransformFunction`.
+For a different service binding structure, write your own transform function of type `ServiceBindingTransformFunction`.
 
 For example, if you have the following binding for a custom service:
 


### PR DESCRIPTION
## What Has Changed?

https://github.com/SAP/cloud-sdk-js/issues/5517

The current usage for using the `serviceBindingTransformFn` function is wrong. Also improved the overall doc which was confusing to the user.