### PR TITLE
chore: Use gh token instead of deploy key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,24 +11,11 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
-      - name: Add key
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-        run: |
-          mkdir -p ~/.ssh
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          echo "${{ secrets.GH_PAGES_DEPLOY }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          cat <<EOT >> ~/.ssh/config
-          Host github.com
-          HostName github.com
-          IdentityFile ~/.ssh/id_rsa
-          EOT
+          node-version: 24
       - name: Release Documentation to GitHub Pages
         env:
-          USE_SSH: true
-          GIT_USER: gh-actions
+          GIT_USER: x-access-token
+          GIT_PASS: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global user.email "gh-actions@github.com"
           git config --global user.name "gh-actions"


### PR DESCRIPTION
The token is enough.