### PR TITLE
fix: Revert "Add new release notes (#2207)" from test workflow

### DIFF
--- a/docs-java/release-notes/release-notes-30-to-44.mdx
+++ b/docs-java/release-notes/release-notes-30-to-44.mdx
@@ -1,8 +1,0 @@
-## 0.43.0 - July 23, 2025
-
-[All Release Changes](https://github.com/SAP/cloud-sdk-java/releases/tag/rel%2F0.43.0)
-
-### 🐛 Fixed Issues
-
-- OData v2 and OData v4: Fixes eager HTTP response evaluation for _Create_, _Update_, and _Delete_ request builders in convenience APIs.
-  Previous change of `5.20.0` may have resulted in the HTTP connection being left open after the request was executed.


### PR DESCRIPTION
This reverts commit edd9700f8c29e6e4aeec37841d8c70480c9dad57.

## What Has Changed?

The commit in question was to test the full release workflow of Cloud SDK.
