### PR TITLE
docs: Add missing release note for JS 4.0.1 and 3.26.4

### DIFF
--- a/docs-js/release-notes.mdx
+++ b/docs-js/release-notes.mdx
@@ -28,6 +28,12 @@ import LicenseBadge from '@site/src/sap/sdk-js/LicenseBadge';
   - @sap-cloud-sdk/resilience@4.0.2
   - @sap-cloud-sdk/util@4.0.2 (4a187d6)
 
+## 4.0.1 [Core Modules] - March 05, 2025
+
+## Fixed Issues
+
+- [eslint-config] Downgrade `@stylistic/eslint-plugin` to v3 as v4 is EMS-only. (97ad0ad)
+
 ## 4.0.0 [Core Modules] - March 04, 2025
 
 ### Improvements

--- a/docs-js_versioned_docs/version-v3/release-notes.mdx
+++ b/docs-js_versioned_docs/version-v3/release-notes.mdx
@@ -20,6 +20,14 @@ import LicenseBadge from '@site/src/sap/sdk-js/LicenseBadge';
 <!-- vale off -->
 <!-- This line is used for our release notes automation -->
 
+## 3.26.4 [Core Modules] - March 18, 2025
+
+### Fixed Issues
+
+- [connectivity] Remove destination cache in `getDestinationFromServiceBinding()` function to let cached destinations retrieved in `getDestinationFromDestinationService()` function be added with the `proxyConfiguration` property.
+  - @sap-cloud-sdk/resilience@3.26.4
+  - @sap-cloud-sdk/util@3.26.4 (51cab2a)
+
 ## 3.26.3 [Core Modules] - March 05, 2025
 
 ### Fixed Issues


### PR DESCRIPTION
## What Has Changed?

Release notes for JS 4.0.1 and 3.26.4 were missing.
