### PR TITLE
Discourage users from disabling local caching

### DIFF
--- a/docs-js/guides/upgrade-to-version-4.mdx
+++ b/docs-js/guides/upgrade-to-version-4.mdx
@@ -15,8 +15,8 @@ The To-Do list is:
 
 - [Update Your Project Dependencies](#update-your-project-dependencies)
 - [Update to Node 22 or Newer](#update-to-node-22-or-newer)
-- [Set `useCache` explicitly to `false` to turn off destination caching](#set-usecache-explicitly-to-false-to-turn-off-destination-caching)
-- [Set `iasToXsuaaTokenExchange` to `true` to enable IAS to XSUAA token exchange](#set-iastoxsuaatokenexchange-to-true-to-enable-ias-to-xsuaa-token-exchange)
+- [Optionally, set `useCache` explicitly to `false` to turn off destination caching](#set-usecache-explicitly-to-false-to-turn-off-destination-caching)
+- [Optionally, set `iasToXsuaaTokenExchange` to `true` to enable IAS to XSUAA token exchange](#set-iastoxsuaatokenexchange-to-true-to-enable-ias-to-xsuaa-token-exchange)
 - [Remove Deprecated Content](#remove-deprecated-content)
 
 ## Update Your Project Dependencies
@@ -34,11 +34,13 @@ All SAP Cloud SDK for JavaScript libraries now support node 22 (LTS) as the **mi
 If you are using a node version older than 22, update your runtime environment to a newer version.
 On Cloud Foundry you can do this by [setting the node engine in your `package.json`](https://docs.cloudfoundry.org/buildpacks/node/index.html#runtime).
 
-## Set `useCache` explicitly to `false` to turn off destination caching
+## Optionally, set `useCache` explicitly to `false` to turn off destination caching
 
 **Destination caching while retrieving destinations via the destination service is now enabled by default.**
 
 This change affects the default behaviour of `getDestination()` method, `getAllDestinationsFromDestinationService()` method, generated client's `execute()` method and generic HTTP requests execution using `executeHttpRequest()`.
+
+**Note: It is not recommended to disable the caching unless this is strictly required.**
 
 To disable caching set `useCache: false` in the options, for example in `execute()` method:
 
@@ -46,7 +48,7 @@ To disable caching set `useCache: false` in the options, for example in `execute
 .execute({ destinationName: 'DESTINATION', jwt: 'JWT', useCache: false })
 ```
 
-## Set `iasToXsuaaTokenExchange` to `true` to enable IAS to XSUAA token exchange
+## Optionally, set `iasToXsuaaTokenExchange` to `true` to enable IAS to XSUAA token exchange
 
 **Token exchange from IAS to XSUAA is now disabled by default.
 Set `iasToXsuaaTokenExchange` to `true` explicitly if token exchange is expected.**


### PR DESCRIPTION
It is of high importance that clients use local cache whenever and wherever possible. This has direct impact on the overall load towards central services. Therefore, users shall be encouraged to use local caching and do not disable it unless it is strictly required.

In addition, this change proposal marks the other optional action (iasToXsuaaTokenExchange) as such, to keep the same approach on bullet and section naming.

## What Has Changed?

1. The bullet and section naming of optional actions is changed accordingly to be clear that those actions are optional.
2. In the section for the destination caching, a note is added to make it clear for the users that they should not disable the local caching unless it's strictly required.

Regards,
Manol Valchev
Product Lead & Area Product Owner of [SAP BTP Connectivity](https://help.sap.com/docs/connectivity)