### PR TITLE
fix: Make new Java release notes visible

### DIFF
--- a/docs-java/release-notes.mdx
+++ b/docs-java/release-notes.mdx
@@ -28,7 +28,7 @@ import MvnBadge from '@site/src/sap/sdk-java/MvnBadge';
 
 ## Should I update?
 
-:::tip SAP Cloud SDK Version 5.0.0 is out 🥳
+:::tip SAP Cloud SDK Version `5.0.0` is out 🥳
 
 We are happy to announce the latest release of the SAP Cloud SDK.
 SAP Cloud SDK Version 5.0.0 is the first release of the SAP Cloud SDK as an **open source** project under the Apache 2.0 license.

--- a/docs-java/release-notes.mdx
+++ b/docs-java/release-notes.mdx
@@ -12,7 +12,11 @@ keywords:
   - sap cloud sdk
 ---
 
-import { ReleaseNotes0To14, ReleaseNotes15To29, ReleaseNotes30To44 } from './release-notes';
+import {
+  ReleaseNotes0To14,
+  ReleaseNotes15To29,
+  ReleaseNotes30To44
+} from './release-notes';
 
 <!-- vale off -->
 

--- a/docs-java/release-notes.mdx
+++ b/docs-java/release-notes.mdx
@@ -12,7 +12,7 @@ keywords:
   - sap cloud sdk
 ---
 
-import { ReleaseNotes0To14, ReleaseNotes15To29 } from './release-notes';
+import { ReleaseNotes0To14, ReleaseNotes15To29, ReleaseNotes30To44 } from './release-notes';
 
 <!-- vale off -->
 
@@ -55,6 +55,8 @@ It will help you:
 
 ## Fixed Issues
 -->
+
+<ReleaseNotes30To44 />
 
 <ReleaseNotes15To29 />
 


### PR DESCRIPTION
## What Has Changed?

Previously, the Java release notes for version greater equal `5.30.0` were stored in this repo but not visible in the docs. THis is changed with this PR.
