### PR TITLE
chore: Adapting destination fetch documentation to reflect JWT verification step removal

### DIFF
--- a/docs-js/features/connectivity/destination.mdx
+++ b/docs-js/features/connectivity/destination.mdx
@@ -485,6 +485,7 @@ A few of the options were already listed above, but this section gives a compreh
   Alternative values are `alwaysProvider` and `alwaysSubscriber`.
 - `iasToXsuaaTokenExchange`: Switches on token exchange from IAS format tokens to XSUAA if needed using the `@sap/xssec` library.
   The default value is `false`.
+  <!-- TODO: Remove `cacheVerificationKeys` property when releasing v5 -->
 - `cacheVerificationKeys`: This property is deprecated since `v4.0.3` and has no effect as the incoming JWT is no longer verified when fetching a destination.
 - `useCache`: Switches on caching for destinations received from the destination service.
   The default value is `true`. You can set it to `false` to disable caching.
@@ -528,7 +529,12 @@ Please use the `TrustAll` with **great caution** since it opens the gate to man-
 
 ### JWT Validation
 
+<!-- TODO: Remove the warning when releasing v5 -->
+
+:::warning
 Since `v4.0.3`, the SAP Cloud SDK no longer verifies the JWT issued by the XSUAA service.
+:::
+
 If you use JWTs not issued by the XSUAA service, you can configure validation by the destination service using the `x_user_token.jwks` or `x_user_token.jwks_uri` property.
 For more details on JWTs, have a look at the more detailed [guide](../../guides/how-to-retrieve-jwt.mdx).
 

--- a/docs-js/guides/how-to-retrieve-jwt.mdx
+++ b/docs-js/guides/how-to-retrieve-jwt.mdx
@@ -42,7 +42,9 @@ A JWT issued this way contains a `JKU` header property.
 This property points to the URL where you can obtain the certificate to verify the JWT.
 The URL must be from the XSUAA domain so that it is trusted and the JWT validation does not fail.
 
-:::info
+<!-- TODO: Remove the warning when releasing v5 -->
+
+:::warning
 Since `v4.0.3` SAP Cloud SDK no longer verifies the JWT issued by XSUAA.
 :::
 


### PR DESCRIPTION
## What Has Changed?

With https://github.com/SAP/cloud-sdk-backlog/issues/1274 we removed usage of XSUAA binding during destination fetch flows. This PR contains relevant changes to documentation.

**Note: To be merged only after `v4.0.3` is released.**
