### PR TITLE
(JS) Update default value of `iasToXsuaaTokenExchange` to `false` in V4 documentation

### DIFF
--- a/docs-js/features/connectivity/destination.mdx
+++ b/docs-js/features/connectivity/destination.mdx
@@ -490,7 +490,7 @@ A few of the options were already listed above, but this section gives a compreh
   Default is `subscriberFirst`.
   Alternative values are `alwaysProvider` and `alwaysSubscriber`.
 - `iasToXsuaaTokenExchange`: Switches on token exchange from IAS format tokens to XSUAA if needed using the `@sap/xssec` library.
-  The default value is `true`.
+  The default value is `false`.
 - `cacheVerificationKeys`: Switches on caching for the verification certificates for the JWT.
   The default value is `true`.
 - `useCache`: Switches on caching for destinations received from the destination service.


### PR DESCRIPTION
## What Has Changed?

Relates to SAP/ai-sdk-js-backlog#192

We disable `iasToXsuaaTokenExchange` by default in v4. Updating the docs.