### PR TITLE
Clarify caching behavior for SAMLAssertion destinations

### DIFF
--- a/docs-js/features/connectivity/destination-cache-isolation.mdx
+++ b/docs-js/features/connectivity/destination-cache-isolation.mdx
@@ -49,7 +49,7 @@ The destination cache holds destinations that potentially require HTTP requests,
 Registered destinations and destinations from environment variables are not held in the destination cache.
 
 :::note
-Destinations with authentication type "SAMLAssertion" are never cached.
+Destinations with authentication type "SAMLAssertion" are never cached. (versions 4.6.0 and higher)
 SAML assertions are only valid once and therefore should never be cached.
 :::
 

--- a/docs-js/features/connectivity/destination-cache-isolation.mdx
+++ b/docs-js/features/connectivity/destination-cache-isolation.mdx
@@ -48,6 +48,11 @@ The destination cache holds destinations that potentially require HTTP requests,
 
 Registered destinations and destinations from environment variables are not held in the destination cache.
 
+:::note
+Destinations with authentication type "SAMLAssertion" are never cached.
+SAML assertions are only valid once and therefore should never be cached.
+:::
+
 ### Cache Expiration
 
 Destinations include authorization information and therefore should not be cached limitlessly.


### PR DESCRIPTION
Added note about SAMLAssertion authentication type not being cached.

